### PR TITLE
(DNM) D4N dirty prefix removal

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -4107,7 +4107,7 @@ options:
 - name: rgw_d4n_cache_cleaning_interval
   type: int
   level: advanced
-  desc: This is the interval for invoking write cache cleaning process
+  desc: This is the interval in seconds for invoking write cache cleaning process
   default: 1000
   services: 
   - rgw

--- a/src/rgw/driver/d4n/d4n_directory.cc
+++ b/src/rgw/driver/d4n/d4n_directory.cc
@@ -319,6 +319,128 @@ int ObjectDirectory::update_field(const DoutPrefixProvider* dpp, CacheObj* objec
   }
 }
 
+int ObjectDirectory::zadd(const DoutPrefixProvider* dpp, CacheObj* object, double score, const std::string& member, optional_yield y)
+{
+  std::string key = build_index(object);
+  try {
+    boost::system::error_code ec;
+    request req;
+    req.push("ZADD", key, "CH", std::to_string(score), member);
+
+    response<std::string> resp;
+    redis_exec(conn, ec, req, resp, y);
+
+    if (ec) {
+      ldpp_dout(dpp, 0) << "ObjectDirectory::" << __func__ << "() ERROR: " << ec.what() << dendl;
+      return -ec.value();
+    }
+
+    if (std::get<0>(resp).value() != "1") {
+      ldpp_dout(dpp, 0) << "ObjectDirectory::" << __func__ << "() Response value is: " << std::get<0>(resp).value() << dendl;
+      return -EINVAL;
+    }
+
+  } catch (std::exception &e) {
+    ldpp_dout(dpp, 0) << "ObjectDirectory::" << __func__ << "() ERROR: " << e.what() << dendl;
+    return -EINVAL;
+  }
+
+  return 0;
+
+}
+
+int ObjectDirectory::zrange(const DoutPrefixProvider* dpp, CacheObj* object, int start, int stop, std::vector<std::string>& members, optional_yield y)
+{
+  std::string key = build_index(object);
+  try {
+    boost::system::error_code ec;
+    request req;
+    req.push("ZRANGE", key, std::to_string(start), std::to_string(stop));
+
+    response<std::vector<std::string> > resp;
+    redis_exec(conn, ec, req, resp, y);
+
+    if (ec) {
+      ldpp_dout(dpp, 0) << "ObjectDirectory::" << __func__ << "() ERROR: " << ec.what() << dendl;
+      return -ec.value();
+    }
+
+    if (std::get<0>(resp).value().empty()) {
+      ldpp_dout(dpp, 0) << "ObjectDirectory::" << __func__ << "() Empty response" << dendl;
+      return -EINVAL;
+    }
+
+    members = std::get<0>(resp).value();
+
+  } catch (std::exception &e) {
+    ldpp_dout(dpp, 0) << "ObjectDirectory::" << __func__ << "() ERROR: " << e.what() << dendl;
+    return -EINVAL;
+  }
+
+  return 0;
+}
+
+int ObjectDirectory::zrevrange(const DoutPrefixProvider* dpp, CacheObj* object, int start, int stop, std::vector<std::string>& members, optional_yield y)
+{
+  std::string key = build_index(object);
+  try {
+    boost::system::error_code ec;
+    request req;
+    req.push("ZREVRANGE", key, std::to_string(start), std::to_string(stop));
+
+    response<std::vector<std::string> > resp;
+    redis_exec(conn, ec, req, resp, y);
+
+    if (ec) {
+      ldpp_dout(dpp, 0) << "ObjectDirectory::" << __func__ << "() ERROR: " << ec.what() << dendl;
+      return -ec.value();
+    }
+
+    if (std::get<0>(resp).value().empty()) {
+      ldpp_dout(dpp, 0) << "ObjectDirectory::" << __func__ << "() Empty response" << dendl;
+      return -EINVAL;
+    }
+
+    members = std::get<0>(resp).value();
+
+  } catch (std::exception &e) {
+    ldpp_dout(dpp, 0) << "ObjectDirectory::" << __func__ << "() ERROR: " << e.what() << dendl;
+    return -EINVAL;
+  }
+
+  return 0;
+}
+
+int ObjectDirectory::zrem(const DoutPrefixProvider* dpp, CacheObj* object, const std::string& member, optional_yield y)
+{
+  std::string key = build_index(object);
+  try {
+    boost::system::error_code ec;
+    request req;
+    req.push("ZREM", key, member);
+    response<std::string> resp;
+
+    redis_exec(conn, ec, req, resp, y);
+
+    if (ec) {
+      ldpp_dout(dpp, 0) << "ObjectDirectory::" << __func__ << "() ERROR: " << ec.what() << dendl;
+      return -ec.value();
+    }
+
+    if (std::get<0>(resp).value() != "1") {
+      ldpp_dout(dpp, 0) << "ObjectDirectory::" << __func__ << "() Response is: " << std::get<0>(resp).value() << dendl;
+      return -EINVAL;
+    }
+
+  } catch (std::exception &e) {
+    ldpp_dout(dpp, 0) << "ObjectDirectory::" << __func__ << "() ERROR: " << e.what() << dendl;
+    return -EINVAL;
+  }
+
+  return 0;
+}
+
+
 std::string BlockDirectory::build_index(CacheBlock* block) 
 {
   return block->cacheObj.bucketName + "_" + block->cacheObj.objName + "_" + std::to_string(block->blockID) + "_" + std::to_string(block->size);
@@ -666,6 +788,127 @@ int BlockDirectory::remove_host(const DoutPrefixProvider* dpp, CacheBlock* block
 	return -ec.value();
       }
     }
+  } catch (std::exception &e) {
+    ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() ERROR: " << e.what() << dendl;
+    return -EINVAL;
+  }
+
+  return 0;
+}
+
+int BlockDirectory::zadd(const DoutPrefixProvider* dpp, CacheBlock* block, double score, const std::string& member, optional_yield y)
+{
+  std::string key = build_index(block);
+  try {
+    boost::system::error_code ec;
+    request req;
+    req.push("ZADD", key, "CH", std::to_string(score), member);
+
+    response<std::string> resp;
+    redis_exec(conn, ec, req, resp, y);
+
+    if (ec) {
+      ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() ERROR: " << ec.what() << dendl;
+      return -ec.value();
+    }
+
+    if (std::get<0>(resp).value() != "1") {
+      ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() Response value is: " << std::get<0>(resp).value() << dendl;
+      return -EINVAL;
+    }
+
+  } catch (std::exception &e) {
+    ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() ERROR: " << e.what() << dendl;
+    return -EINVAL;
+  }
+
+  return 0;
+
+}
+
+int BlockDirectory::zrange(const DoutPrefixProvider* dpp, CacheBlock* block, int start, int stop, std::vector<std::string>& members, optional_yield y)
+{
+  std::string key = build_index(block);
+  try {
+    boost::system::error_code ec;
+    request req;
+    req.push("ZRANGE", key, std::to_string(start), std::to_string(stop));
+
+    response<std::vector<std::string> > resp;
+    redis_exec(conn, ec, req, resp, y);
+
+    if (ec) {
+      ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() ERROR: " << ec.what() << dendl;
+      return -ec.value();
+    }
+
+    if (std::get<0>(resp).value().empty()) {
+      ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() Empty response" << dendl;
+      return -EINVAL;
+    }
+
+    members = std::get<0>(resp).value();
+
+  } catch (std::exception &e) {
+    ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() ERROR: " << e.what() << dendl;
+    return -EINVAL;
+  }
+
+  return 0;
+}
+
+int BlockDirectory::zrevrange(const DoutPrefixProvider* dpp, CacheBlock* block, int start, int stop, std::vector<std::string>& members, optional_yield y)
+{
+  std::string key = build_index(block);
+  try {
+    boost::system::error_code ec;
+    request req;
+    req.push("ZREVRANGE", key, std::to_string(start), std::to_string(stop));
+
+    response<std::vector<std::string> > resp;
+    redis_exec(conn, ec, req, resp, y);
+
+    if (ec) {
+      ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() ERROR: " << ec.what() << dendl;
+      return -ec.value();
+    }
+
+    if (std::get<0>(resp).value().empty()) {
+      ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() Empty response" << dendl;
+      return -EINVAL;
+    }
+
+    members = std::get<0>(resp).value();
+
+  } catch (std::exception &e) {
+    ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() ERROR: " << e.what() << dendl;
+    return -EINVAL;
+  }
+
+  return 0;
+}
+
+int BlockDirectory::zrem(const DoutPrefixProvider* dpp, CacheBlock* block, const std::string& member, optional_yield y)
+{
+  std::string key = build_index(block);
+  try {
+    boost::system::error_code ec;
+    request req;
+    req.push("ZREM", key, member);
+    response<std::string> resp;
+
+    redis_exec(conn, ec, req, resp, y);
+
+    if (ec) {
+      ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() ERROR: " << ec.what() << dendl;
+      return -ec.value();
+    }
+
+    if (std::get<0>(resp).value() != "1") {
+      ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() Response is: " << std::get<0>(resp).value() << dendl;
+      return -EINVAL;
+    }
+
   } catch (std::exception &e) {
     ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() ERROR: " << e.what() << dendl;
     return -EINVAL;

--- a/src/rgw/driver/d4n/d4n_directory.cc
+++ b/src/rgw/driver/d4n/d4n_directory.cc
@@ -351,7 +351,7 @@ int ObjectDirectory::zadd(const DoutPrefixProvider* dpp, CacheObj* object, doubl
     if (!multi) {
       if (std::get<0>(resp).value() != "1") {
         ldpp_dout(dpp, 0) << "ObjectDirectory::" << __func__ << "() Response value is: " << std::get<0>(resp).value() << dendl;
-        return -EINVAL;
+        return -ENOENT;
       }
     }
 
@@ -382,7 +382,7 @@ int ObjectDirectory::zrange(const DoutPrefixProvider* dpp, CacheObj* object, int
 
     if (std::get<0>(resp).value().empty()) {
       ldpp_dout(dpp, 0) << "ObjectDirectory::" << __func__ << "() Empty response" << dendl;
-      return -EINVAL;
+      return -ENOENT;
     }
 
     members = std::get<0>(resp).value();
@@ -440,7 +440,7 @@ int ObjectDirectory::zrem(const DoutPrefixProvider* dpp, CacheObj* object, const
     if (!multi) {
       if (std::get<0>(resp).value() != "1") {
         ldpp_dout(dpp, 0) << "ObjectDirectory::" << __func__ << "() Response is: " << std::get<0>(resp).value() << dendl;
-        return -EINVAL;
+        return -ENOENT;
       }
     }
 
@@ -471,7 +471,7 @@ int ObjectDirectory::zremrangebyscore(const DoutPrefixProvider* dpp, CacheObj* o
     if (!multi) {
       if (std::get<0>(resp).value() == "0") {
         ldpp_dout(dpp, 0) << "ObjectDirectory::" << __func__ << "() No element removed!" << dendl;
-        return -EINVAL;
+        return -ENOENT;
       }
     }
 
@@ -729,7 +729,7 @@ int BlockDirectory::del(const DoutPrefixProvider* dpp, CacheBlock* block, option
     } else { //if delete is called as part of a transaction, the command will be queued, hence the response will be a string
       response<std::string> resp;
       redis_exec(conn, ec, req, resp, y);
-      }
+    }
     if (ec) {
       ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() ERROR: " << ec.what() << dendl;
       std::cout << "BlockDirectory::" << __func__ << "() ERROR: " << ec.what() << std::endl;

--- a/src/rgw/driver/d4n/d4n_directory.cc
+++ b/src/rgw/driver/d4n/d4n_directory.cc
@@ -150,6 +150,7 @@ int ObjectDirectory::get(const DoutPrefixProvider* dpp, CacheObj* object, option
 {
   std::string key = build_index(object);
   std::vector<std::string> fields;
+  ldpp_dout(dpp, 10) << "ObjectDirectory::" << __func__ << "(): index is: " << key << dendl;
 
   fields.push_back("objName");
   fields.push_back("bucketName");
@@ -231,6 +232,7 @@ int ObjectDirectory::copy(const DoutPrefixProvider* dpp, CacheObj* object, std::
 int ObjectDirectory::del(const DoutPrefixProvider* dpp, CacheObj* object, optional_yield y) 
 {
   std::string key = build_index(object);
+  ldpp_dout(dpp, 10) << "ObjectDirectory::" << __func__ << "(): index is: " << key << dendl;
 
   try {
     boost::system::error_code ec;
@@ -326,7 +328,7 @@ int BlockDirectory::exist_key(const DoutPrefixProvider* dpp, CacheBlock* block, 
 {
   std::string key = build_index(block);
   response<int> resp;
-  ldpp_dout(dpp, 10) << __func__ << "(): index is: " << key << dendl;
+
   try {
     boost::system::error_code ec;
     request req;
@@ -351,6 +353,7 @@ int BlockDirectory::set(const DoutPrefixProvider* dpp, CacheBlock* block, option
   /* For existing keys, call get method beforehand. 
      Sets completely overwrite existing values. */
   std::string key = build_index(block);
+  ldpp_dout(dpp, 10) << "BlockDirectory::" << __func__ << "(): index is: " << key << dendl;
     
   std::string entries;
   std::list<std::string> redisValues;
@@ -369,20 +372,6 @@ int BlockDirectory::set(const DoutPrefixProvider* dpp, CacheBlock* block, option
     return -EINVAL;
   }
   redisValues.push_back(std::to_string(block->deleteMarker));
-  redisValues.push_back("prevVersion");
-  std::string prevVersion;
-  if (block->prevVersion) {
-    bool deleteMarker;
-    if ((ret = check_bool(std::to_string(block->prevVersion->second))) != -EINVAL) {
-      deleteMarker = (ret != 0);
-    } else {
-      ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() ERROR: Invalid bool value for previous delete marker" << dendl;
-      return -EINVAL;
-    }
-
-    prevVersion = std::to_string(deleteMarker) + ":" + block->prevVersion->first;
-  }
-  redisValues.push_back(prevVersion);
   redisValues.push_back("size");
   redisValues.push_back(std::to_string(block->size));
   redisValues.push_back("globalWeight");
@@ -440,13 +429,11 @@ int BlockDirectory::get(const DoutPrefixProvider* dpp, CacheBlock* block, option
 {
   std::string key = build_index(block);
   std::vector<std::string> fields;
-
-  ldpp_dout(dpp, 10) << __func__ << "(): index is: " << key << dendl;
+  ldpp_dout(dpp, 10) << "BlockDirectory::" << __func__ << "(): index is: " << key << dendl;
 
   fields.push_back("blockID");
   fields.push_back("version");
   fields.push_back("deleteMarker");
-  fields.push_back("prevVersion");
   fields.push_back("size");
   fields.push_back("globalWeight");
 
@@ -470,26 +457,20 @@ int BlockDirectory::get(const DoutPrefixProvider* dpp, CacheBlock* block, option
     }
 
     if (std::get<0>(resp).value().value().empty()) {
-      ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "(): No values returned." << dendl;
+      ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "(): No values returned for key=" << key << dendl;
       return -ENOENT;
     } 
 
     block->blockID = std::stoull(std::get<0>(resp).value().value()[0]);
     block->version = std::get<0>(resp).value().value()[1];
     block->deleteMarker = (std::stoi(std::get<0>(resp).value().value()[2]) != 0);
-    auto version = std::get<0>(resp).value().value()[3];
-    if (!version.empty()) {
-      std::vector<std::string> versionSet;
-      boost::split(versionSet, version, boost::is_any_of(":"));
-      block->prevVersion = std::pair<std::string, bool>(versionSet[1], std::stoi(versionSet[0]));
-    }
-    block->size = std::stoull(std::get<0>(resp).value().value()[4]);
-    block->globalWeight = std::stoull(std::get<0>(resp).value().value()[5]);
-    block->cacheObj.objName = std::get<0>(resp).value().value()[6];
-    block->cacheObj.bucketName = std::get<0>(resp).value().value()[7];
-    block->cacheObj.creationTime = std::get<0>(resp).value().value()[8];
-    block->cacheObj.dirty = (std::stoi(std::get<0>(resp).value().value()[9]) != 0);
-    boost::split(block->cacheObj.hostsList, std::get<0>(resp).value().value()[10], boost::is_any_of("_"));
+    block->size = std::stoull(std::get<0>(resp).value().value()[3]);
+    block->globalWeight = std::stoull(std::get<0>(resp).value().value()[4]);
+    block->cacheObj.objName = std::get<0>(resp).value().value()[5];
+    block->cacheObj.bucketName = std::get<0>(resp).value().value()[6];
+    block->cacheObj.creationTime = std::get<0>(resp).value().value()[7];
+    block->cacheObj.dirty = (std::stoi(std::get<0>(resp).value().value()[8]) != 0);
+    boost::split(block->cacheObj.hostsList, std::get<0>(resp).value().value()[9], boost::is_any_of("_"));
   } catch (std::exception &e) {
     ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() ERROR: " << e.what() << dendl;
     return -EINVAL;
@@ -541,6 +522,7 @@ int BlockDirectory::copy(const DoutPrefixProvider* dpp, CacheBlock* block, std::
 int BlockDirectory::del(const DoutPrefixProvider* dpp, CacheBlock* block, optional_yield y) 
 {
   std::string key = build_index(block);
+  ldpp_dout(dpp, 10) << "BlockDirectory::" << __func__ << "(): index is: " << key << dendl;
 
   try {
     boost::system::error_code ec;
@@ -551,7 +533,7 @@ int BlockDirectory::del(const DoutPrefixProvider* dpp, CacheBlock* block, option
     redis_exec(conn, ec, req, resp, y);
 
     if (!std::get<0>(resp).value()) {
-      ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "(): No values deleted." << dendl;
+      ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "(): No values deleted for key=" << key << dendl;
       return -ENOENT;
     }
 

--- a/src/rgw/driver/d4n/d4n_directory.cc
+++ b/src/rgw/driver/d4n/d4n_directory.cc
@@ -48,6 +48,19 @@ void redis_exec(std::shared_ptr<connection> conn,
   }
 }
 
+void redis_exec(std::shared_ptr<connection> conn,
+                boost::system::error_code& ec,
+                const boost::redis::request& req,
+                boost::redis::generic_response& resp, optional_yield y)
+{
+  if (y) {
+    auto yield = y.get_yield_context();
+    async_exec(std::move(conn), req, resp, yield[ec]);
+  } else {
+    async_exec(std::move(conn), req, resp, ceph::async::use_blocked[ec]);
+  }
+}
+
 int check_bool(std::string str) {
   if (str == "true" || str == "1") {
     return 1;
@@ -87,7 +100,7 @@ int ObjectDirectory::exist_key(const DoutPrefixProvider* dpp, CacheObj* object, 
   return std::get<0>(resp).value();
 }
 
-int ObjectDirectory::set(const DoutPrefixProvider* dpp, CacheObj* object, optional_yield y) 
+int ObjectDirectory::set(const DoutPrefixProvider* dpp, CacheObj* object, optional_yield y)
 {
   /* For existing keys, call get method beforehand. 
      Sets completely overwrite existing values. */
@@ -440,6 +453,33 @@ int ObjectDirectory::zrem(const DoutPrefixProvider* dpp, CacheObj* object, const
   return 0;
 }
 
+int ObjectDirectory::incr(const DoutPrefixProvider* dpp, CacheObj* object, optional_yield y)
+{
+  std::string key = build_index(object);
+  key = key + "_versioned_epoch";
+  uint64_t value;
+  try {
+    boost::system::error_code ec;
+    request req;
+    req.push("INCR", key);
+    response<std::string> resp;
+
+    redis_exec(conn, ec, req, resp, y);
+
+    if (ec) {
+      ldpp_dout(dpp, 0) << "ObjectDirectory::" << __func__ << "() ERROR: " << ec.what() << dendl;
+      return -ec.value();
+    }
+
+    value = std::stoull(std::get<0>(resp).value());
+
+  } catch (std::exception &e) {
+    ldpp_dout(dpp, 0) << "ObjectDirectory::" << __func__ << "() ERROR: " << e.what() << dendl;
+    return -EINVAL;
+  }
+
+  return value;
+}
 
 std::string BlockDirectory::build_index(CacheBlock* block) 
 {
@@ -470,7 +510,7 @@ int BlockDirectory::exist_key(const DoutPrefixProvider* dpp, CacheBlock* block, 
   return std::get<0>(resp).value();
 }
 
-int BlockDirectory::set(const DoutPrefixProvider* dpp, CacheBlock* block, optional_yield y) 
+int BlockDirectory::set(const DoutPrefixProvider* dpp, CacheBlock* block, optional_yield y)
 {
   /* For existing keys, call get method beforehand. 
      Sets completely overwrite existing values. */
@@ -534,7 +574,6 @@ int BlockDirectory::set(const DoutPrefixProvider* dpp, CacheBlock* block, option
     req.push_range("HSET", key, redisValues);
 
     redis_exec(conn, ec, req, resp, y);
-
     if (ec) {
       ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() ERROR: " << ec.what() << dendl;
       return -ec.value();
@@ -641,30 +680,34 @@ int BlockDirectory::copy(const DoutPrefixProvider* dpp, CacheBlock* block, std::
   }
 }
 
-int BlockDirectory::del(const DoutPrefixProvider* dpp, CacheBlock* block, optional_yield y) 
+int BlockDirectory::del(const DoutPrefixProvider* dpp, CacheBlock* block, optional_yield y, bool multi) 
 {
   std::string key = build_index(block);
   ldpp_dout(dpp, 10) << "BlockDirectory::" << __func__ << "(): index is: " << key << dendl;
 
   try {
     boost::system::error_code ec;
-    response<int> resp;
     request req;
     req.push("DEL", key);
-
-    redis_exec(conn, ec, req, resp, y);
-
-    if (!std::get<0>(resp).value()) {
-      ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "(): No values deleted for key=" << key << dendl;
-      return -ENOENT;
-    }
-
+    if (!multi) {
+      response<int> resp;
+      redis_exec(conn, ec, req, resp, y);
+      if (!std::get<0>(resp).value()) {
+        ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "(): No values deleted for key=" << key << dendl;
+        return -ENOENT;
+      }
+    } else { //if delete is called as part of a transaction, the command will be queued, hence the response will be a string
+      response<std::string> resp;
+      redis_exec(conn, ec, req, resp, y);
+      }
     if (ec) {
       ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() ERROR: " << ec.what() << dendl;
+      std::cout << "BlockDirectory::" << __func__ << "() ERROR: " << ec.what() << std::endl;
       return -ec.value();
     }
   } catch (std::exception &e) {
     ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() ERROR: " << e.what() << dendl;
+    std::cout << "BlockDirectory::" << __func__ << "() ERROR: " << e.what() << std::endl;
     return -EINVAL;
   }
 
@@ -905,6 +948,122 @@ int BlockDirectory::zrem(const DoutPrefixProvider* dpp, CacheBlock* block, const
     }
 
     if (std::get<0>(resp).value() != "1") {
+      ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() Response is: " << std::get<0>(resp).value() << dendl;
+      return -EINVAL;
+    }
+
+  } catch (std::exception &e) {
+    ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() ERROR: " << e.what() << dendl;
+    return -EINVAL;
+  }
+
+  return 0;
+}
+
+int BlockDirectory::watch(const DoutPrefixProvider* dpp, CacheBlock* block, optional_yield y)
+{
+  std::string key = build_index(block);
+  try {
+    boost::system::error_code ec;
+    request req;
+    req.push("WATCH", key);
+    response<std::string> resp;
+
+    redis_exec(conn, ec, req, resp, y);
+
+    if (ec) {
+      ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() ERROR: " << ec.what() << dendl;
+      return -ec.value();
+    }
+
+    if (std::get<0>(resp).value() != "OK") {
+      ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() Response is: " << std::get<0>(resp).value() << dendl;
+      return -EINVAL;
+    }
+
+  } catch (std::exception &e) {
+    ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() ERROR: " << e.what() << dendl;
+    return -EINVAL;
+  }
+
+  return 0;
+}
+
+int BlockDirectory::exec(const DoutPrefixProvider* dpp, std::vector<std::string>& responses, optional_yield y)
+{
+  try {
+    boost::system::error_code ec;
+    request req;
+    req.push("EXEC");
+    boost::redis::generic_response resp;
+
+    redis_exec(conn, ec, req, resp, y);
+
+    if (ec) {
+      ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() ERROR: " << ec.what() << dendl;
+      std::cout << "BlockDirectory::" << __func__ << "() ERROR: " << ec.what() << std::endl;
+      return -ec.value();
+    }
+
+    for (uint64_t i = 0; i < resp.value().size(); i++) {
+      ldpp_dout(dpp, 20) << "BlockDirectory::" << __func__ << "() MULTI: " << resp.value().front().value << dendl;
+      responses.emplace_back(resp.value().front().value);
+      boost::redis::consume_one(resp);
+    }
+
+  } catch (std::exception &e) {
+    ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() ERROR: " << e.what() << dendl;
+    std::cout << "BlockDirectory::" << __func__ << "() ERROR: " << e.what() << std::endl;
+    return -EINVAL;
+  }
+
+  return 0;
+}
+
+int BlockDirectory::multi(const DoutPrefixProvider* dpp, optional_yield y)
+{
+  try {
+    boost::system::error_code ec;
+    request req;
+    req.push("MULTI");
+    response<std::string> resp;
+
+    redis_exec(conn, ec, req, resp, y);
+
+    if (ec) {
+      ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() ERROR: " << ec.what() << dendl;
+      return -ec.value();
+    }
+
+    if (std::get<0>(resp).value() != "OK") {
+      ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() Response is: " << std::get<0>(resp).value() << dendl;
+      return -EINVAL;
+    }
+
+  } catch (std::exception &e) {
+    ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() ERROR: " << e.what() << dendl;
+    return -EINVAL;
+  }
+
+  return 0;
+}
+
+int BlockDirectory::discard(const DoutPrefixProvider* dpp, optional_yield y)
+{
+  try {
+    boost::system::error_code ec;
+    request req;
+    req.push("DISCARD");
+    response<std::string> resp;
+
+    redis_exec(conn, ec, req, resp, y);
+
+    if (ec) {
+      ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() ERROR: " << ec.what() << dendl;
+      return -ec.value();
+    }
+
+    if (std::get<0>(resp).value() != "OK") {
       ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() Response is: " << std::get<0>(resp).value() << dendl;
       return -EINVAL;
     }

--- a/src/rgw/driver/d4n/d4n_directory.h
+++ b/src/rgw/driver/d4n/d4n_directory.h
@@ -27,7 +27,6 @@ struct CacheBlock {
   uint64_t blockID;
   std::string version;
   bool deleteMarker{false};
-  std::optional<std::pair<std::string, bool>> prevVersion; /* Format is <version, deleteMarker> */
   uint64_t size; /* Block size in bytes */
   int globalWeight = 0; /* LFUDA policy variable */
   /* Blocks use the cacheObj's dirty and hostsList metadata to store their dirty flag values and locations in the block directory. */

--- a/src/rgw/driver/d4n/d4n_directory.h
+++ b/src/rgw/driver/d4n/d4n_directory.h
@@ -48,10 +48,11 @@ class ObjectDirectory: public Directory {
     int copy(const DoutPrefixProvider* dpp, CacheObj* object, std::string copyName, std::string copyBucketName, optional_yield y);
     int del(const DoutPrefixProvider* dpp, CacheObj* object, optional_yield y);
     int update_field(const DoutPrefixProvider* dpp, CacheObj* object, std::string field, std::string value, optional_yield y);
-    int zadd(const DoutPrefixProvider* dpp, CacheObj* object, double score, const std::string& member, optional_yield y);
+    int zadd(const DoutPrefixProvider* dpp, CacheObj* object, double score, const std::string& member, optional_yield y, bool multi=false);
     int zrange(const DoutPrefixProvider* dpp, CacheObj* object, int start, int stop, std::vector<std::string>& members, optional_yield y);
     int zrevrange(const DoutPrefixProvider* dpp, CacheObj* object, int start, int stop, std::vector<std::string>& members, optional_yield y);
-    int zrem(const DoutPrefixProvider* dpp, CacheObj* object, const std::string& member, optional_yield y);
+    int zrem(const DoutPrefixProvider* dpp, CacheObj* object, const std::string& member, optional_yield y, bool multi=false);
+    int zremrangebyscore(const DoutPrefixProvider* dpp, CacheObj* object, double min, double max, optional_yield y, bool multi=false);
     //Return value is the incremented value, else return error
     int incr(const DoutPrefixProvider* dpp, CacheObj* object, optional_yield y);
 
@@ -73,14 +74,16 @@ class BlockDirectory: public Directory {
     int del(const DoutPrefixProvider* dpp, CacheBlock* block, optional_yield y, bool multi=false);
     int update_field(const DoutPrefixProvider* dpp, CacheBlock* block, std::string field, std::string value, optional_yield y);
     int remove_host(const DoutPrefixProvider* dpp, CacheBlock* block, std::string value, optional_yield y);
-    int zadd(const DoutPrefixProvider* dpp, CacheBlock* block, double score, const std::string& member, optional_yield y);
+    int zadd(const DoutPrefixProvider* dpp, CacheBlock* block, double score, const std::string& member, optional_yield y, bool multi=false);
     int zrange(const DoutPrefixProvider* dpp, CacheBlock* block, int start, int stop, std::vector<std::string>& members, optional_yield y);
     int zrevrange(const DoutPrefixProvider* dpp, CacheBlock* block, int start, int stop, std::vector<std::string>& members, optional_yield y);
     int zrem(const DoutPrefixProvider* dpp, CacheBlock* block, const std::string& member, optional_yield y);
     int watch(const DoutPrefixProvider* dpp, CacheBlock* block, optional_yield y);
+    //Move MULTI, EXEC and DISCARD to directory? As they do not operate on a key
     int exec(const DoutPrefixProvider* dpp, std::vector<std::string>& responses, optional_yield y);
     int multi(const DoutPrefixProvider* dpp, optional_yield y);
     int discard(const DoutPrefixProvider* dpp, optional_yield y);
+    int unwatch(const DoutPrefixProvider* dpp, optional_yield y);
 
   private:
     std::shared_ptr<connection> conn;

--- a/src/rgw/driver/d4n/d4n_directory.h
+++ b/src/rgw/driver/d4n/d4n_directory.h
@@ -48,6 +48,10 @@ class ObjectDirectory: public Directory {
     int copy(const DoutPrefixProvider* dpp, CacheObj* object, std::string copyName, std::string copyBucketName, optional_yield y);
     int del(const DoutPrefixProvider* dpp, CacheObj* object, optional_yield y);
     int update_field(const DoutPrefixProvider* dpp, CacheObj* object, std::string field, std::string value, optional_yield y);
+    int zadd(const DoutPrefixProvider* dpp, CacheObj* object, double score, const std::string& member, optional_yield y);
+    int zrange(const DoutPrefixProvider* dpp, CacheObj* object, int start, int stop, std::vector<std::string>& members, optional_yield y);
+    int zrevrange(const DoutPrefixProvider* dpp, CacheObj* object, int start, int stop, std::vector<std::string>& members, optional_yield y);
+    int zrem(const DoutPrefixProvider* dpp, CacheObj* object, const std::string& member, optional_yield y);
 
   private:
     std::shared_ptr<connection> conn;
@@ -67,6 +71,10 @@ class BlockDirectory: public Directory {
     int del(const DoutPrefixProvider* dpp, CacheBlock* block, optional_yield y);
     int update_field(const DoutPrefixProvider* dpp, CacheBlock* block, std::string field, std::string value, optional_yield y);
     int remove_host(const DoutPrefixProvider* dpp, CacheBlock* block, std::string value, optional_yield y);
+    int zadd(const DoutPrefixProvider* dpp, CacheBlock* block, double score, const std::string& member, optional_yield y);
+    int zrange(const DoutPrefixProvider* dpp, CacheBlock* block, int start, int stop, std::vector<std::string>& members, optional_yield y);
+    int zrevrange(const DoutPrefixProvider* dpp, CacheBlock* block, int start, int stop, std::vector<std::string>& members, optional_yield y);
+    int zrem(const DoutPrefixProvider* dpp, CacheBlock* block, const std::string& member, optional_yield y);
 
   private:
     std::shared_ptr<connection> conn;

--- a/src/rgw/driver/d4n/d4n_directory.h
+++ b/src/rgw/driver/d4n/d4n_directory.h
@@ -52,6 +52,8 @@ class ObjectDirectory: public Directory {
     int zrange(const DoutPrefixProvider* dpp, CacheObj* object, int start, int stop, std::vector<std::string>& members, optional_yield y);
     int zrevrange(const DoutPrefixProvider* dpp, CacheObj* object, int start, int stop, std::vector<std::string>& members, optional_yield y);
     int zrem(const DoutPrefixProvider* dpp, CacheObj* object, const std::string& member, optional_yield y);
+    //Return value is the incremented value, else return error
+    int incr(const DoutPrefixProvider* dpp, CacheObj* object, optional_yield y);
 
   private:
     std::shared_ptr<connection> conn;
@@ -68,17 +70,20 @@ class BlockDirectory: public Directory {
     int set(const DoutPrefixProvider* dpp, CacheBlock* block, optional_yield y);
     int get(const DoutPrefixProvider* dpp, CacheBlock* block, optional_yield y);
     int copy(const DoutPrefixProvider* dpp, CacheBlock* block, std::string copyName, std::string copyBucketName, optional_yield y);
-    int del(const DoutPrefixProvider* dpp, CacheBlock* block, optional_yield y);
+    int del(const DoutPrefixProvider* dpp, CacheBlock* block, optional_yield y, bool multi=false);
     int update_field(const DoutPrefixProvider* dpp, CacheBlock* block, std::string field, std::string value, optional_yield y);
     int remove_host(const DoutPrefixProvider* dpp, CacheBlock* block, std::string value, optional_yield y);
     int zadd(const DoutPrefixProvider* dpp, CacheBlock* block, double score, const std::string& member, optional_yield y);
     int zrange(const DoutPrefixProvider* dpp, CacheBlock* block, int start, int stop, std::vector<std::string>& members, optional_yield y);
     int zrevrange(const DoutPrefixProvider* dpp, CacheBlock* block, int start, int stop, std::vector<std::string>& members, optional_yield y);
     int zrem(const DoutPrefixProvider* dpp, CacheBlock* block, const std::string& member, optional_yield y);
+    int watch(const DoutPrefixProvider* dpp, CacheBlock* block, optional_yield y);
+    int exec(const DoutPrefixProvider* dpp, std::vector<std::string>& responses, optional_yield y);
+    int multi(const DoutPrefixProvider* dpp, optional_yield y);
+    int discard(const DoutPrefixProvider* dpp, optional_yield y);
 
   private:
     std::shared_ptr<connection> conn;
-
     std::string build_index(CacheBlock* block);
 };
 

--- a/src/rgw/driver/d4n/d4n_policy.cc
+++ b/src/rgw/driver/d4n/d4n_policy.cc
@@ -54,8 +54,8 @@ int LFUDAPolicy::init(CephContext *cct, const DoutPrefixProvider* dpp, asio::io_
   static auto obj_callback = [this](
           const DoutPrefixProvider* dpp, std::string& key, std::string version, bool dirty, uint64_t size, 
 			    time_t creationTime, const rgw_user user, std::string& etag, const std::string& bucket_name, const std::string& bucket_id,
-			    const rgw_obj_key& obj_key, optional_yield y) {
-    update_dirty_object(dpp, key, version, dirty, size, creationTime, user, etag, bucket_name, bucket_id, obj_key, y);
+			    const rgw_obj_key& obj_key, optional_yield y, std::string& restore_val) {
+    update_dirty_object(dpp, key, version, dirty, size, creationTime, user, etag, bucket_name, bucket_id, obj_key, y, restore_val);
   };
 
   static auto block_callback = [this](
@@ -243,6 +243,40 @@ asio::awaitable<void> LFUDAPolicy::redis_sync(const DoutPrefixProvider* dpp, opt
   }
 }
 
+// Changes state to INVALID for dirty objects. An INVALID state indicates that a delete request has been
+// issued on an object and it must be deleted rather than written to the backend. This lazy deletion occurs
+// in the Cleaning method and prevents data races during concurrent requests. The method below returns "false"
+// if the state has not been set to INVALID, and "true" if it has. The state is not set to INVALID when
+// cleaning is in progress, a process which writes the object to the backend store.
+bool LFUDAPolicy::invalidate_dirty_object(const DoutPrefixProvider* dpp, std::string& key) {
+  std::unique_lock<std::mutex> l(lfuda_cleaning_lock);
+
+  if (o_entries_map.empty())
+    return false;
+
+  auto p = o_entries_map.find(key);
+  if (p == o_entries_map.end()) {
+    ldpp_dout(dpp, 10) << "LFUDAPolicy::" << __func__ << "(): key=" << key << " not found" << dendl;
+    return false;
+  }
+
+  if (p->second.second == State::INIT) {
+    ldpp_dout(dpp, 10) << "LFUDAPolicy::" << __func__ << "(): Setting State::INVALID for key=" << key << dendl;
+    p->second.second = State::INVALID;
+    int ret = cacheDriver->set_attr(dpp, DIRTY_BLOCK_PREFIX + key, RGW_CACHE_ATTR_INVALID, "1", y);
+    if (ret < 0) {
+      ldpp_dout(dpp, 0) << "LFUDAPolicy::" << __func__ << "(): Failed to set xattr, ret=" << ret << dendl;
+      return false;
+    }
+
+    return true;
+  } else if (p->second.second == State::IN_PROGRESS) {
+    state_cond.wait(l, [this, &key]{ return (o_entries_map.find(key) == o_entries_map.end()); });
+  }
+
+  return false;
+}
+
 CacheBlock* LFUDAPolicy::get_victim_block(const DoutPrefixProvider* dpp, optional_yield y) {
   const std::lock_guard l(lfuda_lock);
   if (entries_heap.empty())
@@ -252,13 +286,15 @@ CacheBlock* LFUDAPolicy::get_victim_block(const DoutPrefixProvider* dpp, optiona
   std::string key = entries_heap.top()->key;
   CacheBlock* victim = new CacheBlock();
 
-  victim->cacheObj.bucketName = key.substr(0, key.find('_')); 
-  key.erase(0, key.find('_') + 1);
-  victim->version = key.substr(0, key.find('_'));
-  key.erase(0, key.find('_') + 1);
-  victim->cacheObj.objName = key.substr(0, key.find('_'));
-  victim->blockID = entries_heap.top()->offset;
-  victim->size = entries_heap.top()->len;
+  victim->cacheObj.bucketName = key.substr(0, key.find('#')); 
+  key.erase(0, key.find('#') + 1);
+  victim->version = key.substr(0, key.find('#'));
+  key.erase(0, key.find('#') + 1);
+  victim->cacheObj.objName = key.substr(0, key.find('#'));
+  key.erase(0, key.find('#') + 1);
+  victim->blockID = std::stoull(key.substr(0, key.find('#')));
+  key.erase(0, key.find('#') + 1);
+  victim->size = std::stoull(key.substr(0, key.find('#'))); // TODO: size not being set correctly in heap
 
   if (blockDir->get(dpp, victim, y) < 0) {
     return nullptr;
@@ -280,6 +316,7 @@ int LFUDAPolicy::eviction(const DoutPrefixProvider* dpp, uint64_t size, optional
   if (entries_heap.empty())
     return 0;
 
+  int ret = -1;
   uint64_t freeSpace = cacheDriver->get_free_space(dpp);
 
   while (freeSpace < size) { // TODO: Think about parallel reads and writes; can this turn into an infinite loop? 
@@ -288,7 +325,7 @@ int LFUDAPolicy::eviction(const DoutPrefixProvider* dpp, uint64_t size, optional
     if (victim == nullptr) {
       ldpp_dout(dpp, 0) << "LFUDAPolicy::" << __func__ << "(): Could not retrieve victim block." << dendl;
       delete victim;
-      return 0; // not necessarily an error? -Sam
+      return -ENOSPC;
     }
 
     const std::lock_guard l(lfuda_lock);
@@ -301,7 +338,7 @@ int LFUDAPolicy::eviction(const DoutPrefixProvider* dpp, uint64_t size, optional
     // check dirty flag of entry to be evicted, if the flag is dirty, all entries on the local node are dirty
     if (it->second->dirty) {
       ldpp_dout(dpp, 0) << "LFUDAPolicy::" << __func__ << "(): Top entry in min heap is dirty, no entry is available for eviction!" << dendl;
-      return 0;
+      return -ENOSPC;
     }
     int avgWeight = weightSum / entries_map.size();
 
@@ -311,7 +348,7 @@ int LFUDAPolicy::eviction(const DoutPrefixProvider* dpp, uint64_t size, optional
         (*it->second->handle)->localWeight = it->second->localWeight;
 	entries_heap.decrease(it->second->handle); // larger value means node must be decreased to maintain min heap 
 
-	if (int ret = cacheDriver->set_attr(dpp, key, RGW_CACHE_ATTR_LOCAL_WEIGHT, std::to_string(it->second->localWeight), y) < 0) { 
+	if ((ret = cacheDriver->set_attr(dpp, key, RGW_CACHE_ATTR_LOCAL_WEIGHT, std::to_string(it->second->localWeight), y)) < 0) { 
 	  delete victim;
 	  return ret;
         }
@@ -326,20 +363,21 @@ int LFUDAPolicy::eviction(const DoutPrefixProvider* dpp, uint64_t size, optional
     }
 
     victim->globalWeight += it->second->localWeight;
-    if (int ret = blockDir->update_field(dpp, victim, "globalWeight", std::to_string(victim->globalWeight), y) < 0) {
+    if ((ret = blockDir->update_field(dpp, victim, "globalWeight", std::to_string(victim->globalWeight), y)) < 0) {
       delete victim;
       return ret;
     }
 
-    if (int ret = blockDir->remove_host(dpp, victim, dpp->get_cct()->_conf->rgw_d4n_l1_datacache_address, y) < 0) {
+    if ((ret = blockDir->remove_host(dpp, victim, dpp->get_cct()->_conf->rgw_d4n_l1_datacache_address, y)) < 0) {
       delete victim;
       return ret;
     }
 
     delete victim;
 
-    if (int ret = cacheDriver->del(dpp, key, y) < 0) 
+    if ((ret = cacheDriver->delete_data(dpp, key, y)) < 0) {
       return ret;
+    }
 
     ldpp_dout(dpp, 10) << "LFUDAPolicy::" << __func__ << "(): Block " << key << " has been evicted." << dendl;
 
@@ -404,15 +442,24 @@ void LFUDAPolicy::update(const DoutPrefixProvider* dpp, std::string& key, uint64
   weightSum += ((localWeight < 0) ? 0 : localWeight);
 }
 
-void LFUDAPolicy::update_dirty_object(const DoutPrefixProvider* dpp, std::string& key, std::string version, bool deleteMarker, uint64_t size, time_t creationTime, const rgw_user user, std::string& etag, const std::string& bucket_name, const std::string& bucket_id, const rgw_obj_key& obj_key, optional_yield y)
+void LFUDAPolicy::update_dirty_object(const DoutPrefixProvider* dpp, std::string& key, std::string version, bool deleteMarker, uint64_t size, time_t creationTime, const rgw_user user, std::string& etag, const std::string& bucket_name, const std::string& bucket_id, const rgw_obj_key& obj_key, optional_yield y, std::string& restore_val)
 {
   using handle_type = boost::heap::fibonacci_heap<LFUDAObjEntry*, boost::heap::compare<ObjectComparator<LFUDAObjEntry>>>::handle_type;
+  State state{State::INIT};
   ldpp_dout(dpp, 10) << "LFUDAPolicy::" << __func__ << "(): Before acquiring lock, adding entry: " << key << dendl;
+
+  if (!restore_val.empty() && restore_val == "1") { // No need to set the xattr because this case only occurs when the state has
+    state = State::INVALID;                         // been retrieved from the xattr itself.
+    ldpp_dout(dpp, 10) << "LFUDAPolicy::" << __func__ << "(): State restored to INVALID." << dendl;
+  } else {
+    state = State::INIT;
+  }
+
   const std::lock_guard l(lfuda_cleaning_lock);
   LFUDAObjEntry *e = new LFUDAObjEntry{key, version, deleteMarker, size, creationTime, user, etag, bucket_name, bucket_id, obj_key};
   handle_type handle = object_heap.push(e);
   e->set_handle(handle);
-  o_entries_map.emplace(key, e);
+  o_entries_map.emplace(key, std::make_pair(e, state));
   cond.notify_one();
 }
 
@@ -441,12 +488,43 @@ bool LFUDAPolicy::erase_dirty_object(const DoutPrefixProvider* dpp, const std::s
     return false;
   }
 
-  object_heap.erase(p->second->handle);
+  object_heap.erase(p->second.first->handle);
   o_entries_map.erase(p);
-  delete p->second;
-  p->second = nullptr;
+  delete p->second.first;
+  p->second.first = nullptr;
+  state_cond.notify_one();
 
   return true;
+}
+
+int LFUDAPolicy::delete_data_blocks(const DoutPrefixProvider* dpp, LFUDAObjEntry* e, optional_yield y) {
+  off_t lst = e->size, fst = 0, ofs = 0;
+  uint64_t len = 0;
+
+  do {
+    if (fst >= lst) {
+      break;
+    }
+    off_t cur_size = std::min<off_t>(fst + dpp->get_cct()->_conf->rgw_max_chunk_size, lst);
+    off_t cur_len = cur_size - fst;
+    std::string prefix = e->key + CACHE_DELIM + std::to_string(fst) + CACHE_DELIM + std::to_string(cur_len);
+    std::string oid_in_cache = DIRTY_BLOCK_PREFIX + prefix;
+
+    int ret = -1;
+    if ((ret = cacheDriver->delete_data(dpp, oid_in_cache, y)) == 0) { // Sam: do we want del or delete_data here?
+      if (!(ret = erase(dpp, prefix, y))) {
+	ldpp_dout(dpp, 0) << "Failed to delete policy entry for: " << oid_in_cache << ", ret=" << ret << dendl;
+        return -EINVAL;
+      }
+    } else {
+      ldpp_dout(dpp, 0) << "Failed to delete data block " << oid_in_cache << ", ret=" << ret << dendl;
+      return -EINVAL;
+    }
+
+    ofs += len;
+  } while (len > 0);
+
+  return 0;
 }
 
 void LFUDAPolicy::cleaning(const DoutPrefixProvider* dpp)
@@ -456,6 +534,7 @@ void LFUDAPolicy::cleaning(const DoutPrefixProvider* dpp)
     ldpp_dout(dpp, 20) << __func__ << " : " << " Cache cleaning!" << dendl;
     uint64_t len = 0;
     rgw::sal::Attrs obj_attrs;
+    bool invalid = false;
   
     ldpp_dout(dpp, 20) << "LFUDAPolicy::" << __func__ << "" << __LINE__ << "(): Before acquiring cleaning-lock" << dendl;
     std::unique_lock<std::mutex> l(lfuda_cleaning_lock);
@@ -474,231 +553,364 @@ void LFUDAPolicy::cleaning(const DoutPrefixProvider* dpp)
     ldpp_dout(dpp, 10) << __LINE__ << " " << __func__ << "(): e->user=" << e->user << dendl;
     ldpp_dout(dpp, 10) << __LINE__ << " " << __func__ << "(): e->obj_key=" << e->obj_key << dendl;
     l.unlock();
-    if (!e->key.empty() && (std::difftime(time(NULL), e->creationTime) > interval)) { //if block is dirty and written more than interval seconds ago
-      rgw_user c_rgw_user = e->user;
-      //writing data to the backend
-      //we need to create an atomic_writer
-      std::unique_ptr<rgw::sal::User> c_user = driver->get_user(c_rgw_user);
 
-      std::unique_ptr<rgw::sal::Bucket> c_bucket;
-      rgw_bucket c_rgw_bucket = rgw_bucket(c_rgw_user.tenant, e->bucket_name, e->bucket_id);
-
-      RGWBucketInfo c_bucketinfo;
-      c_bucketinfo.bucket = c_rgw_bucket;
-      c_bucketinfo.owner = c_rgw_user;
-      int ret = driver->load_bucket(dpp, c_rgw_bucket, &c_bucket, null_yield);
-      if (ret < 0) {
-        ldpp_dout(dpp, 10) << __func__ << "(): load_bucket() returned ret=" << ret << dendl;
-        //Remove bucket should be implemented in d4n which will take care of deleting objects belonging to the bucket, and hence we should not reach here
-        erase_dirty_object(dpp, e->key, null_yield);
-        continue;
+    int diff = std::difftime(time(NULL), e->creationTime);
+    if (!e->key.empty() && (diff > interval)) { // if block is dirty and written more than interval seconds ago
+      l.lock();
+      auto p = o_entries_map.find(e->key);
+      if (p == o_entries_map.end()) {
+	l.unlock();
+	continue;
       }
-
-      std::unique_ptr<rgw::sal::Object> c_obj = c_bucket->get_object(e->obj_key);
-      ldpp_dout(dpp, 20) << __func__ << "(): c_obj oid =" << c_obj->get_oid() << dendl;
-
-      ACLOwner owner{c_user->get_id(), c_user->get_display_name()};
-
-      std::unique_ptr<rgw::sal::Writer> processor =  driver->get_atomic_writer(dpp,
-              null_yield,
-              c_obj.get(),
-              owner,
-              NULL,
-              0,
-              "");
-
-      int op_ret = processor->prepare(null_yield);
-      if (op_ret < 0) {
-	ldpp_dout(dpp, 20) << __func__ << "processor->prepare() returned ret=" << op_ret << dendl;
-        erase_dirty_object(dpp, e->key, null_yield);
+      if (p->second.second == State::INVALID) {
+	invalid = true;
       }
+      l.unlock();
+      
+      // If the state is invalid, the blocks must be deleted from the cache rather than written to the backend.
+      if (invalid) {
+	ldpp_dout(dpp, 10) << __func__ << "(): State is INVALID; deleting object." << dendl;
+	int ret = -1;
+	if ((ret = cacheDriver->delete_data(dpp, DIRTY_BLOCK_PREFIX + e->key, y)) == 0) { // Sam: do we want del or delete_data here?
+	  if (!(ret = erase(dpp, e->key, y))) {
+	    ldpp_dout(dpp, 0) << "Failed to delete head policy entry for: " << e->key << ", ret=" << ret << dendl; // TODO: what must occur during failure?
+	  }
+	} else {
+	  ldpp_dout(dpp, 0) << "Failed to delete head object for: " << e->key << ", ret=" << ret << dendl;
+	}
 
-      std::string prefix = url_encode(e->bucket_id) + CACHE_DELIM + url_encode(e->version) + CACHE_DELIM + url_encode(c_obj->get_name());
-      off_t lst = e->size;
-      off_t fst = 0;
-      off_t ofs = 0;
-
-      rgw::sal::DataProcessor *filter = processor.get();
-      std::string head_oid_in_cache = DIRTY_BLOCK_PREFIX + prefix;
-      std::string new_head_oid_in_cache = prefix;
-      ldpp_dout(dpp, 10) << __func__ << "(): head_oid_in_cache=" << head_oid_in_cache << dendl;
-      ldpp_dout(dpp, 10) << __func__ << "(): new_head_oid_in_cache=" << new_head_oid_in_cache << dendl;
-      bufferlist bl;
-      cacheDriver->get_attrs(dpp, head_oid_in_cache, obj_attrs, null_yield); //get obj attrs from head
-      obj_attrs.erase(RGW_CACHE_ATTR_MTIME);
-      obj_attrs.erase(RGW_CACHE_ATTR_OBJECT_SIZE);
-      obj_attrs.erase(RGW_CACHE_ATTR_ACCOUNTED_SIZE);
-      obj_attrs.erase(RGW_CACHE_ATTR_EPOCH);
-
-      do {
-        ceph::bufferlist data;
-        if (fst >= lst){
-	  break;
-        }
-        off_t cur_size = std::min<off_t>(fst + dpp->get_cct()->_conf->rgw_max_chunk_size, lst);
-        off_t cur_len = cur_size - fst;
-        std::string oid_in_cache = DIRTY_BLOCK_PREFIX + prefix + CACHE_DELIM + std::to_string(fst) + CACHE_DELIM + std::to_string(cur_len);
-        ldpp_dout(dpp, 10) << __func__ << "(): oid_in_cache=" << oid_in_cache << dendl;
-        rgw::sal::Attrs attrs;
-        cacheDriver->get(dpp, oid_in_cache, 0, cur_len, data, attrs, null_yield);
-        len = data.length();
-        fst += len;
-
-        if (len == 0) {
-          // TODO: if len of any block is 0 for some reason, we must return from here?
-          break;
-        }
-
-        op_ret = filter->process(std::move(data), ofs);
-        if (op_ret < 0) {
-	  ldpp_dout(dpp, 20) << __func__ << "processor->process() returned ret="
-	  << op_ret << dendl;
-          erase_dirty_object(dpp, e->key, null_yield);
-        }
-
-        ofs += len;
-      } while (len > 0);
-
-      op_ret = filter->process({}, ofs);
-
-      const req_context rctx{dpp, null_yield, nullptr};
-      ceph::real_time mtime = ceph::real_clock::from_time_t(e->creationTime);
-      op_ret = processor->complete(lst, e->etag, &mtime, ceph::real_clock::from_time_t(e->creationTime), obj_attrs,
-                              std::nullopt, ceph::real_time(), nullptr, nullptr,
-                              nullptr, nullptr, nullptr,
-                              rctx, rgw::sal::FLAG_LOG_OP);
-
-      if (op_ret < 0) {
-        ldpp_dout(dpp, 20) << __func__ << "processor->complete() returned ret=" << op_ret << dendl;
-        erase_dirty_object(dpp, e->key, null_yield);
-      }
-      //invoke update() with dirty flag set to false, to update in-memory metadata for each block
-      // reset values
-      lst = e->size;
-      fst = 0;
-      do {
-        if (fst >= lst) {
-	  break;
-        }
-        off_t cur_size = std::min<off_t>(fst + dpp->get_cct()->_conf->rgw_max_chunk_size, lst);
-        off_t cur_len = cur_size - fst;
-
-        std::string oid_in_cache = DIRTY_BLOCK_PREFIX + prefix + CACHE_DELIM + std::to_string(fst) + CACHE_DELIM + std::to_string(cur_len);
-        ldpp_dout(dpp, 20) << __func__ << "(): oid_in_cache =" << oid_in_cache << dendl;
-        std::string new_oid_in_cache = prefix + CACHE_DELIM + std::to_string(fst) + CACHE_DELIM + std::to_string(cur_len);
-        //Rename block to remove "D" prefix
-        cacheDriver->rename(dpp, oid_in_cache, new_oid_in_cache, null_yield);
-        //Update in-memory data structure for each block
-        this->update(dpp, new_oid_in_cache, 0, 0, e->version, false, y);
-
-        rgw::d4n::CacheBlock block;
-        block.cacheObj.bucketName = c_obj->get_bucket()->get_bucket_id();
-        block.cacheObj.objName = c_obj->get_key().get_oid();
-        block.size = cur_len;
-        block.blockID = fst;
-        op_ret = blockDir->update_field(dpp, &block, "dirty", "false", null_yield);
-        if (op_ret < 0) {
-	  ldpp_dout(dpp, 0) << __func__ << "updating dirty flag in block directory failed, ret=" << op_ret << dendl;
-        }
-        fst += cur_len;
-      } while(fst < lst);
-
-      cacheDriver->rename(dpp, head_oid_in_cache, new_head_oid_in_cache, null_yield);
-
-      //invoke update() with dirty flag set to false, to update in-memory metadata for head
-      this->update(dpp, new_head_oid_in_cache, 0, 0, e->version, false, y);
-
-      rgw::d4n::CacheBlock block;
-      block.cacheObj.bucketName = c_obj->get_bucket()->get_bucket_id();
-      block.cacheObj.objName = c_obj->get_name();
-      block.size = 0;
-      block.blockID = 0;
-      if (c_obj->have_instance()) {
-        blockDir->get(dpp, &block, null_yield);
-        if (block.version == c_obj->get_instance()) { //versioned case - update head block entry that has latest version
-          op_ret = blockDir->update_field(dpp, &block, "dirty", "false", null_yield);
-          if (op_ret < 0) {
-              ldpp_dout(dpp, 20) << __func__ << "updating dirty flag in block directory for head failed!" << dendl;
-          }
-        }
-      } else { //non-versioned case
-        op_ret = blockDir->update_field(dpp, &block, "dirty", "false", null_yield);
-        if (op_ret < 0) {
-            ldpp_dout(dpp, 20) << __func__ << "updating dirty flag in block directory for head failed!" << dendl;
-        }
-      }
-      if (c_obj->have_instance()) {
-        rgw::d4n::CacheBlock instance_block;
-        instance_block.cacheObj.bucketName = c_obj->get_bucket()->get_bucket_id();
-        instance_block.cacheObj.objName = c_obj->get_oid();
-        instance_block.size = 0;
-        instance_block.blockID = 0;
-        op_ret = blockDir->update_field(dpp, &instance_block, "dirty", "false", null_yield);
-        if (op_ret < 0) {
-            ldpp_dout(dpp, 20) << __func__ << "updating dirty flag in block directory for instance block failed!" << dendl;
-        }
-      }
-
-      //the next steps remove the entry from the ordered set and if needed the latest hash entry also in case of versioned buckets
-      if (!c_obj->have_instance()) {
-        ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): Removing object name: "<< c_obj->get_name() << " score: " << std::setprecision(std::numeric_limits<double>::max_digits10) << e->creationTime << " from ordered set" << dendl;
-        rgw::d4n::CacheObj dir_obj = rgw::d4n::CacheObj{
-          .objName = c_obj->get_name(),
-          .bucketName = c_obj->get_bucket()->get_bucket_id(),
-        };
-        ret = objDir->zremrangebyscore(dpp, &dir_obj, e->creationTime, e->creationTime, y, true);
-        if (ret < 0) {
-          ldpp_dout(dpp, 0) << __func__ << "(): Failed to remove object from ordered set with error: " << ret << dendl;
-        }
+	if (!e->delete_marker) {
+	  ret = delete_data_blocks(dpp, e, y);
+	  if (ret == 0) {
+	    erase_dirty_object(dpp, e->key, null_yield);
+	  } else {
+	    ldpp_dout(dpp, 0) << "Failed to delete blocks for: " << e->key << ", ret=" << ret << dendl;
+	  }
+	}
       } else {
-        rgw::d4n::CacheBlock latest_block = block;
-        latest_block.cacheObj.objName = c_obj->get_name();
-        //add watch on latest entry, as it can be modified by a put or a del
-        ret = blockDir->watch(dpp, &latest_block, y);
-        if (ret < 0) {
-          ldpp_dout(dpp, 0) << __func__ << "(): Failed to add a watch on: " << latest_block.cacheObj.objName << ", ret=" << ret << dendl;
-        }
-        int retry = 3;
-        while(retry) {
-          retry--;
-          //get latest entry
-          ret = blockDir->get(dpp, &latest_block, y);
-          if (ret < 0) {
-            ldpp_dout(dpp, 0) << __func__ << "(): Failed to get latest entry in block directory for: " << latest_block.cacheObj.objName << ", ret=" << ret << dendl;
-          }
-          //start redis transaction using MULTI
-          blockDir->multi(dpp, y);
-          if (latest_block.version == e->version) {
-            //remove object entry from ordered set
-            if (c_obj->have_instance()) {
-              blockDir->del(dpp, &latest_block, y, true);
-              if (ret < 0) {
-                ldpp_dout(dpp, 0) << __func__ << "(): Failed to queue del for latest hash entry: " << latest_block.cacheObj.objName << ", ret=" << ret << dendl;
-              }
-            }
-          }
-          ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): Removing object name: "<< c_obj->get_name() << " score: " << std::setprecision(std::numeric_limits<double>::max_digits10) << e->creationTime << " from ordered set" << dendl;
-          rgw::d4n::CacheObj dir_obj = rgw::d4n::CacheObj{
-            .objName = c_obj->get_name(),
-            .bucketName = c_obj->get_bucket()->get_bucket_id(),
-          };
-          ret = objDir->zremrangebyscore(dpp, &dir_obj, e->creationTime, e->creationTime, y, true);
-          if (ret < 0) {
-            ldpp_dout(dpp, 0) << __func__ << "(): Failed to remove object from ordered set with error: " << ret << dendl;
-          }
-          std::vector<std::string> responses;
-          ret = blockDir->exec(dpp, responses, y);
-          if (responses.empty()) {
-            ldpp_dout(dpp, 0) << __func__ << "(): Execute responses are empty hence continuing!" << dendl;
-            continue;
-          }
-          break;
-        }//end-while (retry)
+	l.lock();
+	p->second.second = State::IN_PROGRESS;
+	l.unlock();
+
+	rgw_user c_rgw_user = e->user; 
+	//writing data to the backend
+	//we need to create an atomic_writer
+	std::unique_ptr<rgw::sal::User> c_user = driver->get_user(c_rgw_user);
+
+	std::unique_ptr<rgw::sal::Bucket> c_bucket;
+	rgw_bucket c_rgw_bucket = rgw_bucket(c_rgw_user.tenant, e->bucket_name, e->bucket_id);
+
+	RGWBucketInfo c_bucketinfo;
+	c_bucketinfo.bucket = c_rgw_bucket;
+	c_bucketinfo.owner = c_rgw_user;
+	int ret = driver->load_bucket(dpp, c_rgw_bucket, &c_bucket, null_yield);
+	if (ret < 0) {
+	  ldpp_dout(dpp, 10) << __func__ << "(): load_bucket() returned ret=" << ret << dendl;
+	  //Remove bucket should be implemented in d4n which will take care of deleting objects belonging to the bucket, and hence we should not reach here
+	  erase_dirty_object(dpp, e->key, null_yield);
+	  continue;
+	}
+
+	std::unique_ptr<rgw::sal::Object> c_obj = c_bucket->get_object(e->obj_key);
+	bool null_instance = (c_obj->get_instance() == "null");
+	if (null_instance) {
+	  //clear the instance for backend store
+	  c_obj->clear_instance();
+	}
+	ldpp_dout(dpp, 20) << __func__ << "(): c_obj oid =" << c_obj->get_oid() << dendl;
+
+	ACLOwner owner{c_user->get_id(), c_user->get_display_name()};
+
+	std::string prefix = url_encode(e->bucket_id) + CACHE_DELIM + url_encode(e->version) + CACHE_DELIM + url_encode(c_obj->get_name());
+	std::string head_oid_in_cache = DIRTY_BLOCK_PREFIX + prefix;
+	std::string new_head_oid_in_cache = prefix;
+	ldpp_dout(dpp, 10) << __func__ << "(): head_oid_in_cache=" << head_oid_in_cache << dendl;
+	ldpp_dout(dpp, 10) << __func__ << "(): new_head_oid_in_cache=" << new_head_oid_in_cache << dendl;
+	int op_ret;
+	if (e->delete_marker) {
+	  bool null_delete_marker = (c_obj->get_instance() == "null");
+	  if (null_delete_marker) {
+	    //clear the instance for backend store
+	    c_obj->clear_instance();
+	  }
+	  std::unique_ptr<rgw::sal::Object::DeleteOp> del_op = c_obj->get_delete_op();
+	  del_op->params.obj_owner = owner;
+	  del_op->params.bucket_owner = c_bucket->get_owner();
+	  del_op->params.versioning_status = c_bucket->get_info().versioning_status();
+	  //populate marker_version_id only when delete marker is not null
+	  del_op->params.marker_version_id = e->version;
+	  op_ret = del_op->delete_obj(dpp, null_yield, rgw::sal::FLAG_LOG_OP);
+	  if (op_ret >= 0) {
+	    bool delete_marker = del_op->result.delete_marker;
+	    std::string version_id = del_op->result.version_id;
+	    ldpp_dout(dpp, 20) << __func__ << "delete_obj delete_marker=" << delete_marker << dendl;
+	    ldpp_dout(dpp, 20) << __func__ << "delete_obj version_id=" << version_id << dendl;
+	  } else {
+	    ldpp_dout(dpp, 20) << __func__ << "delete_obj returned ret=" << op_ret << dendl;
+	    erase_dirty_object(dpp, e->key, null_yield);
+	    continue;
+	  }
+	  if (null_delete_marker) {
+	    //restore instance for directory data processing in later steps
+	    c_obj->set_instance("null");
+	  }
+	} else { //end-if delete_marker
+
+	  std::unique_ptr<rgw::sal::Writer> processor =  driver->get_atomic_writer(dpp,
+		  null_yield,
+		  c_obj.get(),
+		  owner,
+		  NULL,
+		  0,
+		  "");
+
+	  op_ret = processor->prepare(null_yield);
+	  if (op_ret < 0) {
+      ldpp_dout(dpp, 20) << __func__ << "processor->prepare() returned ret=" << op_ret << dendl;
+	    erase_dirty_object(dpp, e->key, null_yield);
+	    continue;
+	  }
+
+	  off_t lst = e->size;
+	  off_t fst = 0;
+	  off_t ofs = 0;
+
+	  rgw::sal::DataProcessor *filter = processor.get();
+	  bufferlist bl;
+	  op_ret = cacheDriver->get_attrs(dpp, head_oid_in_cache, obj_attrs, null_yield); //get obj attrs from head
+	  if (op_ret < 0) {
+	    ldpp_dout(dpp, 20) << __func__ << "cacheDriver->get_attrs returned ret=" << op_ret << dendl;
+	    erase_dirty_object(dpp, e->key, null_yield);
+	    continue;
+	  }
+	  obj_attrs.erase(RGW_CACHE_ATTR_MTIME);
+	  obj_attrs.erase(RGW_CACHE_ATTR_OBJECT_SIZE);
+	  obj_attrs.erase(RGW_CACHE_ATTR_ACCOUNTED_SIZE);
+	  obj_attrs.erase(RGW_CACHE_ATTR_EPOCH);
+	  obj_attrs.erase(RGW_CACHE_ATTR_MULTIPART);
+	  obj_attrs.erase(RGW_CACHE_ATTR_OBJECT_NS);
+	  obj_attrs.erase(RGW_CACHE_ATTR_BUCKET_NAME);
+	  obj_attrs.erase(RGW_CACHE_ATTR_LOCAL_WEIGHT);
+
+	  do {
+	    ceph::bufferlist data;
+	    if (fst >= lst){
+	break;
+	    }
+	    off_t cur_size = std::min<off_t>(fst + dpp->get_cct()->_conf->rgw_max_chunk_size, lst);
+	    off_t cur_len = cur_size - fst;
+	    std::string oid_in_cache = DIRTY_BLOCK_PREFIX + prefix + CACHE_DELIM + std::to_string(fst) + CACHE_DELIM + std::to_string(cur_len);
+	    ldpp_dout(dpp, 10) << __func__ << "(): oid_in_cache=" << oid_in_cache << dendl;
+	    rgw::sal::Attrs attrs;
+	    cacheDriver->get(dpp, oid_in_cache, 0, cur_len, data, attrs, null_yield);
+	    if (op_ret < 0) {
+	      ldpp_dout(dpp, 20) << __func__ << "cacheDriver->get returned ret=" << op_ret << dendl;
+	      erase_dirty_object(dpp, e->key, null_yield);
+	      continue;
+	    }
+	    len = data.length();
+	    fst += len;
+
+	    if (len == 0) {
+	      // TODO: if len of any block is 0 for some reason, we must return from here?
+	      break;
+	    }
+
+	    op_ret = filter->process(std::move(data), ofs);
+	    if (op_ret < 0) {
+	ldpp_dout(dpp, 20) << __func__ << "processor->process() returned ret="
+	<< op_ret << dendl;
+	      erase_dirty_object(dpp, e->key, null_yield);
+	      continue;
+	    }
+
+	    ofs += len;
+	  } while (len > 0);
+
+	  op_ret = filter->process({}, ofs);
+
+	  const req_context rctx{dpp, null_yield, nullptr};
+	  ceph::real_time mtime = ceph::real_clock::from_time_t(e->creationTime);
+	  op_ret = processor->complete(lst, e->etag, &mtime, ceph::real_clock::from_time_t(e->creationTime), obj_attrs,
+				  std::nullopt, ceph::real_time(), nullptr, nullptr,
+				  nullptr, nullptr, nullptr,
+				  rctx, rgw::sal::FLAG_LOG_OP);
+
+	  if (op_ret < 0) {
+	    ldpp_dout(dpp, 20) << __func__ << "processor->complete() returned ret=" << op_ret << dendl;
+	    erase_dirty_object(dpp, e->key, null_yield);
+	    continue;
+	  }
+	  //invoke update() with dirty flag set to false, to update in-memory metadata for each block
+	  // reset values
+	  lst = e->size;
+	  fst = 0;
+	  do {
+	    if (fst >= lst) {
+	break;
+	    }
+	    off_t cur_size = std::min<off_t>(fst + dpp->get_cct()->_conf->rgw_max_chunk_size, lst);
+	    off_t cur_len = cur_size - fst;
+
+	    std::string oid_in_cache = DIRTY_BLOCK_PREFIX + prefix + CACHE_DELIM + std::to_string(fst) + CACHE_DELIM + std::to_string(cur_len);
+	    ldpp_dout(dpp, 20) << __func__ << "(): oid_in_cache =" << oid_in_cache << dendl;
+	    std::string new_oid_in_cache = prefix + CACHE_DELIM + std::to_string(fst) + CACHE_DELIM + std::to_string(cur_len);
+	    //Rename block to remove "D" prefix
+	    cacheDriver->rename(dpp, oid_in_cache, new_oid_in_cache, null_yield);
+	    //Update in-memory data structure for each block
+	    this->update(dpp, new_oid_in_cache, 0, 0, e->version, false, y);
+
+	    rgw::d4n::CacheBlock block;
+	    block.cacheObj.bucketName = c_obj->get_bucket()->get_bucket_id();
+	    block.cacheObj.objName = c_obj->get_key().get_oid();
+	    block.size = cur_len;
+	    block.blockID = fst;
+	    op_ret = blockDir->update_field(dpp, &block, "dirty", "false", null_yield);
+	    if (op_ret < 0) {
+	ldpp_dout(dpp, 0) << __func__ << "updating dirty flag in block directory failed, ret=" << op_ret << dendl;
+	    }
+	    fst += cur_len;
+	  } while(fst < lst);
+	} //end-else if delete_marker
+
+	cacheDriver->rename(dpp, head_oid_in_cache, new_head_oid_in_cache, null_yield);
+
+	//invoke update() with dirty flag set to false, to update in-memory metadata for head
+	this->update(dpp, new_head_oid_in_cache, 0, 0, e->version, false, y);
+
+	if (null_instance) {
+	  //restore instance for directory data processing in later steps
+	  c_obj->set_instance("null");
+	}
+	rgw::d4n::CacheBlock block;
+	block.cacheObj.bucketName = c_obj->get_bucket()->get_bucket_id();
+	block.cacheObj.objName = c_obj->get_name();
+	block.size = 0;
+	block.blockID = 0;
+	//non-versioned case
+	if (!c_obj->have_instance()) {
+	  //add watch on latest entry, as it can be modified by a put or a del
+	  ret = blockDir->watch(dpp, &block, y);
+	  if (ret < 0) {
+	    ldpp_dout(dpp, 0) << __func__ << "(): Failed to add a watch on: " << block.cacheObj.objName << ", ret=" << ret << dendl;
+	  }
+	  // hash entry for latest version
+	  op_ret = blockDir->get(dpp, &block, y);
+	  if (op_ret < 0) {
+	    ldpp_dout(dpp, 0) << __func__ << "(): Failed to get latest entry in block directory for: " << block.cacheObj.objName << ", ret=" << ret << dendl;
+	  } else {
+	    // if this entry is the latest, it could have been overwritten by a newer one
+	    if (block.version == e->version) {
+	      rgw::d4n::CacheBlock null_block;
+	      null_block = block;
+	      null_block.cacheObj.objName = "_:null_" + c_obj->get_name();
+	      //hash entry for null block
+	      op_ret = blockDir->get(dpp, &null_block, y);
+	      if (op_ret < 0) {
+		ldpp_dout(dpp, 0) << __func__ << "(): Failed to get latest entry in block directory for: " << null_block.cacheObj.objName << ", ret=" << ret << dendl;
+	      } else {
+		if (null_block.version == e->version) {
+		  block.cacheObj.dirty = false;
+		  null_block.cacheObj.dirty = false;
+		  //start redis transaction using MULTI
+		  blockDir->multi(dpp, y);
+		  auto blk_op_ret = blockDir->set(dpp, &block, y);
+		  auto null_op_ret = blockDir->set(dpp, &null_block, y);
+		  if (blk_op_ret < 0 || null_op_ret < 0) {
+		    blockDir->discard(dpp, y);
+		    ldpp_dout(dpp, 0) << __func__ << "(): Failed to Queue update dirty flag for latest entry/null entry in block directory" << dendl;
+		  } else {
+		    std::vector<std::string> responses;
+		    ret = blockDir->exec(dpp, responses, y);
+		    if (responses.empty()) {
+		      //transaction failed, which means latest hash entry has been modified by a put/del so ignore and do not update the entries
+		      ldpp_dout(dpp, 0) << __func__ << "(): Execute responses are empty which means transaction failed!" << dendl;
+		    }
+		  }
+		}
+	      }
+	    } //end-if (block.version == entry->version)
+	  } //end - else if op_ret == 0
+	  ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): Removing object name: "<< c_obj->get_name() << " score: " << std::setprecision(std::numeric_limits<double>::max_digits10) << e->creationTime << " from ordered set" << dendl;
+	  rgw::d4n::CacheObj dir_obj = rgw::d4n::CacheObj{
+	    .objName = c_obj->get_name(),
+	    .bucketName = c_obj->get_bucket()->get_bucket_id(),
+	  };
+	  //remove the entry from the ordered set using its score, as the object is already cleaned
+	  //need not be part of a transaction as it is being removed based on its score which is its creation time.
+	  ret = objDir->zremrangebyscore(dpp, &dir_obj, e->creationTime, e->creationTime, y);
+	  if (ret < 0) {
+	    ldpp_dout(dpp, 0) << __func__ << "(): Failed to remove object from ordered set with error: " << ret << dendl;
+	  }
+	}
+	if (c_obj->have_instance()) { //versioned case
+	  std::string objName = c_obj->get_oid();
+	  if (c_obj->get_instance() == "null") {
+	    objName = "_:null_" + c_obj->get_name();
+	  }
+	  rgw::d4n::CacheBlock instance_block;
+	  instance_block.cacheObj.bucketName = c_obj->get_bucket()->get_bucket_id();
+	  instance_block.cacheObj.objName = objName;
+	  instance_block.size = 0;
+	  instance_block.blockID = 0;
+	  op_ret = blockDir->update_field(dpp, &instance_block, "dirty", "false", null_yield);
+	  if (op_ret < 0) {
+	      ldpp_dout(dpp, 20) << __func__ << "updating dirty flag in block directory for instance block failed!" << dendl;
+	  }
+	  //the next steps remove the entry from the ordered set and if needed the latest hash entry also in case of versioned buckets
+	  rgw::d4n::CacheBlock latest_block = block;
+	  latest_block.cacheObj.objName = c_obj->get_name();
+	  //add watch on latest entry, as it can be modified by a put or a del
+	  ret = blockDir->watch(dpp, &latest_block, y);
+	  if (ret < 0) {
+	    ldpp_dout(dpp, 0) << __func__ << "(): Failed to add a watch on: " << latest_block.cacheObj.objName << ", ret=" << ret << dendl;
+	  }
+	  int retry = 3;
+	  while(retry) {
+	    retry--;
+	    //get latest entry
+	    ret = blockDir->get(dpp, &latest_block, y);
+	    if (ret < 0) {
+	      ldpp_dout(dpp, 0) << __func__ << "(): Failed to get latest entry in block directory for: " << latest_block.cacheObj.objName << ", ret=" << ret << dendl;
+	    }
+	    //start redis transaction using MULTI
+	    blockDir->multi(dpp, y);
+	    if (latest_block.version == e->version) {
+	      //remove object entry from ordered set
+	      if (c_obj->have_instance()) {
+		blockDir->del(dpp, &latest_block, y, true);
+		if (ret < 0) {
+		  blockDir->discard(dpp, y);
+		  ldpp_dout(dpp, 0) << __func__ << "(): Failed to queue del for latest hash entry: " << latest_block.cacheObj.objName << ", ret=" << ret << dendl;
+		  continue;
+		}
+	      }
+	    }
+	    ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): Removing object name: "<< c_obj->get_name() << " score: " << std::setprecision(std::numeric_limits<double>::max_digits10) << e->creationTime << " from ordered set" << dendl;
+	    rgw::d4n::CacheObj dir_obj = rgw::d4n::CacheObj{
+	      .objName = c_obj->get_name(),
+	      .bucketName = c_obj->get_bucket()->get_bucket_id(),
+	    };
+	    ret = objDir->zremrangebyscore(dpp, &dir_obj, e->creationTime, e->creationTime, y, true);
+	    if (ret < 0) {
+	      blockDir->discard(dpp, y);
+	      ldpp_dout(dpp, 0) << __func__ << "(): Failed to remove object from ordered set with error: " << ret << dendl;
+	      continue;
+	    }
+	    std::vector<std::string> responses;
+	    ret = blockDir->exec(dpp, responses, y);
+	    if (responses.empty()) {
+	      ldpp_dout(dpp, 0) << __func__ << "(): Execute responses are empty hence continuing!" << dendl;
+	      continue;
+	    }
+	    break;
+	  }//end-while (retry)
+	}
+	//remove entry from map and queue, erase_dirty_object locks correctly
+	erase_dirty_object(dpp, e->key, null_yield);
       }
-      //remove entry from map and queue, erase_dirty_object locks correctly
-      erase_dirty_object(dpp, e->key, null_yield);
-    } else { //end-if std::difftime(time(NULL), e->creationTime) > interval
-      std::this_thread::sleep_for(std::chrono::milliseconds(interval)); //TODO:: should this time be optimised?
+    } else if (diff < interval) { //end-if std::difftime(time(NULL), e->creationTime) > interval
+      std::this_thread::sleep_for(std::chrono::seconds(interval - diff)); //TODO:: should this time be optimised?
     }
   } //end-while true
 }
@@ -743,7 +955,7 @@ void LRUPolicy::update(const DoutPrefixProvider* dpp, std::string& key, uint64_t
 }
 
 void LRUPolicy::update_dirty_object(const DoutPrefixProvider* dpp, std::string& key, std::string version, bool dirty, uint64_t size, time_t creationTime, const rgw_user user, std::string& etag, const std::string& bucket_name, const std::string& bucket_id,
-const rgw_obj_key& obj_key, optional_yield y)
+const rgw_obj_key& obj_key, optional_yield y, std::string& restore_val)
 {
   const std::lock_guard l(lru_lock);
   ObjEntry *e = new ObjEntry(key, version, dirty, size, creationTime, user, etag, bucket_name, bucket_id, obj_key);

--- a/src/rgw/driver/d4n/d4n_policy.cc
+++ b/src/rgw/driver/d4n/d4n_policy.cc
@@ -263,7 +263,7 @@ bool LFUDAPolicy::invalidate_dirty_object(const DoutPrefixProvider* dpp, std::st
   if (p->second.second == State::INIT) {
     ldpp_dout(dpp, 10) << "LFUDAPolicy::" << __func__ << "(): Setting State::INVALID for key=" << key << dendl;
     p->second.second = State::INVALID;
-    int ret = cacheDriver->set_attr(dpp, DIRTY_BLOCK_PREFIX + key, RGW_CACHE_ATTR_INVALID, "1", y);
+    int ret = cacheDriver->set_attr(dpp, key, RGW_CACHE_ATTR_INVALID, "1", y);
     if (ret < 0) {
       ldpp_dout(dpp, 0) << "LFUDAPolicy::" << __func__ << "(): Failed to set xattr, ret=" << ret << dendl;
       return false;
@@ -433,11 +433,6 @@ void LFUDAPolicy::update(const DoutPrefixProvider* dpp, std::string& key, uint64
   bool updateLocalWeight = true;
   uint64_t refcount = 0;
 
-  std::string oid_in_cache = key;
-  if (dirty == true) {
-    oid_in_cache = DIRTY_BLOCK_PREFIX + key;
-  }
-
   if (!restore_val.empty()) {
     updateLocalWeight = false;
     localWeight = std::stoull(restore_val);
@@ -473,7 +468,7 @@ void LFUDAPolicy::update(const DoutPrefixProvider* dpp, std::string& key, uint64
 
   if (updateLocalWeight) {
     int ret = -1;
-    if ((ret = cacheDriver->set_attr(dpp, oid_in_cache, RGW_CACHE_ATTR_LOCAL_WEIGHT, std::to_string(localWeight), y)) < 0) 
+    if ((ret = cacheDriver->set_attr(dpp, key, RGW_CACHE_ATTR_LOCAL_WEIGHT, std::to_string(localWeight), y)) < 0) 
       ldpp_dout(dpp, 0) << "LFUDAPolicy::" << __func__ << "(): CacheDriver set_attr method failed, ret=" << ret << dendl;
   }
 
@@ -550,12 +545,11 @@ int LFUDAPolicy::delete_data_blocks(const DoutPrefixProvider* dpp, LFUDAObjEntry
     }
     off_t cur_size = std::min<off_t>(fst + dpp->get_cct()->_conf->rgw_max_chunk_size, lst);
     off_t cur_len = cur_size - fst;
-    std::string prefix = e->key + CACHE_DELIM + std::to_string(fst) + CACHE_DELIM + std::to_string(cur_len);
-    std::string oid_in_cache = DIRTY_BLOCK_PREFIX + prefix;
+    std::string oid_in_cache = e->key + CACHE_DELIM + std::to_string(fst) + CACHE_DELIM + std::to_string(cur_len);
 
     int ret = -1;
     std::unique_lock<std::mutex> ll(lfuda_lock);
-    auto it = entries_map.find(prefix);
+    auto it = entries_map.find(oid_in_cache);
     if (it != entries_map.end()) {
       if (it->second->refcount > 0) {
         return -EBUSY;//better error code?
@@ -563,7 +557,7 @@ int LFUDAPolicy::delete_data_blocks(const DoutPrefixProvider* dpp, LFUDAObjEntry
     }
     ll.unlock();
     if ((ret = cacheDriver->delete_data(dpp, oid_in_cache, y)) == 0) { // Sam: do we want del or delete_data here?
-      if (!(ret = erase(dpp, prefix, y))) {
+      if (!(ret = erase(dpp, oid_in_cache, y))) {
 	ldpp_dout(dpp, 0) << "Failed to delete policy entry for: " << oid_in_cache << ", ret=" << ret << dendl;
         return -EINVAL;
       }
@@ -638,7 +632,7 @@ void LFUDAPolicy::cleaning(const DoutPrefixProvider* dpp)
           continue;
         }
         ll.unlock();
-        if ((ret = cacheDriver->delete_data(dpp, DIRTY_BLOCK_PREFIX + e->key, y)) == 0) { // Sam: do we want del or delete_data here?
+        if ((ret = cacheDriver->delete_data(dpp, e->key, y)) == 0) { // Sam: do we want del or delete_data here?
           if (!(ret = erase(dpp, e->key, y))) {
             ldpp_dout(dpp, 0) << "Failed to delete head policy entry for: " << e->key << ", ret=" << ret << dendl; // TODO: what must occur during failure?
           }
@@ -696,11 +690,8 @@ void LFUDAPolicy::cleaning(const DoutPrefixProvider* dpp)
 
 	ACLOwner owner{c_user->get_id(), c_user->get_display_name()};
 
-	std::string prefix = url_encode(e->bucket_id) + CACHE_DELIM + url_encode(e->version) + CACHE_DELIM + url_encode(c_obj->get_name());
-	std::string head_oid_in_cache = DIRTY_BLOCK_PREFIX + prefix;
-	std::string new_head_oid_in_cache = prefix;
+	std::string head_oid_in_cache = url_encode(e->bucket_id) + CACHE_DELIM + url_encode(e->version) + CACHE_DELIM + url_encode(c_obj->get_name());
 	ldpp_dout(dpp, 10) << __func__ << "(): head_oid_in_cache=" << head_oid_in_cache << dendl;
-	ldpp_dout(dpp, 10) << __func__ << "(): new_head_oid_in_cache=" << new_head_oid_in_cache << dendl;
 	int op_ret;
 	if (e->delete_marker) {
 	  bool null_delete_marker = (c_obj->get_instance() == "null");
@@ -774,7 +765,7 @@ void LFUDAPolicy::cleaning(const DoutPrefixProvider* dpp)
 	    }
 	    off_t cur_size = std::min<off_t>(fst + dpp->get_cct()->_conf->rgw_max_chunk_size, lst);
 	    off_t cur_len = cur_size - fst;
-	    std::string oid_in_cache = DIRTY_BLOCK_PREFIX + prefix + CACHE_DELIM + std::to_string(fst) + CACHE_DELIM + std::to_string(cur_len);
+	    std::string oid_in_cache = head_oid_in_cache + CACHE_DELIM + std::to_string(fst) + CACHE_DELIM + std::to_string(cur_len);
 	    ldpp_dout(dpp, 10) << __func__ << "(): oid_in_cache=" << oid_in_cache << dendl;
 	    rgw::sal::Attrs attrs;
 	    cacheDriver->get(dpp, oid_in_cache, 0, cur_len, data, attrs, null_yield);
@@ -827,31 +818,35 @@ void LFUDAPolicy::cleaning(const DoutPrefixProvider* dpp)
 	    off_t cur_size = std::min<off_t>(fst + dpp->get_cct()->_conf->rgw_max_chunk_size, lst);
 	    off_t cur_len = cur_size - fst;
 
-	    std::string oid_in_cache = DIRTY_BLOCK_PREFIX + prefix + CACHE_DELIM + std::to_string(fst) + CACHE_DELIM + std::to_string(cur_len);
+	    std::string oid_in_cache = head_oid_in_cache + CACHE_DELIM + std::to_string(fst) + CACHE_DELIM + std::to_string(cur_len);
 	    ldpp_dout(dpp, 20) << __func__ << "(): oid_in_cache =" << oid_in_cache << dendl;
-	    std::string new_oid_in_cache = prefix + CACHE_DELIM + std::to_string(fst) + CACHE_DELIM + std::to_string(cur_len);
-	    //Rename block to remove "D" prefix
-	    cacheDriver->rename(dpp, oid_in_cache, new_oid_in_cache, null_yield);
 	    //Update in-memory data structure for each block
-	    this->update(dpp, new_oid_in_cache, 0, 0, e->version, false, 0, y);
+	    this->update(dpp, oid_in_cache, 0, 0, e->version, false, 0, y);
 
 	    rgw::d4n::CacheBlock block;
 	    block.cacheObj.bucketName = c_obj->get_bucket()->get_bucket_id();
 	    block.cacheObj.objName = c_obj->get_key().get_oid();
 	    block.size = cur_len;
 	    block.blockID = fst;
-	    op_ret = blockDir->update_field(dpp, &block, "dirty", "false", null_yield);
-	    if (op_ret < 0) {
-	ldpp_dout(dpp, 0) << __func__ << "updating dirty flag in block directory failed, ret=" << op_ret << dendl;
-	    }
+            if ((op_ret = cacheDriver->set_attr(dpp, oid_in_cache, RGW_CACHE_ATTR_DIRTY, "0", y)) == 0) {
+		op_ret = blockDir->update_field(dpp, &block, "dirty", "false", null_yield);
+		if (op_ret < 0) {
+		    ldpp_dout(dpp, 0) << __func__ << "updating dirty flag in block directory failed, ret=" << op_ret << dendl;
+		}
+            } else {
+		ldpp_dout(dpp, 0) << __func__ << "(): Failed to update dirty xattr in cache, ret=" << op_ret << dendl;
+            }
+
 	    fst += cur_len;
 	  } while(fst < lst);
 	} //end-else if delete_marker
 
-	cacheDriver->rename(dpp, head_oid_in_cache, new_head_oid_in_cache, null_yield);
-
 	//invoke update() with dirty flag set to false, to update in-memory metadata for head
-	this->update(dpp, new_head_oid_in_cache, 0, 0, e->version, false, 0, y);
+	this->update(dpp, head_oid_in_cache, 0, 0, e->version, false, 0, y);
+         
+        if ((ret = cacheDriver->set_attr(dpp, head_oid_in_cache, RGW_CACHE_ATTR_DIRTY, "0", y)) < 0) {
+	  ldpp_dout(dpp, 0) << __func__ << "(): Failed to update dirty attr in cache, ret=" << op_ret << dendl;
+        }
 
 	if (null_instance) {
 	  //restore instance for directory data processing in later steps
@@ -859,6 +854,7 @@ void LFUDAPolicy::cleaning(const DoutPrefixProvider* dpp)
 	}
 	rgw::d4n::CacheBlock block;
 	block.cacheObj.bucketName = c_obj->get_bucket()->get_bucket_id();
+        std::cout << "bucket name: " << block.cacheObj.bucketName  << std::endl;
 	block.cacheObj.objName = c_obj->get_name();
 	block.size = 0;
 	block.blockID = 0;

--- a/src/rgw/driver/d4n/d4n_policy.h
+++ b/src/rgw/driver/d4n/d4n_policy.h
@@ -39,7 +39,7 @@ class CachePolicy {
     struct ObjEntry {
       std::string key;
       std::string version;
-      bool dirty;
+      bool delete_marker;
       uint64_t size;
       time_t creationTime;
       rgw_user user;
@@ -48,9 +48,9 @@ class CachePolicy {
       std::string bucket_id;
       rgw_obj_key obj_key;
       ObjEntry() = default;
-      ObjEntry(std::string& key, std::string version, bool dirty, uint64_t size, 
+      ObjEntry(std::string& key, std::string version, bool delete_marker, uint64_t size,
 		time_t creationTime, rgw_user user, std::string& etag, 
-		const std::string& bucket_name, const std::string& bucket_id, const rgw_obj_key& obj_key) : key(key), version(version), dirty(dirty), size(size), 
+		const std::string& bucket_name, const std::string& bucket_id, const rgw_obj_key& obj_key) : key(key), version(version), delete_marker(delete_marker), size(size),
 									      creationTime(creationTime), user(user), etag(etag), 
 									      bucket_name(bucket_name), bucket_id(bucket_id), obj_key(obj_key) {}
     };
@@ -112,9 +112,9 @@ class LFUDAPolicy : public CachePolicy {
       using handle_type = boost::heap::fibonacci_heap<LFUDAObjEntry*, boost::heap::compare<ObjectComparator<LFUDAObjEntry>>>::handle_type;
       handle_type handle;
 
-      LFUDAObjEntry(std::string& key, std::string& version, bool dirty, uint64_t size, 
+      LFUDAObjEntry(std::string& key, std::string& version, bool deleteMarker, uint64_t size,
                      time_t creationTime, rgw_user user, std::string& etag, 
-                     const std::string& bucket_name, const std::string& bucket_id, const rgw_obj_key& obj_key) : ObjEntry(key, version, dirty, size, 
+                     const std::string& bucket_name, const std::string& bucket_id, const rgw_obj_key& obj_key) : ObjEntry(key, version, deleteMarker, size,
 									    creationTime, user, etag, bucket_name, bucket_id, obj_key) {}
 
       void set_handle(handle_type handle_) { handle = handle_; }

--- a/src/rgw/driver/d4n/d4n_policy.h
+++ b/src/rgw/driver/d4n/d4n_policy.h
@@ -17,6 +17,10 @@ namespace sys = boost::system;
 
 static std::string empty = std::string();
 
+static constexpr uint32_t REFCOUNT_NOOP = 0x0000;
+static constexpr uint32_t REFCOUNT_INCR = 0x0001;
+static constexpr uint32_t REFCOUNT_DECR = 0x0002;
+
 enum class State { // state machine for dirty objects in the cache
   INIT,
   IN_PROGRESS, // object is being written to the backend
@@ -31,8 +35,9 @@ class CachePolicy {
       uint64_t len;
       std::string version;
       bool dirty;
-      Entry(std::string& key, uint64_t offset, uint64_t len, std::string version, bool dirty) : key(key), offset(offset), 
-											        len(len), version(version), dirty(dirty) {}
+      uint64_t refcount{0};
+      Entry(std::string& key, uint64_t offset, uint64_t len, std::string version, bool dirty, uint64_t refcount) : key(key), offset(offset), 
+											        len(len), version(version), dirty(dirty), refcount(refcount) {}
       };
    
     //The disposer object function
@@ -68,10 +73,11 @@ class CachePolicy {
     virtual int init(CephContext *cct, const DoutPrefixProvider* dpp, asio::io_context& io_context, rgw::sal::Driver *_driver) = 0; 
     virtual int exist_key(std::string key) = 0;
     virtual int eviction(const DoutPrefixProvider* dpp, uint64_t size, optional_yield y) = 0;
-    virtual void update(const DoutPrefixProvider* dpp, std::string& key, uint64_t offset, uint64_t len, std::string version, bool dirty, optional_yield y, std::string& restore_val=empty) = 0;
+    virtual bool update_refcount_if_key_exists(const DoutPrefixProvider* dpp, std::string& key, uint32_t flag, optional_yield y) = 0;
+    virtual void update(const DoutPrefixProvider* dpp, std::string& key, uint64_t offset, uint64_t len, std::string version, bool dirty, uint32_t refcount_flag, optional_yield y, std::string& restore_val=empty) = 0;
     virtual void update_dirty_object(const DoutPrefixProvider* dpp, std::string& key, std::string version, bool dirty, uint64_t size, 
 			    time_t creationTime, const rgw_user user, std::string& etag, const std::string& bucket_name, const std::string& bucket_id,
-			    const rgw_obj_key& obj_key, optional_yield y, std::string& restore_val=empty) = 0;
+			    const rgw_obj_key& obj_key, uint32_t refcount_flag, optional_yield y, std::string& restore_val=empty) = 0;
     virtual bool erase(const DoutPrefixProvider* dpp, const std::string& key, optional_yield y) = 0;
     virtual bool erase_dirty_object(const DoutPrefixProvider* dpp, const std::string& key, optional_yield y) = 0;
     virtual bool invalidate_dirty_object(const DoutPrefixProvider* dpp, std::string& key) = 0;
@@ -83,14 +89,18 @@ class LFUDAPolicy : public CachePolicy {
     template<typename T>
     struct EntryComparator {
       bool operator()(T* const e1, T* const e2) const {
-        // order the min heap using localWeight and dirty flag so that dirty blocks are at the bottom
-        if ((e1->dirty && e2->dirty) || (!e1->dirty && !e2->dirty)) {
+        // order the min heap using localWeight, refcount and dirty flag so that dirty blocks and blocks with positive refcount are at the bottom
+        if ((e1->dirty && e2->dirty) || (!e1->dirty && !e2->dirty) || (e1->refcount > 0 && e2->refcount > 0)) {
 	        return e1->localWeight > e2->localWeight;
         } else if (e1->dirty && !e2->dirty){
           return true;
         } else if (!e1->dirty && e2->dirty) {
           return false;
-        } else {
+        } else if (e1->refcount > 0 && e2->refcount == 0) {
+          return true;
+        } else if (e1->refcount == 0 && e2->refcount > 0) {
+          return false;
+        }else {
           return e1->localWeight > e2->localWeight;
         }
       }
@@ -109,7 +119,7 @@ class LFUDAPolicy : public CachePolicy {
       using handle_type = boost::heap::fibonacci_heap<LFUDAEntry*, boost::heap::compare<EntryComparator<LFUDAEntry>>>::handle_type;
       handle_type handle;
 
-      LFUDAEntry(std::string& key, uint64_t offset, uint64_t len, std::string& version, bool dirty, int localWeight) : Entry(key, offset, len, version, dirty), 
+      LFUDAEntry(std::string& key, uint64_t offset, uint64_t len, std::string& version, bool dirty, uint64_t refcount, int localWeight) : Entry(key, offset, len, version, dirty, refcount), 
 														       localWeight(localWeight) {}
       
       void set_handle(handle_type handle_) { handle = handle_; }
@@ -120,7 +130,7 @@ class LFUDAPolicy : public CachePolicy {
       handle_type handle;
 
       LFUDAObjEntry(std::string& key, std::string& version, bool deleteMarker, uint64_t size,
-                     time_t creationTime, rgw_user user, std::string& etag, 
+                     time_t creationTime, rgw_user user, std::string& etag,
                      const std::string& bucket_name, const std::string& bucket_id, const rgw_obj_key& obj_key) : ObjEntry(key, version, deleteMarker, size,
 									    creationTime, user, etag, bucket_name, bucket_id, obj_key) {}
 
@@ -188,12 +198,14 @@ class LFUDAPolicy : public CachePolicy {
     virtual int init(CephContext *cct, const DoutPrefixProvider* dpp, asio::io_context& io_context, rgw::sal::Driver *_driver);
     virtual int exist_key(std::string key) override;
     virtual int eviction(const DoutPrefixProvider* dpp, uint64_t size, optional_yield y) override;
-    virtual void update(const DoutPrefixProvider* dpp, std::string& key, uint64_t offset, uint64_t len, std::string version, bool dirty, optional_yield y, std::string& restore_val=empty) override;
+    virtual bool update_refcount_if_key_exists(const DoutPrefixProvider* dpp, std::string& key, uint32_t flag, optional_yield y) override;
+    virtual void update(const DoutPrefixProvider* dpp, std::string& key, uint64_t offset, uint64_t len, std::string version, bool dirty, uint32_t refcount_flag, optional_yield y, std::string& restore_val=empty) override;
     virtual bool erase(const DoutPrefixProvider* dpp, const std::string& key, optional_yield y) override;
+    virtual bool _erase(const DoutPrefixProvider* dpp, const std::string& key, optional_yield y);
     void save_y(optional_yield y) { this->y = y; }
     virtual void update_dirty_object(const DoutPrefixProvider* dpp, std::string& key, std::string version, bool dirty, uint64_t size, 
 			    time_t creationTime, const rgw_user user, std::string& etag, const std::string& bucket_name, const std::string& bucket_id,
-			    const rgw_obj_key& obj_key, optional_yield y, std::string& restore_val=empty) override;
+			    const rgw_obj_key& obj_key, uint32_t refcount_flag, optional_yield y, std::string& restore_val=empty) override;
     virtual bool erase_dirty_object(const DoutPrefixProvider* dpp, const std::string& key, optional_yield y) override;
     virtual bool invalidate_dirty_object(const DoutPrefixProvider* dpp, std::string& key) override;
     virtual void cleaning(const DoutPrefixProvider* dpp) override;
@@ -224,10 +236,11 @@ class LRUPolicy : public CachePolicy {
     virtual int init(CephContext *cct, const DoutPrefixProvider* dpp, asio::io_context& io_context, rgw::sal::Driver* _driver) { return 0; } 
     virtual int exist_key(std::string key) override;
     virtual int eviction(const DoutPrefixProvider* dpp, uint64_t size, optional_yield y) override;
-    virtual void update(const DoutPrefixProvider* dpp, std::string& key, uint64_t offset, uint64_t len, std::string version, bool dirty, optional_yield y, std::string& restore_val=empty) override;
+    virtual bool update_refcount_if_key_exists(const DoutPrefixProvider* dpp, std::string& key, uint32_t flag, optional_yield y) override { return false; }
+    virtual void update(const DoutPrefixProvider* dpp, std::string& key, uint64_t offset, uint64_t len, std::string version, bool dirty, uint32_t refcount_flag, optional_yield y, std::string& restore_val=empty) override;
     virtual void update_dirty_object(const DoutPrefixProvider* dpp, std::string& key, std::string version, bool dirty, uint64_t size, 
 			    time_t creationTime, const rgw_user user, std::string& etag, const std::string& bucket_name, const std::string& bucket_id,
-    			    const rgw_obj_key& obj_key, optional_yield y, std::string& restore_val=empty) override;
+    			    const rgw_obj_key& obj_key, uint32_t refcount_flag, optional_yield y, std::string& restore_val=empty) override;
     virtual bool erase(const DoutPrefixProvider* dpp, const std::string& key, optional_yield y) override;
     virtual bool erase_dirty_object(const DoutPrefixProvider* dpp, const std::string& key, optional_yield y) override;
     virtual bool invalidate_dirty_object(const DoutPrefixProvider* dpp, std::string& key) override { return false; }

--- a/src/rgw/driver/d4n/rgw_sal_d4n.cc
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.cc
@@ -1871,12 +1871,6 @@ int D4NFilterObject::D4NFilterDeleteOp::delete_obj(const DoutPrefixProvider* dpp
 	  return ret;
 	}
       }
-
-      if ((ret = source->driver->get_obj_dir()->del(dpp, &block.cacheObj, y)) < 0) {
-	ldpp_dout(dpp, 0) << "Failed to delete object directory entry for: " << block.cacheObj.objName << ", ret=" << ret << dendl;
-	return ret;
-      }
-      
       std::string size;
       if (attrs.find(RGW_CACHE_ATTR_OBJECT_SIZE) != attrs.end()) {
 	size = attrs.find(RGW_CACHE_ATTR_OBJECT_SIZE)->second.to_str();

--- a/src/rgw/driver/d4n/rgw_sal_d4n.cc
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.cc
@@ -314,7 +314,7 @@ int D4NFilterObject::copy_object(const ACLOwner& owner,
     if (ret == 0) {
       ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " version stored in update method is: " << dest_version << dendl;
       bufferlist bl;
-      driver->get_policy_driver()->get_cache_policy()->update(dpp, key, 0, bl.length(), dest_version, dirty, y);
+      driver->get_policy_driver()->get_cache_policy()->update(dpp, key, 0, bl.length(), dest_version, dirty, rgw::d4n::REFCOUNT_NOOP, y);
       d4n_dest_object->set_object_version(dest_version);
       ret = d4n_dest_object->set_head_obj_dir_entry(dpp, nullptr, y, true, dirty);
       if (ret < 0) {
@@ -322,7 +322,7 @@ int D4NFilterObject::copy_object(const ACLOwner& owner,
         return ret;
       }
       if (dirty) {
-        driver->get_policy_driver()->get_cache_policy()->update_dirty_object(dpp, key, dest_version, false, this->get_size(), creationTime, std::get<rgw_user>(dest_object->get_bucket()->get_owner()), *etag, dest_object->get_bucket()->get_name(), dest_object->get_bucket()->get_bucket_id(), dest_object->get_key(), y);
+        driver->get_policy_driver()->get_cache_policy()->update_dirty_object(dpp, key, dest_version, false, this->get_size(), creationTime, std::get<rgw_user>(dest_object->get_bucket()->get_owner()), *etag, dest_object->get_bucket()->get_name(), dest_object->get_bucket()->get_bucket_id(), dest_object->get_key(), rgw::d4n::REFCOUNT_NOOP, y);
       }
     }
   }
@@ -337,7 +337,9 @@ int D4NFilterObject::set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattr
   rgw::sal::Attrs attrs;
   std::string head_oid_in_cache;
   rgw::d4n::CacheBlock block;
+  bool found_in_cache = false;
   if (check_head_exists_in_cache_get_oid(dpp, head_oid_in_cache, attrs, block, y)) {
+    found_in_cache = true;
     if (setattrs != nullptr) {
       /* Ensure setattrs and delattrs do not overlap */
       if (delattrs != nullptr) {
@@ -348,9 +350,15 @@ int D4NFilterObject::set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattr
         }
       }
       //if set_obj_attrs() can be called to update existing attrs, then update_attrs() need to be called
-      if (auto ret = driver->get_cache_driver()->set_attrs(dpp, head_oid_in_cache, *setattrs, y); ret < 0) {
-        ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): CacheDriver set_attrs method failed with ret: " << ret << dendl;
-        return ret;
+      if (this->driver->get_policy_driver()->get_cache_policy()->update_refcount_if_key_exists(dpp, head_oid_in_cache, rgw::d4n::REFCOUNT_INCR, y)) {
+        auto ret = driver->get_cache_driver()->set_attrs(dpp, head_oid_in_cache, *setattrs, y);
+        this->driver->get_policy_driver()->get_cache_policy()->update_refcount_if_key_exists(dpp, head_oid_in_cache, rgw::d4n::REFCOUNT_DECR, y);
+        if (ret < 0) {
+          ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): CacheDriver set_attrs method failed with ret: " << ret << dendl;
+          return ret;
+        }
+      } else {
+        found_in_cache = false;
       }
     } //if setattrs != nullptr
 
@@ -364,10 +372,15 @@ int D4NFilterObject::set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattr
           delattrs->erase(std::find(delattrs->begin(), delattrs->end(), attr));
         }
       }
-
-      if (auto ret = driver->get_cache_driver()->delete_attrs(dpp, head_oid_in_cache, *delattrs, y); ret < 0) {
-        ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): CacheDriver delete_attrs method failed with ret: " << ret << dendl;
-        return ret;
+      if (this->driver->get_policy_driver()->get_cache_policy()->update_refcount_if_key_exists(dpp, head_oid_in_cache, rgw::d4n::REFCOUNT_INCR, y)) {
+        auto ret = driver->get_cache_driver()->delete_attrs(dpp, head_oid_in_cache, *delattrs, y);
+        this->driver->get_policy_driver()->get_cache_policy()->update_refcount_if_key_exists(dpp, head_oid_in_cache, rgw::d4n::REFCOUNT_DECR, y);
+        if (ret < 0) {
+          ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): CacheDriver delete_attrs method failed with ret: " << ret << dendl;
+          return ret;
+        }
+      } else {
+        found_in_cache = false;
       }
     } //if delattrs != nullptr
   } else {
@@ -375,7 +388,9 @@ int D4NFilterObject::set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattr
       ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): object " << this->get_name() << " does not exist." << dendl;
       return -ENOENT;
     }
+  }
 
+  if (!found_in_cache) {
     auto ret = next->set_obj_attrs(dpp, setattrs, delattrs, y, flags);
     if (ret < 0) {
       ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): set_obj_attrs method of backend store failed with ret: " << ret << dendl;
@@ -572,7 +587,7 @@ int D4NFilterObject::create_delete_marker(const DoutPrefixProvider* dpp, optiona
     ret = driver->get_cache_driver()->put(dpp, oid_in_cache, bl, 0, attrs, y);
     if (ret == 0) {
       ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << "(): version stored in update method is: " << version << dendl;
-      driver->get_policy_driver()->get_cache_policy()->update(dpp, key, 0, bl.length(), version, true, y);
+      driver->get_policy_driver()->get_cache_policy()->update(dpp, key, 0, bl.length(), version, true, rgw::d4n::REFCOUNT_NOOP, y);
       std::vector<std::string> exec_responses;
       ret = this->set_head_obj_dir_entry(dpp, &exec_responses , y, true, true);
       if (exec_responses.empty()) {
@@ -588,7 +603,7 @@ int D4NFilterObject::create_delete_marker(const DoutPrefixProvider* dpp, optiona
       auto creationTime = ceph::real_clock::to_time_t(this->get_mtime());
       ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): key=" << key << dendl;
       std::string objEtag = "";
-      driver->get_policy_driver()->get_cache_policy()->update_dirty_object(dpp, key, version, true, this->get_accounted_size(), creationTime, std::get<rgw_user>(this->get_bucket()->get_owner()), objEtag, this->get_bucket()->get_name(), this->get_bucket()->get_bucket_id(), this->get_key(), y);
+      driver->get_policy_driver()->get_cache_policy()->update_dirty_object(dpp, key, version, true, this->get_accounted_size(), creationTime, std::get<rgw_user>(this->get_bucket()->get_owner()), objEtag, this->get_bucket()->get_name(), this->get_bucket()->get_bucket_id(), this->get_key(), rgw::d4n::REFCOUNT_NOOP, y);
     } else { //if get_cache_driver()->put()
       ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): put failed for oid_in_cache, ret=" << ret << " oid_in_cache: " << oid_in_cache << dendl;
       return ret;
@@ -927,21 +942,25 @@ bool D4NFilterObject::check_head_exists_in_cache_get_oid(const DoutPrefixProvide
     //for distributed cache-the blockHostsList can be used to determine if the head block resides on the localhost, then get the block from localhost, whether or not the block is dirty
     //can be determined using the block entry.
 
-    //uniform name for versioned and non-versioned objects, since input for versioned objects might not contain version
-    ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): Is block dirty: " << block.cacheObj.dirty << dendl;
-    ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): version: " << block.version << dendl;
-    head_oid_in_cache = get_cache_block_prefix(this, version, block.cacheObj.dirty);
-    ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): Fetching attrs from cache for head obj id: " << head_oid_in_cache << dendl;
-    auto ret = this->driver->get_cache_driver()->get_attrs(dpp, head_oid_in_cache, attrs, y);
-    if (ret < 0) {
+    std::string key = get_cache_block_prefix(this, version, false);
+    if (this->driver->get_policy_driver()->get_cache_policy()->update_refcount_if_key_exists(dpp, key, rgw::d4n::REFCOUNT_INCR, y)) {
+      ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): Is block dirty: " << block.cacheObj.dirty << dendl;
+      ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): version: " << block.version << dendl;
+      head_oid_in_cache = get_cache_block_prefix(this, version, block.cacheObj.dirty);
+      ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): Fetching attrs from cache for head obj id: " << head_oid_in_cache << dendl;
+      auto ret = this->driver->get_cache_driver()->get_attrs(dpp, head_oid_in_cache, attrs, y);
+      if (ret < 0) {
+        found_in_cache = false;
+        ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): CacheDriver get_attrs method failed." << dendl;
+      }
+      std::string key = head_oid_in_cache;
+      if (block.cacheObj.dirty) {
+        key = key.erase(0, 2); // Remove dirty prefix
+      }
+      this->driver->get_policy_driver()->get_cache_policy()->update(dpp, key, 0, 0, version, block.cacheObj.dirty, rgw::d4n::REFCOUNT_DECR, y);
+    } else {
       found_in_cache = false;
-      ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): CacheDriver get_attrs method failed." << dendl;
     }
-    std::string key = head_oid_in_cache;
-    if (block.cacheObj.dirty) {
-      key = key.erase(0, 2); // Remove dirty prefix
-    }
-    this->driver->get_policy_driver()->get_cache_policy()->update(dpp, key, 0, 0, version, block.cacheObj.dirty, y);
   } else if (ret == -ENOENT) { //if blockDir->get
     found_in_cache = false;
   } else {
@@ -993,7 +1012,7 @@ int D4NFilterObject::get_obj_attrs(optional_yield y, const DoutPrefixProvider* d
     }
     std::string objName = this->get_name();
     head_oid_in_cache = get_cache_block_prefix(this, version, false);
-    if (this->driver->get_policy_driver()->get_cache_policy()->exist_key(head_oid_in_cache) > 0) {
+    if (this->driver->get_policy_driver()->get_cache_policy()->update_refcount_if_key_exists(dpp, head_oid_in_cache, rgw::d4n::REFCOUNT_INCR, y)) {
       ret = this->driver->get_cache_driver()->set_attrs(dpp, head_oid_in_cache, attrs, y);
     } else {
       ret = this->driver->get_policy_driver()->get_cache_policy()->eviction(dpp, attrs.size(), y);
@@ -1006,12 +1025,13 @@ int D4NFilterObject::get_obj_attrs(optional_yield y, const DoutPrefixProvider* d
     }
     if (ret == 0) {
       ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " version stored in update method is: " << this->get_object_version() << dendl;
-      this->driver->get_policy_driver()->get_cache_policy()->update(dpp, head_oid_in_cache, 0, 0, version, false, y);
+      this->driver->get_policy_driver()->get_cache_policy()->update(dpp, head_oid_in_cache, 0, 0, version, false, rgw::d4n::REFCOUNT_DECR, y);
       ret = set_head_obj_dir_entry(dpp, nullptr, y, is_latest_version);
       if (ret < 0) {
         ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object, ret=" << ret << dendl;
       }
     } else {
+      this->driver->get_policy_driver()->get_cache_policy()->update_refcount_if_key_exists(dpp, head_oid_in_cache, rgw::d4n::REFCOUNT_DECR, y);
       ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): failed to cache head object in cache backend, ret=" << ret << dendl;
     }
   } else {
@@ -1059,7 +1079,9 @@ int D4NFilterObject::delete_obj_attrs(const DoutPrefixProvider* dpp, const char*
   rgw::sal::Attrs attrs;
   Attrs delattr;
   rgw::d4n::CacheBlock block;
+  bool found_in_cache = false;
   if (check_head_exists_in_cache_get_oid(dpp, head_oid_in_cache, attrs, block, y)) {
+    found_in_cache = true;
     delattr.insert({attr_name, bl});
     Attrs currentattrs = this->get_attrs();
     rgw::sal::Attrs::iterator attr = delattr.begin();
@@ -1067,10 +1089,15 @@ int D4NFilterObject::delete_obj_attrs(const DoutPrefixProvider* dpp, const char*
     /* Ensure delAttr exists */
     if (std::find_if(currentattrs.begin(), currentattrs.end(),
         [&](const auto& pair) { return pair.first == attr->first; }) != currentattrs.end()) {
-
-      if (auto ret = driver->get_cache_driver()->delete_attrs(dpp, head_oid_in_cache, delattr, y); ret < 0) {
-        ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): CacheDriver delete_attrs method failed with ret: " << ret << dendl;
-        return ret;
+      if (this->driver->get_policy_driver()->get_cache_policy()->update_refcount_if_key_exists(dpp, head_oid_in_cache, rgw::d4n::REFCOUNT_INCR, y)) {
+        auto ret = driver->get_cache_driver()->delete_attrs(dpp, head_oid_in_cache, delattr, y);
+        this->driver->get_policy_driver()->get_cache_policy()->update_refcount_if_key_exists(dpp, head_oid_in_cache, rgw::d4n::REFCOUNT_DECR, y);
+        if ( ret < 0) {
+          ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): CacheDriver delete_attrs method failed with ret: " << ret << dendl;
+          return ret;
+        }
+      } else {
+        found_in_cache = false;
       }
     }
   } else {
@@ -1078,7 +1105,8 @@ int D4NFilterObject::delete_obj_attrs(const DoutPrefixProvider* dpp, const char*
       ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): object " << this->get_name() << " does not exist." << dendl;
       return -ENOENT;
     }
-
+  }
+  if (!found_in_cache) {
     if (auto ret = next->delete_obj_attrs(dpp, attr_name, y); ret < 0) {
       ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): delete_obj_attrs method of backend store failed with ret: " << ret << dendl;
       return ret;
@@ -1169,7 +1197,7 @@ int D4NFilterObject::D4NFilterReadOp::prepare(optional_yield y, const DoutPrefix
       ret = source->driver->get_cache_driver()->put(dpp, head_oid_in_cache, bl, 0, attrs, y);
       if (ret == 0) {
         ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " version stored in update method is: " << this->source->get_object_version() << dendl;
-        source->driver->get_policy_driver()->get_cache_policy()->update(dpp, head_oid_in_cache, 0, bl.length(), version, false, y);
+        source->driver->get_policy_driver()->get_cache_policy()->update(dpp, head_oid_in_cache, 0, bl.length(), version, false, rgw::d4n::REFCOUNT_NOOP, y);
         ret = source->set_head_obj_dir_entry(dpp, nullptr, y, is_latest_version);
         if (ret < 0) {
           ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object, ret=" << ret << dendl;
@@ -1256,6 +1284,15 @@ void D4NFilterObject::D4NFilterReadOp::cancel() {
 int D4NFilterObject::D4NFilterReadOp::drain(const DoutPrefixProvider* dpp, optional_yield y) {
   auto c = aio->drain();
   int r = flush(dpp, std::move(c), y);
+  std::string version = source->get_object_version();
+  std::string prefix = source->get_prefix();
+  for (auto it : blocks_info) {
+    std::pair<uint64_t, uint64_t> ofs_len_pair = it.second;
+    uint64_t ofs = ofs_len_pair.first;
+    uint64_t len = ofs_len_pair.second;
+    std::string oid_in_cache = prefix + CACHE_DELIM + std::to_string(ofs) + CACHE_DELIM + std::to_string(len);
+    source->driver->get_policy_driver()->get_cache_policy()->update_refcount_if_key_exists(dpp, oid_in_cache, rgw::d4n::REFCOUNT_DECR, y);
+  }
   if (r < 0) {
     cancel();
     return r;
@@ -1315,7 +1352,8 @@ int D4NFilterObject::D4NFilterReadOp::flush(const DoutPrefixProvider* dpp, rgw::
 
       ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " calling update for offset: " << offset << " adjusted offset: " << ofs  << " length: " << len << " oid_in_cache: " << oid_in_cache << dendl;
       ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " version stored in update method is: " << version << " " << source->get_object_version() << dendl;
-      source->driver->get_policy_driver()->get_cache_policy()->update(dpp, oid_in_cache, ofs, len, version, dirty, y);
+      source->driver->get_policy_driver()->get_cache_policy()->update(dpp, oid_in_cache, ofs, len, version, dirty, rgw::d4n::REFCOUNT_DECR, y);
+      blocks_info.erase(it);
       if (source->dest_object && source->dest_bucket) {
         D4NFilterObject* d4n_dest_object = dynamic_cast<D4NFilterObject*>(source->dest_object);
         std::string dest_version = d4n_dest_object->get_object_version();
@@ -1337,7 +1375,7 @@ int D4NFilterObject::D4NFilterReadOp::flush(const DoutPrefixProvider* dpp, rgw::
           ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " destination object version in update method is: " << dest_version << dendl;
           ret = source->driver->get_cache_driver()->put(dpp, dest_oid_in_cache, bl, bl.length(), attrs, y);
           if (ret == 0) {
-            source->driver->get_policy_driver()->get_cache_policy()->update(dpp, key, ofs, bl.length(), dest_version, true, y);
+            source->driver->get_policy_driver()->get_cache_policy()->update(dpp, key, ofs, bl.length(), dest_version, true, rgw::d4n::REFCOUNT_NOOP, y);
           }
           if (ret = source->driver->get_block_dir()->set(dpp, &dest_block, y); ret < 0){
             ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " BlockDirectory set failed with ret: " << ret << dendl;
@@ -1346,7 +1384,6 @@ int D4NFilterObject::D4NFilterReadOp::flush(const DoutPrefixProvider* dpp, rgw::
           ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " eviction returned ret: " << ret << dendl;
         }
       }
-      blocks_info.erase(it);
     } else {
       ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << " offset not found: " << offset << dendl;
     }
@@ -1448,7 +1485,7 @@ int D4NFilterObject::D4NFilterReadOp::iterate(const DoutPrefixProvider* dpp, int
           ldpp_dout(dpp, 20) << "D4NFilterObject::iterate:: " << __func__ << "(): " << __LINE__ << ": READ FROM CACHE: key=" << key << dendl;
 
     if (block.version == version) {
-      if (source->driver->get_policy_driver()->get_cache_policy()->exist_key(oid_in_cache) > 0) {
+      if (source->driver->get_policy_driver()->get_cache_policy()->update_refcount_if_key_exists(dpp, oid_in_cache, rgw::d4n::REFCOUNT_INCR, y) > 0) {
         // Read From Cache
         auto completed = source->driver->get_cache_driver()->get_async(dpp, y, aio.get(), key, read_ofs, len_to_read, cost, id);
 
@@ -1530,7 +1567,7 @@ int D4NFilterObject::D4NFilterReadOp::iterate(const DoutPrefixProvider* dpp, int
         ldpp_dout(dpp, 20) << "D4NFilterObject::iterate:: " << __func__ << "(): READ FROM CACHE: oid=" << oid_in_cache <<
           " length to read is: " << len_to_read << " part num: " << start_part_num << " read_ofs: " << read_ofs << " part len: " << part_len << dendl;
 
-        if ((part_len != chunk_size) && source->driver->get_policy_driver()->get_cache_policy()->exist_key(oid_in_cache) > 0) {
+        if ((part_len != chunk_size) && source->driver->get_policy_driver()->get_cache_policy()->update_refcount_if_key_exists(dpp, oid_in_cache, rgw::d4n::REFCOUNT_INCR, y) > 0) {
           // Read From Cache
           if (block.cacheObj.dirty == true){
       key = DIRTY_BLOCK_PREFIX + oid_in_cache;
@@ -1768,7 +1805,7 @@ int D4NFilterObject::D4NFilterReadOp::D4NFilterGetCB::handle_data(bufferlist& bl
           ret = filter->get_cache_driver()->put(dpp, oid, bl, bl.length(), attrs, *y);
           if (ret == 0) {
   	    std::string objEtag = "";
- 	    filter->get_policy_driver()->get_cache_policy()->update(dpp, oid, adjusted_start_ofs, bl.length(), version, dirty, *y);
+ 	    filter->get_policy_driver()->get_cache_policy()->update(dpp, oid, adjusted_start_ofs, bl.length(), version, dirty, rgw::d4n::REFCOUNT_NOOP, *y);
 
 	    /* Store block in directory */
 	    existing_block.blockID = block.blockID;
@@ -1802,7 +1839,7 @@ int D4NFilterObject::D4NFilterReadOp::D4NFilterGetCB::handle_data(bufferlist& bl
         if (ret == 0) {
           ret = filter->get_cache_driver()->put(dpp, dest_oid, bl, bl.length(), attrs, *y);
           if (ret == 0) {
-            filter->get_policy_driver()->get_cache_policy()->update(dpp, dest_oid, adjusted_start_ofs, bl.length(), dest_version, dirty, *y);
+            filter->get_policy_driver()->get_cache_policy()->update(dpp, dest_oid, adjusted_start_ofs, bl.length(), dest_version, dirty, rgw::d4n::REFCOUNT_NOOP, *y);
             if (ret = blockDir->set(dpp, &dest_block, *y); ret < 0) {
               ldpp_dout(dpp, 20) << "D4N Filter: " << __func__ << " BlockDirectory set failed with ret: " << ret << dendl;
             }
@@ -1818,7 +1855,7 @@ int D4NFilterObject::D4NFilterReadOp::D4NFilterGetCB::handle_data(bufferlist& bl
         if (ret == 0) {
           ret = filter->get_cache_driver()->put(dpp, oid, bl, bl.length(), attrs, *y);
           if (ret == 0) {
-            filter->get_policy_driver()->get_cache_policy()->update(dpp, oid, adjusted_start_ofs, bl.length(), version, dirty, *y);
+            filter->get_policy_driver()->get_cache_policy()->update(dpp, oid, adjusted_start_ofs, bl.length(), version, dirty, rgw::d4n::REFCOUNT_NOOP, *y);
 
             /* Store block in directory */
 	    existing_block.blockID = block.blockID;
@@ -1852,7 +1889,7 @@ int D4NFilterObject::D4NFilterReadOp::D4NFilterGetCB::handle_data(bufferlist& bl
         if (ret == 0) {
           ret = filter->get_cache_driver()->put(dpp, dest_oid, bl, bl.length(), attrs, *y);
           if (ret == 0) {
-            filter->get_policy_driver()->get_cache_policy()->update(dpp, dest_oid, adjusted_start_ofs, bl.length(), dest_version, dirty, *y);
+            filter->get_policy_driver()->get_cache_policy()->update(dpp, dest_oid, adjusted_start_ofs, bl.length(), dest_version, dirty, rgw::d4n::REFCOUNT_NOOP, *y);
             if (ret = blockDir->set(dpp, &dest_block, *y); ret < 0) {
               ldpp_dout(dpp, 20) << "D4N Filter: " << __func__ << " BlockDirectory set failed with ret: " << ret << dendl;
             }
@@ -1878,7 +1915,7 @@ int D4NFilterObject::D4NFilterReadOp::D4NFilterGetCB::handle_data(bufferlist& bl
           if (ret == 0) {
             ret = filter->get_cache_driver()->put(dpp, oid, bl_rem, bl_rem.length(), attrs, *y);
             if (ret == 0) {
-              filter->get_policy_driver()->get_cache_policy()->update(dpp, oid, adjusted_start_ofs, bl_rem.length(), version, dirty, *y);
+              filter->get_policy_driver()->get_cache_policy()->update(dpp, oid, adjusted_start_ofs, bl_rem.length(), version, dirty, rgw::d4n::REFCOUNT_NOOP, *y);
 
               /* Store block in directory */
 	      existing_block.blockID = block.blockID;
@@ -1915,7 +1952,7 @@ int D4NFilterObject::D4NFilterReadOp::D4NFilterGetCB::handle_data(bufferlist& bl
           if (ret == 0) {
             ret = filter->get_cache_driver()->put(dpp, dest_oid, bl_rem, bl_rem.length(), attrs, *y);
             if (ret == 0) {
-              filter->get_policy_driver()->get_cache_policy()->update(dpp, dest_oid, adjusted_start_ofs, bl_rem.length(), dest_version, dirty, *y);
+              filter->get_policy_driver()->get_cache_policy()->update(dpp, dest_oid, adjusted_start_ofs, bl_rem.length(), dest_version, dirty, rgw::d4n::REFCOUNT_NOOP, *y);
               if (ret = blockDir->set(dpp, &dest_block, *y); ret < 0) {
                 ldpp_dout(dpp, 20) << "D4N Filter: " << __func__ << " BlockDirectory set failed with ret: " << ret << dendl;
               }
@@ -2338,7 +2375,7 @@ int D4NFilterWriter::process(bufferlist&& data, uint64_t offset)
           ret = driver->get_cache_driver()->put(dpp, key, bl, bl.length(), attrs, y);
           if (ret == 0) {
             ldpp_dout(dpp, 10) << "D4NFilterWriter::" << __func__ << "(): oid_in_cache is: " << oid_in_cache << dendl;
- 	    driver->get_policy_driver()->get_cache_policy()->update(dpp, oid_in_cache, ofs, bl.length(), version, dirty, y);
+ 	    driver->get_policy_driver()->get_cache_policy()->update(dpp, oid_in_cache, ofs, bl.length(), version, dirty, rgw::d4n::REFCOUNT_NOOP, y);
           } else {
             ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): ERROR: writting data to the cache failed, ret=" << ret << dendl;
 	    return ret;
@@ -2491,7 +2528,7 @@ int D4NFilterWriter::complete(size_t accounted_size, const std::string& etag,
     object->set_object_version(version);
     if (ret == 0) {
       ldpp_dout(dpp, 20) << "D4NFilterWriter::" << __func__ << "(): version stored in update method is: " << version << dendl;
-      driver->get_policy_driver()->get_cache_policy()->update(dpp, key, 0, bl.length(), version, dirty, y);
+      driver->get_policy_driver()->get_cache_policy()->update(dpp, key, 0, bl.length(), version, dirty, rgw::d4n::REFCOUNT_NOOP, y);
       ret = object->set_head_obj_dir_entry(dpp, nullptr, y, true, dirty);
       if (ret < 0) {
         ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): BlockDirectory set method failed for head object, ret=" << ret << dendl;
@@ -2501,7 +2538,7 @@ int D4NFilterWriter::complete(size_t accounted_size, const std::string& etag,
         auto creationTime = ceph::real_clock::to_time_t(object->get_mtime());
         ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): key=" << key << dendl;
         ldpp_dout(dpp, 20) << "D4NFilterWriter::" << __func__ << "(): obj->get_key()=" << obj->get_key() << dendl;
-        driver->get_policy_driver()->get_cache_policy()->update_dirty_object(dpp, key, version, false, accounted_size, creationTime, std::get<rgw_user>(obj->get_bucket()->get_owner()), objEtag, obj->get_bucket()->get_name(), obj->get_bucket()->get_bucket_id(), obj->get_key(), y);
+        driver->get_policy_driver()->get_cache_policy()->update_dirty_object(dpp, key, version, false, accounted_size, creationTime, std::get<rgw_user>(obj->get_bucket()->get_owner()), objEtag, obj->get_bucket()->get_name(), obj->get_bucket()->get_bucket_id(), obj->get_key(), rgw::d4n::REFCOUNT_NOOP, y);
       }
     } else { //if get_cache_driver()->put()
       ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): put failed for head_oid_in_cache, ret=" << ret << dendl;
@@ -2559,7 +2596,7 @@ int D4NFilterMultipartUpload::complete(const DoutPrefixProvider *dpp,
     ret = driver->get_cache_driver()->put(dpp, head_oid_in_cache, bl, 0, attrs, y);
     if (ret == 0) {
       ldpp_dout(dpp, 20) << "D4NFilterMultipartUpload::" << __func__ << " version stored in update method is: " << d4n_target_obj->get_object_version() << dendl;
-      driver->get_policy_driver()->get_cache_policy()->update(dpp, head_oid_in_cache, 0, bl.length(), version, false, y);
+      driver->get_policy_driver()->get_cache_policy()->update(dpp, head_oid_in_cache, 0, bl.length(), version, false, rgw::d4n::REFCOUNT_NOOP, y);
       ret = d4n_target_obj->set_head_obj_dir_entry(dpp, nullptr, y, true);
       if (ret < 0) {
         ldpp_dout(dpp, 0) << "D4NFilterMultipartUpload::" << __func__ << "(): BlockDirectory set method failed for head object, ret=" << ret << dendl;

--- a/src/rgw/driver/d4n/rgw_sal_d4n.cc
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.cc
@@ -316,13 +316,13 @@ int D4NFilterObject::copy_object(const ACLOwner& owner,
       bufferlist bl;
       driver->get_policy_driver()->get_cache_policy()->update(dpp, key, 0, bl.length(), dest_version, dirty, y);
       d4n_dest_object->set_object_version(dest_version);
-      ret = d4n_dest_object->set_head_obj_dir_entry(dpp, y, true, dirty);
+      ret = d4n_dest_object->set_head_obj_dir_entry(dpp, nullptr, y, true, dirty);
       if (ret < 0) {
         ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object with ret: " << ret << dendl;
         return ret;
       }
       if (dirty) {
-        driver->get_policy_driver()->get_cache_policy()->update_dirty_object(dpp, key, dest_version, true, this->get_size(), creationTime, std::get<rgw_user>(dest_object->get_bucket()->get_owner()), *etag, dest_object->get_bucket()->get_name(), dest_object->get_bucket()->get_bucket_id(), dest_object->get_key(), y);
+        driver->get_policy_driver()->get_cache_policy()->update_dirty_object(dpp, key, dest_version, false, this->get_size(), creationTime, std::get<rgw_user>(dest_object->get_bucket()->get_owner()), *etag, dest_object->get_bucket()->get_name(), dest_object->get_bucket()->get_bucket_id(), dest_object->get_key(), y);
       }
     }
   }
@@ -533,13 +533,82 @@ int D4NFilterObject::calculate_version(const DoutPrefixProvider* dpp, optional_y
   return 0;
 }
 
+//This method creates a delete marker for dirty objects:
+// 1. creates a head block entry in cache driver - so that data can be restored from this when rgw goes down
+// 2. calls set_head_obj_dir_entry to set block entries for a delete marker 
+int D4NFilterObject::create_delete_marker(const DoutPrefixProvider* dpp, optional_yield y)
+{
+  this->delete_marker = true;
+  if (this->get_bucket()->versioned() && !this->get_bucket()->versioning_enabled()) { //if versioning is suspended
+    this->version = "null";
+    this->set_instance("null");
+  } else {
+    enum { OBJ_INSTANCE_LEN = 32 };
+    char buf[OBJ_INSTANCE_LEN + 1];
+    gen_rand_alphanumeric_no_underscore(dpp->get_cct(), buf, OBJ_INSTANCE_LEN);
+    this->version = buf; // using gen_rand_alphanumeric_no_underscore for the time being
+    this->set_instance(version);
+    ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << "(): generating delete marker: " << version << dendl;
+  }
+
+  auto m_time = real_clock::now();
+
+  this->set_mtime(m_time);
+  this->set_accounted_size(0); //setting 0 as this is a delete marker
+  this->set_obj_size(0); // setting 0 as this is a delete marker
+  ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " size is: " << this->get_size() << dendl;
+  rgw::sal::Attrs attrs;
+  this->set_attrs_from_obj_state(dpp, y, attrs);
+  bufferlist bl_val;
+  bl_val.append(std::to_string(this->delete_marker));
+  attrs[RGW_CACHE_ATTR_DELETE_MARKER] = std::move(bl_val);
+  std::string key = get_cache_block_prefix(this, this->version, false);
+  std::string oid_in_cache = DIRTY_BLOCK_PREFIX + key;
+
+  bufferlist bl;
+  ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << "(): key is: " << key << dendl;
+  auto ret = driver->get_policy_driver()->get_cache_policy()->eviction(dpp, attrs.size(), y);
+  if (ret == 0) {
+    ret = driver->get_cache_driver()->put(dpp, oid_in_cache, bl, 0, attrs, y);
+    if (ret == 0) {
+      ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << "(): version stored in update method is: " << version << dendl;
+      driver->get_policy_driver()->get_cache_policy()->update(dpp, key, 0, bl.length(), version, true, y);
+      std::vector<std::string> exec_responses;
+      ret = this->set_head_obj_dir_entry(dpp, &exec_responses , y, true, true);
+      if (exec_responses.empty()) {
+        ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Exec respones are empty, error occured!" << dendl;
+        driver->get_policy_driver()->get_cache_policy()->erase(dpp, key, y);
+        driver->get_cache_driver()->delete_data(dpp, oid_in_cache, y);
+        return -ERR_INTERNAL_ERROR;
+      }
+      if (ret < 0) {
+        ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object, ret=" << ret << dendl;
+        return ret;
+      }
+      auto creationTime = ceph::real_clock::to_time_t(this->get_mtime());
+      ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): key=" << key << dendl;
+      std::string objEtag = "";
+      driver->get_policy_driver()->get_cache_policy()->update_dirty_object(dpp, key, version, true, this->get_accounted_size(), creationTime, std::get<rgw_user>(this->get_bucket()->get_owner()), objEtag, this->get_bucket()->get_name(), this->get_bucket()->get_bucket_id(), this->get_key(), y);
+    } else { //if get_cache_driver()->put()
+      ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): put failed for oid_in_cache, ret=" << ret << " oid_in_cache: " << oid_in_cache << dendl;
+      return ret;
+    }
+  } else {
+    ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): eviction failed for oid_in_cache, ret=" << ret << dendl;
+    return ret;
+  }
+
+  return 0;
+}
+
 //This method maintains adds the following entries:
 //1. A hash entry that maintains the latest version for dirty objects (versioned and non-versioned) and non-versioned clean objects.
 //2. A "null" hash entry that maintains the same version as the latest hash entry - this is used when get/delete requests are received
 // for "null" versions, when bucket is non-versioned.
-//3. The "null" hash entry is overwritten when we have a "null" instance when bucket versioning is suspended
+//3. The "null" hash entry is overwritten when we have a "null" instance when bucket versioning is suspended.
 //4. A versioned hash entry for every version for a version enabled bucket - this helps in get/delete requests with version-id specified
-int D4NFilterObject::set_head_obj_dir_entry(const DoutPrefixProvider* dpp, optional_yield y, bool is_latest_version, bool dirty)
+//5. Redis ordered set to maintain the order of dirty objects added for a version enabled bucket. Even when the bucket is non-versioned, this set maintains a "null" entry
+int D4NFilterObject::set_head_obj_dir_entry(const DoutPrefixProvider* dpp, std::vector<std::string>* exec_responses, optional_yield y, bool is_latest_version, bool dirty)
 {
   ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): object name: " << this->get_name() << " bucket name: " << this->get_bucket()->get_name() << dendl;
   int ret = -1;
@@ -555,6 +624,7 @@ int D4NFilterObject::set_head_obj_dir_entry(const DoutPrefixProvider* dpp, optio
     rgw::d4n::CacheObj object = rgw::d4n::CacheObj{
       .objName = objName,
       .bucketName = this->get_bucket()->get_bucket_id(),
+      .creationTime = std::to_string(ceph::real_clock::to_time_t(this->get_mtime())),
       .dirty = dirty,
       .hostsList = { dpp->get_cct()->_conf->rgw_d4n_l1_datacache_address },
       };
@@ -563,26 +633,26 @@ int D4NFilterObject::set_head_obj_dir_entry(const DoutPrefixProvider* dpp, optio
     block.blockID = 0;
     block.version = this->get_object_version();
     block.size = 0;
+    block.deleteMarker = this->delete_marker;
 
-    rgw::d4n::CacheBlock latest = block;
-    ret = blockDir->get(dpp, &latest, y);
-    if (ret == -ENOENT) {
-      //adding an entry to maintain latest version, to serve simple get requests (without any version)
-      //but not for a clean object that belongs to a versioned bucket, as we will get the latest version from backend store
-      //to simplify delete object (maintaining correct order of versions)
-      if (dirty || (!dirty && !(this->get_bucket()->versioned()))) {
-        //start redis transaction using MULTI, to ensure that both latest and null block are added at the same time.
-        blockDir->multi(dpp, y);
-        //we can explore pipelining to send the two 'HSET' commands together
-        ret = blockDir->set(dpp, &block, y);
-        if (ret < 0) {
-    ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object with ret: " << ret << dendl;
-          blockDir->discard(dpp, y);
-          return ret;
-        }
-        //bucket is non versioned, set a null instance
-        //even when the bucket is non versioned, a get with "null" version-id returns the latest version, similarly
-        //delete-obj with "null" as version-id deletes the latest version
+    //adding an entry to maintain latest version, to serve simple get requests (without any version)
+    //but not for a clean object that belongs to a versioned bucket, as we will get the latest version from backend store
+    //to simplify delete object (maintaining correct order of versions)
+
+    //dirty objects
+    if (dirty) {
+    //start redis transaction using MULTI, to ensure that both latest and null block are added at the same time.
+      blockDir->multi(dpp, y);
+      ret = blockDir->set(dpp, &block, y);
+      if (ret < 0) {
+  ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object with ret: " << ret << dendl;
+        blockDir->discard(dpp, y);
+        return ret;
+      }
+      //bucket is non versioned, set a null instance
+      //even when the bucket is non versioned, a get with "null" version-id returns the latest version, similarly
+      //delete-obj with "null" as version-id deletes the latest version
+      if (!(this->get_bucket()->versioned())) {
         block.cacheObj.objName = "_:null_" + this->get_name();
         ret = blockDir->set(dpp, &block, y);
         if (ret < 0) {
@@ -590,40 +660,49 @@ int D4NFilterObject::set_head_obj_dir_entry(const DoutPrefixProvider* dpp, optio
           blockDir->discard(dpp, y);
           return ret;
         }
-        //execute redis transaction using EXEC
-        std::vector<std::string> responses;
-        ret = blockDir->exec(dpp, responses, y);
-        if (ret < 0) {
-          ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory execute method failed for latest and null head object with ret: " << ret << dendl;
-          return ret;
-        }
       }
-    } else if (ret < 0) {
-      ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory get method failed for head object with ret: " << ret << dendl;
-    } else { //head block is found
-        //for clean objects belonging to versioned buckets we will fetch the latest entry from backend store, hence removing latest head entry
-        //once a bucket transitions to a versioned state
-        if (!dirty && this->get_bucket()->versioned()) {
-          ret = blockDir->del(dpp, &block, y);
-          //Ignore a racing delete that could have deleted the latest block
-          if (ret < 0 && ret != -ENOENT) {
-            ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object with ret: " << ret << dendl;
-          }
-        }
-        //even if the head block is found, overwrite existing values with new version in case of non-versioned bucket, clean objects
-        // and versioned and non-versioned buckets dirty objects
-        if (dirty || (!dirty && !(this->get_bucket()->versioned()))) {
+      std::string object_version;
+      //add an entry to ordered set for both versioned and non versioned bucket
+      if (!this->get_bucket()->versioned() || !this->get_bucket()->versioning_enabled()) {
+        object_version = "null";
+      } else {
+        object_version = this->get_object_version();
+      }
+      auto mtime = this->get_mtime();
+      auto score = ceph::real_clock::to_time_t(mtime);
+      ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): Score of object name: "<< this->get_name() << " version: " << object_version << " is: "  << std::setprecision(std::numeric_limits<double>::max_digits10) << score << ret << dendl;
+      rgw::d4n::ObjectDirectory* objDir = this->driver->get_obj_dir();
+      ret = objDir->zadd(dpp, &object, score, object_version, y, true);
+      if (ret < 0) {
+        ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): Failed to add object to ordered set with error: " << ret << dendl;
+        blockDir->discard(dpp, y);
+        return ret;
+      }
+      //execute redis transaction using EXEC
+      std::vector<std::string> responses;
+      ret = blockDir->exec(dpp, responses, y);
+      if (ret < 0) {
+        ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory execute method failed for latest and null head object with ret: " << ret << dendl;
+        return ret;
+      }
+      if (exec_responses) {
+        *exec_responses = responses;
+      }
+    } else { //for clean/non-dirty objects
+      rgw::d4n::CacheBlock latest = block;
+      ret = blockDir->get(dpp, &latest, y);
+      if (ret == -ENOENT) {
+        if (!(this->get_bucket()->versioned())) {
           //start redis transaction using MULTI, to ensure that both latest and null block are added at the same time.
           blockDir->multi(dpp, y);
+          //we can explore pipelining to send the two 'HSET' commands together
           ret = blockDir->set(dpp, &block, y);
           if (ret < 0) {
-            ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object with ret: " << ret << dendl;
+      ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object with ret: " << ret << dendl;
             blockDir->discard(dpp, y);
             return ret;
           }
           //bucket is non versioned, set a null instance
-          //even when the bucket is non versioned, a get with "null" version-id returns the latest version, similarly
-          //delete-obj with "null" as version-id deletes the latest version
           block.cacheObj.objName = "_:null_" + this->get_name();
           ret = blockDir->set(dpp, &block, y);
           if (ret < 0) {
@@ -638,8 +717,54 @@ int D4NFilterObject::set_head_obj_dir_entry(const DoutPrefixProvider* dpp, optio
             ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory execute method failed for latest and null head object with ret: " << ret << dendl;
             return ret;
           }
-        }//end-if dirty || (!dirty && !(this->get_bucket()->versioned()))
-    }
+          if (exec_responses) {
+            *exec_responses = responses;
+          }
+        }
+      } else if (ret < 0) {
+        ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory get method failed for head object with ret: " << ret << dendl;
+      } else { //head block is found
+        //for clean objects belonging to versioned buckets we will fetch the latest entry from backend store, hence removing latest head entry
+        //once a bucket transitions to a versioned state
+        if (this->get_bucket()->versioned()) {
+          ret = blockDir->del(dpp, &block, y);
+          //Ignore a racing delete that could have deleted the latest block
+          if (ret < 0 && ret != -ENOENT) {
+            ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object with ret: " << ret << dendl;
+          }
+        }
+        //even if the head block is found, overwrite existing values with new version in case of non-versioned bucket, clean objects
+        // and versioned and non-versioned buckets dirty objects
+        if (!(this->get_bucket()->versioned())) {
+          //start redis transaction using MULTI, to ensure that both latest and null block are added at the same time.
+          blockDir->multi(dpp, y);
+          ret = blockDir->set(dpp, &block, y);
+          if (ret < 0) {
+            ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object with ret: " << ret << dendl;
+            blockDir->discard(dpp, y);
+            return ret;
+          }
+          //bucket is non versioned, set a null instance
+          block.cacheObj.objName = "_:null_" + this->get_name();
+          ret = blockDir->set(dpp, &block, y);
+          if (ret < 0) {
+            ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for null head object with ret: " << ret << dendl;
+            blockDir->discard(dpp, y);
+            return ret;
+          }
+          //execute redis transaction using EXEC
+          std::vector<std::string> responses;
+          ret = blockDir->exec(dpp, responses, y);
+          if (ret < 0) {
+            ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory execute method failed for latest and null head object with ret: " << ret << dendl;
+            return ret;
+          }
+          if (exec_responses) {
+            *exec_responses = responses;
+          }
+        }//end-if !(this->get_bucket()->versioned())
+      } //end-if ret = 0
+    } //end-else
   }//end-if latest-version
 
   // An entry corresponding to each instance will be needed to locate the head block
@@ -654,6 +779,7 @@ int D4NFilterObject::set_head_obj_dir_entry(const DoutPrefixProvider* dpp, optio
     rgw::d4n::CacheObj version_object = rgw::d4n::CacheObj{
     .objName = objName,
     .bucketName = this->get_bucket()->get_bucket_id(),
+    .creationTime = std::to_string(ceph::real_clock::to_time_t(this->get_mtime())),
     .dirty = dirty,
     };
 
@@ -880,7 +1006,7 @@ int D4NFilterObject::get_obj_attrs(optional_yield y, const DoutPrefixProvider* d
     if (ret == 0) {
       ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " version stored in update method is: " << this->get_object_version() << dendl;
       this->driver->get_policy_driver()->get_cache_policy()->update(dpp, head_oid_in_cache, 0, 0, version, false, y);
-      ret = set_head_obj_dir_entry(dpp, y, is_latest_version);
+      ret = set_head_obj_dir_entry(dpp, nullptr, y, is_latest_version);
       if (ret < 0) {
         ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object, ret=" << ret << dendl;
       }
@@ -1043,7 +1169,7 @@ int D4NFilterObject::D4NFilterReadOp::prepare(optional_yield y, const DoutPrefix
       if (ret == 0) {
         ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " version stored in update method is: " << this->source->get_object_version() << dendl;
         source->driver->get_policy_driver()->get_cache_policy()->update(dpp, head_oid_in_cache, 0, bl.length(), version, false, y);
-        ret = source->set_head_obj_dir_entry(dpp, y, is_latest_version);
+        ret = source->set_head_obj_dir_entry(dpp, nullptr, y, is_latest_version);
         if (ret < 0) {
           ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object, ret=" << ret << dendl;
         }
@@ -1842,6 +1968,8 @@ int D4NFilterObject::D4NFilterDeleteOp::delete_obj(const DoutPrefixProvider* dpp
   // check_head_exists_in_cache_get_oid also returns false if the head object is in the cache, but is a delete marker.
   // As a result, the below check guarantees the head object is not in the cache.  
   if (!source->check_head_exists_in_cache_get_oid(dpp, head_oid_in_cache, attrs, block, y) && !block.deleteMarker) {
+    //for a dirty object, if the first call is a simple delete after versioning is enabled, the call will go to the backend store and create a dlete marker there
+    //since no object with source->get_name() will be found in the cache (and this is correct)
     ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): head object not found; calling next->delete_obj" << dendl;
     next->params = params;
     ret = next->delete_obj(dpp, y, flags);
@@ -1849,15 +1977,20 @@ int D4NFilterObject::D4NFilterDeleteOp::delete_obj(const DoutPrefixProvider* dpp
     return ret;
   } else {
     bool objDirty = block.cacheObj.dirty;
-    auto blockDir = source->driver->get_block_dir(); 
+    auto blockDir = source->driver->get_block_dir();
+    auto objDir = source->driver->get_obj_dir();
     std::string policy_prefix = head_oid_in_cache;
     std::string version = source->get_object_version();
+
+    //call invalidate_object based on whether the object is dirty(objDirty)
+    //if the object is still dirty and has been marked invalid, then let objDirty be true, else set it to false
+    //remove code that deletes head/data block in this method.
 
     if (objDirty) { // head object dirty flag represents object dirty flag
       policy_prefix.erase(0, 2); // remove "D_" prefix from policy key since the policy keys do not hold this information
     }    
 
-    // Versioned buckets - this will delete the head object indexed by version-id (even null)
+    // Versioned buckets - this will delete the head object indexed by version-id (even null) and latest en
     if (source->get_bucket()->versioned()) {
         //1. clean objects - no latest head entry as latest entry to be retrieved from backend now
         // hence delete only versioned head object
@@ -1876,22 +2009,171 @@ int D4NFilterObject::D4NFilterDeleteOp::delete_obj(const DoutPrefixProvider* dpp
       ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Failed to delete head object in block directory for: " << block.cacheObj.objName << ", ret=" << ret << dendl;
             }
           }
-        } else if (objDirty) { //2. dirty objects - TBD for now
-          if ((ret = blockDir->del(dpp, &block, y)) == 0) { // delete head object
-            if (objDirty) {
-        if ((ret = delete_from_cache_and_policy(dpp, head_oid_in_cache, policy_prefix, y)) < 0) {
-          return ret;
-        }
-            }
-          } else if (ret < 0 && ret != -ENOENT) {
-            ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Failed to delete head object in block directory for: " << block.cacheObj.objName << ", ret=" << ret << dendl;
+        } else if (objDirty) { //2. dirty objects - 1. add delete marker for simple request 2. delete version if given and correctly promote latest version if needed
+          bool transaction_success = false;
+          //add watch on latest entry, as it can be modified by a put or another del
+          rgw::d4n::CacheBlock latest_block = block;
+          latest_block.cacheObj.objName = source->get_name();
+          ret = blockDir->watch(dpp, &latest_block, y);
+          if (ret < 0) {
+            ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Failed to add a watch on: " << latest_block.cacheObj.objName << ", ret=" << ret << dendl;
             return ret;
           }
-        }
+          int retry = 3;
+          while(retry) {
+            retry--;
+            //get latest entry
+            ret = blockDir->get(dpp, &latest_block, y);
+            if (ret < 0) {
+              ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Failed to get latest entry in block directory for: " << latest_block.cacheObj.objName << ", ret=" << ret << dendl;
+              blockDir->unwatch(dpp, y);
+              return ret;
+            }
+            //simple delete request with no version id - create a delete marker
+            if (block.cacheObj.objName == source->get_name()) {
+              //we are checking for latest_block and not block because latest_block has the most updated value of latest hash entry
+              //if existing latest entry is already a delete marker, do not create a new one and simply return
+              if (!latest_block.deleteMarker) {
+                ret = source->create_delete_marker(dpp, y);
+                if (ret < 0) {
+                  ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Failed to create a delete marker for: " << block.cacheObj.objName << ", ret=" << ret << dendl;
+                  //ERR_INTERNAL_ERROR is returned when exec_responses are empty which means the watched key has been modified, hence retry
+                  if (ret == -ERR_INTERNAL_ERROR) {
+                    continue;
+                  } else {
+                    blockDir->unwatch(dpp, y);
+                    return ret;
+                  }
+                }
+                if (ret >= 0) {
+                  result.delete_marker = true;
+                  result.version_id = source->get_instance();
+                  transaction_success = true;
+                  return 0;
+                }
+              }
+              //unwatch the key (latest entry), as it is already a delete marker and we won't do anything
+              ret = blockDir->unwatch(dpp, y);
+              if (ret < 0) {
+                ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Failed to add a watch on: " << latest_block.cacheObj.objName << ", ret=" << ret << dendl;
+                return ret;
+              }
+              transaction_success = true;
+              return 0;
+            } else { //not a simple request, delete version requested
+              //get latest entry ret is 0
+              if (ret == 0) {
+                rgw::d4n::CacheObj dir_obj = rgw::d4n::CacheObj{
+                  .objName = source->get_name(),
+                  .bucketName = source->get_bucket()->get_bucket_id(),
+                };
+                bool startmulti = false;
+                //check if version to be deleted is the same as latest version
+                if (latest_block.version == block.version) {
+                  std::vector<std::string> members;
+                  //get the second latest version
+                  ret = objDir->zrevrange(dpp, &dir_obj, 0, 1, members, y);
+                  if (ret < 0) {
+                    ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Failed to get the second latest version for: " << dir_obj.objName << ", ret=" << ret << dendl;
+                    blockDir->unwatch(dpp, y);
+                    return ret;
+                  }
+                  //if there is a second latest version
+                  if (members.size() == 2) {
+                    rgw::d4n::CacheBlock version_block = latest_block;
+                    version_block.cacheObj.objName = "_:" + members[1] + "_" + source->get_name();
+                    //add watch on the second latest versioned entry also as it might be modified by another del
+                    ret = blockDir->watch(dpp, &version_block, y);
+                    if (ret < 0) {
+                      ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Failed to add a watch on: " << version_block.cacheObj.objName << ", ret=" << ret << dendl;
+                      blockDir->unwatch(dpp, y);
+                      return ret;
+                    }
+                    //get versioned entry
+                    ret = blockDir->get(dpp, &version_block, y);
+                    if (ret < 0) {
+                      ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Failed to get the versioned entry for: " << version_block.cacheObj.objName << ", ret=" << ret << dendl;
+                      blockDir->unwatch(dpp, y);
+                      return 0;
+                    }
+                    //start redis transaction using MULTI
+                    blockDir->multi(dpp, y);
+                    startmulti = true;
+                    //set versioned entry as the latest entry
+                    version_block.cacheObj.objName = latest_block.cacheObj.objName;
+                    ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << "(): INFO: promoting latest version entry to version: " << version_block.version << ", ret=" << ret << dendl;
+                    ret = blockDir->set(dpp, &version_block, y);
+                    if (ret < 0) {
+                      ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Failed to set new latest entry for: " << version_block.cacheObj.objName << ", ret=" << ret << dendl;
+                      blockDir->discard(dpp, y);
+                      return 0;
+                    }
+                  } else { // there are no more versions left
+                    //start redis transaction using MULTI
+                    blockDir->multi(dpp, y);
+                    startmulti = true;
+                    //delete latest block entry
+                    ret = blockDir->del(dpp, &latest_block, y, true);
+                    if (ret < 0) {
+                      ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Failed to delete latest entry in block directory, when it is the same as version requested, for: " << block.cacheObj.objName << ", ret=" << ret << dendl;
+                      blockDir->discard(dpp, y);
+                      return ret;
+                    }
+                  }
+                } //end-if latest_block.version == block.version
+                //delete versioned entry (handles delete markers also)
+                if (!startmulti) {
+                  //start redis transaction using MULTI
+                  blockDir->multi(dpp, y);
+                }
+                if ((ret = blockDir->del(dpp, &block, y, true)) == 0) {
+                  if ((ret = delete_from_cache_and_policy(dpp, head_oid_in_cache, policy_prefix, y)) < 0) {
+                    blockDir->discard(dpp, y);
+                    return ret;
+                  }
+                } else if (ret < 0 && ret != -ENOENT) {
+                  ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Failed to delete head object in block directory for: " << block.cacheObj.objName << ", ret=" << ret << dendl;
+                  blockDir->discard(dpp, y);
+                  return ret;
+                }
+                //delete entry from ordered set
+                std::string version = source->get_object_version();
+                if (!source->get_bucket()->versioning_enabled()) {
+                  version = "null";
+                }
+                ret = objDir->zrem(dpp, &dir_obj, version, y, true);
+                if (ret < 0) {
+                  ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Failed to Queue zrem request in object directory for: " << source->get_name() << ", ret=" << ret << dendl;
+                  blockDir->discard(dpp, y);
+                  return ret;
+                }
+                std::vector<std::string> responses;
+                ret = blockDir->exec(dpp, responses, y);
+                if (responses.empty()) {
+                  ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Execute responses are empty hence continuing!" << dendl;
+                  continue;
+                }
+                if (ret < 0) {
+                  ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Failed to execute exec in block directory: " << "ret= " << ret << dendl;
+                  return ret;
+                }
+                result.delete_marker = block.deleteMarker;
+                result.version_id = version;
+                //success, hence break from loop
+                transaction_success = true;
+                break;
+              }
+            } //end-else (simple request)
+          } //end-while retry
+          if (!transaction_success) {
+            ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Redis transaction failed after retrying! " << dendl;
+            return -ERR_INTERNAL_ERROR;
+          }
+        } //end-if objDirty
     } //end-if versioned buckets
 
     //Non-versioned buckets - we will delete the latest entry and the "null" entry
-    //do we need to add "watch" here on the latest entry?
+    //dirty objects - delete "null" entry from ordered set also
     if (!source->get_bucket()->versioned()) {
       //start redis transaction using MULTI to delete the latest entry and the "null" entry together
       blockDir->multi(dpp, y);
@@ -1914,6 +2196,19 @@ int D4NFilterObject::D4NFilterDeleteOp::delete_obj(const DoutPrefixProvider* dpp
         blockDir->discard(dpp, y);
         return ret;
       }
+      //dirty objects - delete from ordered set
+      if (objDirty) {
+        rgw::d4n::CacheObj dir_obj = rgw::d4n::CacheObj{
+          .objName = source->get_name(),
+          .bucketName = source->get_bucket()->get_bucket_id(),
+        };
+        ret = objDir->zrem(dpp, &dir_obj, "null", y, true);
+        if (ret < 0) {
+          ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Failed to Queue zrem request in object directory for: " << source->get_name() << ", ret=" << ret << dendl;
+          blockDir->discard(dpp, y);
+          return ret;
+        }
+      }
       std::vector<std::string> responses;
       ret = blockDir->exec(dpp, responses, y);
       if (ret < 0) {
@@ -1935,13 +2230,13 @@ int D4NFilterObject::D4NFilterDeleteOp::delete_obj(const DoutPrefixProvider* dpp
       return -EINVAL;
     }
 
-    // delete data blocks, when,
+    // delete data blocks directory entries, when,
     // 1. object is clean, bucket is versioned and there is an instance in the request
     // 2. object is clean, bucket is non-versioned
-    // 3. object is dirty - TBD
+    // 3. object is dirty - delete blocks in cache also except for delete markers
     if ((!objDirty && source->get_bucket()->versioned() && source->have_instance()) ||
         (!objDirty && !source->get_bucket()->versioned()) ||
-        objDirty) {
+        (objDirty && !block.deleteMarker)) {
       off_t lst = std::stoi(size);
       off_t fst = 0;
 
@@ -1959,14 +2254,14 @@ int D4NFilterObject::D4NFilterDeleteOp::delete_obj(const DoutPrefixProvider* dpp
 
         if ((ret = blockDir->get(dpp, &block, y)) < 0) {
     if (ret == -ENOENT) {
-      ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Directory entry for: " << source->get_name() << " blockid: " << fst << " block size: " << cur_len << " does not exist; continuing" << dendl;
+      ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Directory entry for: " << source->get_oid() << " blockid: " << fst << " block size: " << cur_len << " does not exist; continuing" << dendl;
       fst += cur_len;
       if (fst >= lst) {
         break;
       }
       continue;
     } else {
-      ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Failed to retrieve directory entry for: " << source->get_name() << " blockid: " << fst << " block size: " << cur_len << ", ret=" << ret << dendl;
+      ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Failed to retrieve directory entry for: " << source->get_oid() << " blockid: " << fst << " block size: " << cur_len << ", ret=" << ret << dendl;
       return ret;
     }
         }
@@ -2019,14 +2314,19 @@ int D4NFilterWriter::prepare(optional_yield y)
     ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): calling next process" << dendl;
     return next->prepare(y);
   } else {
-    //for non-versioned buckets, we need to delete the older dirty blocks of the object from the cache as dirty blocks do not get evicted
+    //for non-versioned buckets or version suspended buckets, we need to delete the older dirty blocks of the object from the cache as dirty blocks do not get evicted
     //alternatively, we could add logic to delete this lazily
-    if (!object->get_bucket()->versioned()) {
+    if (!object->get_bucket()->versioned() || (object->get_bucket()->versioned() && !object->get_bucket()->versioning_enabled())) {
       std::unique_ptr<rgw::sal::Object::DeleteOp> del_op = object->get_delete_op();
+      if (object->get_bucket()->versioned() && !object->get_bucket()->versioning_enabled()) {
+        del_op->params.null_verid = true;
+        object->set_instance("null");
+      }
       auto ret = del_op->delete_obj(dpp, y, rgw::sal::FLAG_LOG_OP);
       if (ret < 0) {
         ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): delete_obj failed, ret=" << ret << dendl;
       }
+      object->clear_instance();
     }
   }
 
@@ -2172,7 +2472,6 @@ int D4NFilterWriter::complete(size_t accounted_size, const std::string& etag,
 
     dirty = true;
     ceph::real_time m_time;
-    dirty = true;
     if (mtime) {
       if (real_clock::is_zero(*mtime)) {
         *mtime = real_clock::now();
@@ -2233,7 +2532,7 @@ int D4NFilterWriter::complete(size_t accounted_size, const std::string& etag,
     if (ret == 0) {
       ldpp_dout(dpp, 20) << "D4NFilterWriter::" << __func__ << "(): version stored in update method is: " << version << dendl;
       driver->get_policy_driver()->get_cache_policy()->update(dpp, key, 0, bl.length(), version, dirty, y);
-      ret = object->set_head_obj_dir_entry(dpp, y, true, dirty);
+      ret = object->set_head_obj_dir_entry(dpp, nullptr, y, true, dirty);
       if (ret < 0) {
         ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): BlockDirectory set method failed for head object, ret=" << ret << dendl;
         return ret;
@@ -2241,7 +2540,8 @@ int D4NFilterWriter::complete(size_t accounted_size, const std::string& etag,
       if (dirty) {
         auto creationTime = ceph::real_clock::to_time_t(object->get_mtime());
         ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): key=" << key << dendl;
-        driver->get_policy_driver()->get_cache_policy()->update_dirty_object(dpp, key, version, dirty, accounted_size, creationTime, std::get<rgw_user>(obj->get_bucket()->get_owner()), objEtag, obj->get_bucket()->get_name(), obj->get_bucket()->get_bucket_id(), obj->get_key(), y);
+        ldpp_dout(dpp, 20) << "D4NFilterWriter::" << __func__ << "(): obj->get_key()=" << obj->get_key() << dendl;
+        driver->get_policy_driver()->get_cache_policy()->update_dirty_object(dpp, key, version, false, accounted_size, creationTime, std::get<rgw_user>(obj->get_bucket()->get_owner()), objEtag, obj->get_bucket()->get_name(), obj->get_bucket()->get_bucket_id(), obj->get_key(), y);
       }
     } else { //if get_cache_driver()->put()
       ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): put failed for head_oid_in_cache, ret=" << ret << dendl;
@@ -2300,7 +2600,7 @@ int D4NFilterMultipartUpload::complete(const DoutPrefixProvider *dpp,
     if (ret == 0) {
       ldpp_dout(dpp, 20) << "D4NFilterMultipartUpload::" << __func__ << " version stored in update method is: " << d4n_target_obj->get_object_version() << dendl;
       driver->get_policy_driver()->get_cache_policy()->update(dpp, head_oid_in_cache, 0, bl.length(), version, false, y);
-      ret = d4n_target_obj->set_head_obj_dir_entry(dpp, y, true);
+      ret = d4n_target_obj->set_head_obj_dir_entry(dpp, nullptr, y, true);
       if (ret < 0) {
         ldpp_dout(dpp, 0) << "D4NFilterMultipartUpload::" << __func__ << "(): BlockDirectory set method failed for head object, ret=" << ret << dendl;
       }

--- a/src/rgw/driver/d4n/rgw_sal_d4n.cc
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.cc
@@ -537,6 +537,7 @@ int D4NFilterObject::set_head_obj_dir_entry(const DoutPrefixProvider* dpp, optio
   ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): object name: " << this->get_name() << " bucket name: " << this->get_bucket()->get_name() << dendl;
   // entry that contains latest version for versioned and non-versioned objects
   int ret = -1;
+  rgw::d4n::CacheBlock block; 
   rgw::d4n::BlockDirectory* blockDir = this->driver->get_block_dir();
   if (is_latest_version) {
     std::string objName = this->get_name();
@@ -552,12 +553,10 @@ int D4NFilterObject::set_head_obj_dir_entry(const DoutPrefixProvider* dpp, optio
       .hostsList = { dpp->get_cct()->_conf->rgw_d4n_l1_datacache_address },
       };
 
-    rgw::d4n::CacheBlock block = rgw::d4n::CacheBlock{
-      .cacheObj = object,
-      .blockID = 0,
-      .version = this->get_object_version(),
-      .size = 0,
-      };
+    block.cacheObj = object;
+    block.blockID = 0;
+    block.version = this->get_object_version();
+    block.size = 0;
 
     ret = blockDir->get(dpp, &block, y);
     if (ret == -ENOENT) {
@@ -566,7 +565,15 @@ int D4NFilterObject::set_head_obj_dir_entry(const DoutPrefixProvider* dpp, optio
 	ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object with ret: " << ret << dendl;
       }
     } else if (ret == 0) { // head object exists; update instead of overwrite
-      block.prevVersion = {block.version, block.deleteMarker};
+      if (!this->get_bucket()->versioning_enabled() && block.version == "null") { // null delete markers get overwritten but only if versioning is suspended
+	auto tempBlock = block;
+	tempBlock.cacheObj.objName = "_:null_" + block.cacheObj.objName;
+
+	if ((ret = blockDir->del(dpp, &tempBlock, y)) < 0 && ret != -ENOENT) {
+	  ldpp_dout(dpp, 0) << "Failed to delete delete marker block in block directory for: " << block.cacheObj.objName << ", ret=" << ret << dendl;
+	  return ret;
+	}
+      }
       block.version = this->get_object_version();
       block.deleteMarker = false;
       block.cacheObj.dirty = dirty;
@@ -588,8 +595,9 @@ int D4NFilterObject::set_head_obj_dir_entry(const DoutPrefixProvider* dpp, optio
     .objName = this->get_oid(),
     .bucketName = this->get_bucket()->get_bucket_id(),
     .dirty = dirty,
-    .hostsList = { dpp->get_cct()->_conf->rgw_d4n_l1_datacache_address },
     };
+
+    version_object.hostsList.insert({ dpp->get_cct()->_conf->rgw_d4n_l1_datacache_address });
 
     rgw::d4n::CacheBlock version_block = rgw::d4n::CacheBlock{
       .cacheObj = version_object,
@@ -598,25 +606,47 @@ int D4NFilterObject::set_head_obj_dir_entry(const DoutPrefixProvider* dpp, optio
       .size = 0,
     };
 
-    ret = blockDir->get(dpp, &version_block, y);
-    if (ret == -ENOENT) {
-      ret = blockDir->set(dpp, &version_block, y);
-      if (ret < 0) {
-	ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object with ret: " << ret << dendl;
-      }
-    } else if (ret == 0) { // head object exists; update instead of overwrite
-      version_block.prevVersion = {version_block.version, version_block.deleteMarker};
-      version_block.version = this->get_object_version();
-      version_block.deleteMarker = false;
-      version_block.cacheObj.dirty = dirty;
-      version_block.cacheObj.hostsList.insert({ dpp->get_cct()->_conf->rgw_d4n_l1_datacache_address });
+    ret = blockDir->set(dpp, &version_block, y);
+    if (ret < 0) {
+      ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for versioned head object with ret: " << ret << dendl;
+    }
+  } else if (!this->get_bucket()->versioned()) {
+    rgw::d4n::CacheObj null_object = rgw::d4n::CacheObj{
+      .objName = "_:null_" + this->get_name(),
+      .bucketName = this->get_bucket()->get_bucket_id(),
+      .dirty = dirty,
+      .hostsList = { dpp->get_cct()->_conf->rgw_d4n_l1_datacache_address },
+    };
 
-      ret = blockDir->set(dpp, &version_block, y);
-      if (ret < 0) {
-	ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object with ret: " << ret << dendl;
-      }
-    } else {
-      ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory get method failed for head object with ret: " << ret << dendl;
+    rgw::d4n::CacheBlock null_block = rgw::d4n::CacheBlock{
+      .cacheObj = null_object,
+      .blockID = 0,
+      .version = this->get_object_version(),
+      .size = 0,
+    };
+
+    ret = blockDir->set(dpp, &null_block, y);
+    if (ret < 0) {
+      ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for null head object with ret: " << ret << dendl;
+    }
+  } else if (this->get_bucket()->versioned() && !this->get_bucket()->versioning_enabled()) {
+    rgw::d4n::CacheObj null_object = rgw::d4n::CacheObj{
+      .objName = "_:null_" + this->get_name(),
+      .bucketName = this->get_bucket()->get_name(),
+      .dirty = dirty,
+      .hostsList = { dpp->get_cct()->_conf->rgw_d4n_l1_datacache_address },
+    };
+
+    rgw::d4n::CacheBlock null_block = rgw::d4n::CacheBlock{
+      .cacheObj = null_object,
+      .blockID = 0,
+      .version = "null",
+      .size = 0,
+    };
+
+    ret = blockDir->set(dpp, &null_block, y);
+    if (ret < 0) {
+      ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for null head object with ret: " << ret << dendl;
     }
   }
 
@@ -754,8 +784,7 @@ bool D4NFilterObject::check_head_exists_in_cache_get_oid(const DoutPrefixProvide
     }
     std::string key = head_oid_in_cache;
     if (block.cacheObj.dirty) {
-      // Remove dirty prefix
-      key = key.erase(0, 2);
+      key = key.erase(0, 2); // Remove dirty prefix
     }
     this->driver->get_policy_driver()->get_cache_policy()->update(dpp, key, 0, 0, version, block.cacheObj.dirty, y);
   } else if (ret == -ENOENT) { //if blockDir->get
@@ -1753,13 +1782,25 @@ int D4NFilterObject::D4NFilterReadOp::D4NFilterGetCB::handle_data(bufferlist& bl
   return 0;
 }
 
+int D4NFilterObject::D4NFilterDeleteOp::delete_from_cache_and_policy(const DoutPrefixProvider* dpp, std::string oid, 
+								     std::string prefix, optional_yield y)
+{
+  int ret = -1;
+
+  if ((ret = source->driver->get_cache_driver()->delete_data(dpp, oid, y)) == 0) { // Sam: do we want del or delete_data here? 
+    if (!(ret = source->driver->get_policy_driver()->get_cache_policy()->erase(dpp, prefix, y))) {
+      ldpp_dout(dpp, 0) << "Failed to delete head policy entry for: " << source->get_key().get_oid() << ", ret=" << ret << dendl;
+    }
+  } else {
+    ldpp_dout(dpp, 0) << "Failed to delete head object for: " << source->get_key().get_oid() << ", ret=" << ret << dendl;
+  }
+
+  return ret;
+}
+
 int D4NFilterObject::D4NFilterDeleteOp::delete_obj(const DoutPrefixProvider* dpp,
                                                    optional_yield y, uint32_t flags)
 {
-  next->params = params;
-  auto ret = next->delete_obj(dpp, y, flags);
-  result = next->result;
-  return ret;
   // TODO: 
   // 1. Send delete request to cache nodes with remote copies
   // 2. See if we can derive dirty flag from the head block 
@@ -1768,198 +1809,118 @@ int D4NFilterObject::D4NFilterDeleteOp::delete_obj(const DoutPrefixProvider* dpp
   rgw::sal::Attrs attrs;
   std::string head_oid_in_cache;
   rgw::d4n::CacheBlock block;
+  int ret = -1;
+
+  // check_head_exists_in_cache_get_oid also returns false if the head object is in the cache, but is a delete marker.
+  // As a result, the below check guarantees the head object is not in the cache.  
   if (!source->check_head_exists_in_cache_get_oid(dpp, head_oid_in_cache, attrs, block, y) && !block.deleteMarker) {
-    ldpp_dout(dpp, 0) << "D4NFilterObject::D4NFilterDeleteOp::" << __func__ << "(): calling next delete_obj" << dendl;
-    return next->delete_obj(dpp, y, flags);
+    ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): head object not found; calling next->delete_obj" << dendl;
+    next->params = params;
+    ret = next->delete_obj(dpp, y, flags);
+    result = next->result;
+    return ret;
   } else {
-    int ret = -1;
-    bool objDirty = false;
+    bool objDirty = block.cacheObj.dirty;
     auto blockDir = source->driver->get_block_dir(); 
-    std::string version, policy_prefix;
+    std::string policy_prefix = head_oid_in_cache;
+    std::string version = source->get_object_version();
 
-    if (!source->get_bucket()->versioned()) {
-      version = source->get_object_version();
-    } else if (source->get_bucket()->versioned() && !source->have_instance()) {
-      rgw::d4n::CacheBlock deleteBlock;
-      block.prevVersion = std::pair<std::string, bool>(block.version, block.deleteMarker);
-      block.deleteMarker = true;
-
-      if (source->get_bucket()->versioned() && !source->get_bucket()->versioning_enabled()) { // if versioning is suspended
-        block.version = "null"; 
-      } else {
-	// create a delete marker
-	enum { OBJ_INSTANCE_LEN = 32 };
-	char buf[OBJ_INSTANCE_LEN + 1];
-	gen_rand_alphanumeric_no_underscore(dpp->get_cct(), buf, OBJ_INSTANCE_LEN);
-        block.version = buf; // using gen_rand_alphanumeric_no_underscore for the time being
-      } 
-      
-      deleteBlock = block;
-      deleteBlock.cacheObj.objName = "_:" + deleteBlock.version + "_" + deleteBlock.cacheObj.objName; // since the request has no instance,
-												      // the oid does not contain the version
-
-      if ((ret = blockDir->set(dpp, &deleteBlock, y)) == 0) {
-	if ((ret = blockDir->set(dpp, &block, y)) < 0) {
-	  ldpp_dout(dpp, 0) << "Failed to set head object in block directory for: " << source->get_key().get_oid() << ", ret=" << ret << dendl;
-	  return ret;
-	}
-      } else {
-	ldpp_dout(dpp, 0) << "Failed to set delete marker block in block directory for: " << source->get_key().get_oid() << ", ret=" << ret << dendl;
-	return ret;
-      }
-
-      return 0;
-    } else {
-      version = source->get_instance();
-    }
-
-    policy_prefix = head_oid_in_cache;
-    if (block.cacheObj.dirty) { // head object dirty flag represents object dirty flag
-      objDirty = true;
-      policy_prefix.erase(0, 2); // remove "D_" prefix from policy key
+    if (objDirty) { // head object dirty flag represents object dirty flag
+      policy_prefix.erase(0, 2); // remove "D_" prefix from policy key since the policy keys do not hold this information
     }    
 
-    if (block.deleteMarker == false) { // provided version is not a delete marker and contains data
-      if (source->get_bucket()->versioned()) { 
-	if (blockDir->del(dpp, &block, y) == 0) { // delete versioned head object
-	  if ((ret = source->driver->get_cache_driver()->delete_data(dpp, head_oid_in_cache, y)) == 0) { // Sam: do we want del or delete_data here? 
-	    if (!(ret = source->driver->get_policy_driver()->get_cache_policy()->erase(dpp, policy_prefix, y))) {
-	      ldpp_dout(dpp, 0) << "Failed to delete head policy entry for: " << source->get_key().get_oid() << ", ret=" << ret << dendl;
-	      return ret;
-	    }
-	  } else {
-	    ldpp_dout(dpp, 0) << "Failed to delete head object for: " << source->get_key().get_oid() << ", ret=" << ret << dendl;
-	    return ret;
-	  }
-        } else {
-	  ldpp_dout(dpp, 0) << "Failed to delete versioned head object in block directory for: " << source->get_key().get_oid() << ", ret=" << ret << dendl;
+    if ((ret = blockDir->del(dpp, &block, y)) == 0) { // delete head object
+      if (objDirty) {
+	if ((ret = delete_from_cache_and_policy(dpp, head_oid_in_cache, policy_prefix, y)) < 0) {
 	  return ret;
 	}
+      }
+    } else if (ret < 0 && ret != -ENOENT) {
+      ldpp_dout(dpp, 0) << "Failed to delete head object in block directory for: " << source->get_key().get_oid() << ", ret=" << ret << dendl;
+      return ret;
+    }
+    
+    if (!source->get_bucket()->versioned()) {
+      std::string name = block.cacheObj.objName;
+      block.cacheObj.objName = "_:null_" + source->get_key().get_oid();
+      if ((ret = blockDir->del(dpp, &block, y)) < 0) { // delete null head object
+	ldpp_dout(dpp, 0) << "Failed to delete head object in block directory for: " << source->get_key().get_oid() << ", ret=" << ret << dendl;
+	return ret;
+      }
+      block.cacheObj.objName = name;
+    }
 
-	auto headObj = block;
-	headObj.cacheObj.objName = source->get_name();
-	ret = blockDir->get(dpp, &headObj, y); // retrieve head object
-	if (!block.prevVersion && ret == 0 && headObj.version == version) { // if the latest version matches the provided version and there are no 
-									    // previous versions left, this is the last version of the object
-	  ldpp_dout(dpp, 10) << "D4NFilterObject::D4NFilterDeleteOp::" << __func__ << "(): No previous version found; deleting head object" << dendl;
+    std::string size;
+    if (attrs.find(RGW_CACHE_ATTR_OBJECT_SIZE) != attrs.end()) {
+      size = attrs.find(RGW_CACHE_ATTR_OBJECT_SIZE)->second.to_str();
+    } else {
+      ldpp_dout(dpp, 0) << "Failed to retrieve size for for: " << block.cacheObj.objName << ", ret=" << ret << dendl;
+      return -EINVAL;
+    }
+    off_t lst = std::stoi(size);
+    off_t fst = 0;
 
-	  if ((ret = blockDir->del(dpp, &headObj, y)) < 0) { // delete head object
-	    ldpp_dout(dpp, 0) << "Failed to delete head object in block directory for: " << source->get_key().get_oid() << ", ret=" << ret << dendl;
-	    return ret;
+    do { // loop through the data blocks
+      std::string prefix = get_cache_block_prefix(source, version, false);
+      if (fst >= lst) {
+	break;
+      }
+
+      off_t cur_size = std::min<off_t>(fst + dpp->get_cct()->_conf->rgw_max_chunk_size, lst);
+      off_t cur_len = cur_size - fst;
+      block.blockID = static_cast<uint64_t>(fst);
+      block.size = static_cast<uint64_t>(cur_len);
+
+      if ((ret = blockDir->get(dpp, &block, y)) < 0) {
+	if (ret == -ENOENT) {
+	  ldpp_dout(dpp, 0) << "Directory entry for: " << source->get_name() << " blockid: " << fst << " block size: " << cur_len << " does not exist; continuing" << dendl;
+	  fst += cur_len;
+	  if (fst >= lst) {
+	    break;
 	  }
-	} else if (ret == 0 && headObj.version == version) { // provided version is current version to be deleted; make previous version the current version 
-	  headObj.version = headObj.prevVersion->first;
-	  headObj.deleteMarker = headObj.prevVersion->second;
-          headObj.prevVersion = block.prevVersion;
-	} else if (ret < 0) {
-	  ldpp_dout(dpp, 0) << "Failed to retrieve head object directory entry for: " << block.cacheObj.objName << ", ret=" << ret << dendl;
-	  return ret;
-	}
-      } else {
-	if ((ret = blockDir->del(dpp, &block, y)) == 0) { // delete head object
-	  if ((ret = source->driver->get_cache_driver()->delete_data(dpp, head_oid_in_cache, y)) == 0) { // Sam: do we want del or delete_data here? 
-	    if (!(ret = source->driver->get_policy_driver()->get_cache_policy()->erase(dpp, policy_prefix, y))) {
-	      ldpp_dout(dpp, 0) << "Failed to delete head policy entry for: " << source->get_key().get_oid() << ", ret=" << ret << dendl;
-	      return ret;
-	    }
-	  } else {
-	    ldpp_dout(dpp, 0) << "Failed to delete head object for: " << source->get_key().get_oid() << ", ret=" << ret << dendl;
-	    return ret;
-	  }
+	  continue;
 	} else {
-	  ldpp_dout(dpp, 0) << "Failed to delete head object in block directory for: " << source->get_key().get_oid() << ", ret=" << ret << dendl;
-	  return ret;
-	}
-      }
-      std::string size;
-      if (attrs.find(RGW_CACHE_ATTR_OBJECT_SIZE) != attrs.end()) {
-	size = attrs.find(RGW_CACHE_ATTR_OBJECT_SIZE)->second.to_str();
-      } else {
-	ldpp_dout(dpp, 0) << "Failed to retrieve size for for: " << block.cacheObj.objName << ", ret=" << ret << dendl;
-        return -EINVAL;
-      }
-      off_t lst = std::stoi(size);
-      off_t fst = 0;
-
-      do {
-  std::string prefix = get_cache_block_prefix(source, version, false);
-	if (fst >= lst) {
-	  break;
-	}
-
-	off_t cur_size = std::min<off_t>(fst + dpp->get_cct()->_conf->rgw_max_chunk_size, lst);
-	off_t cur_len = cur_size - fst;
-	block.blockID = static_cast<uint64_t>(fst);
-	block.size = static_cast<uint64_t>(cur_len);
-
-	if ((ret = blockDir->get(dpp, &block, y)) < 0) {
 	  ldpp_dout(dpp, 0) << "Failed to retrieve directory entry for: " << source->get_name() << " blockid: " << fst << " block size: " << cur_len << ", ret=" << ret << dendl;
 	  return ret;
 	}
+      }
 
-	if (block.cacheObj.dirty)
-	  prefix = DIRTY_BLOCK_PREFIX + prefix;
-
+      if ((ret = blockDir->del(dpp, &block, y)) == 0) { 
+	prefix = DIRTY_BLOCK_PREFIX + prefix;
 	std::string oid_in_cache = prefix + CACHE_DELIM + std::to_string(fst) + CACHE_DELIM + std::to_string(cur_len);
 
-	if ((ret = blockDir->del(dpp, &block, y)) == 0) { 
-	  if ((ret = source->driver->get_cache_driver()->delete_data(dpp, oid_in_cache, y)) == 0) { // Sam: do we want del or delete_data here? 
-      std::string key = policy_prefix + CACHE_DELIM + std::to_string(fst) + CACHE_DELIM + std::to_string(cur_len);
-	    if (!(ret = source->driver->get_policy_driver()->get_cache_policy()->erase(dpp, key, y))) {
-	      ldpp_dout(dpp, 0) << "Failed to delete policy entry for: " << source->get_name() << " blockID: " << fst << " block size: " << cur_len << ", ret=" << ret << dendl;
-	      return ret;
-	    }
-	  } else {
-	    ldpp_dout(dpp, 0) << "Failed to delete existing block for: " << source->get_name() << " blockID: " << fst << " block size: " << cur_len << ", ret=" << ret << dendl;
+	if (objDirty) {
+	  std::string key = policy_prefix + CACHE_DELIM + std::to_string(fst) + CACHE_DELIM + std::to_string(cur_len);
+	  if ((ret = delete_from_cache_and_policy(dpp, oid_in_cache, key, y)) < 0) {
+	    ldpp_dout(dpp, 0) << "ERROR for block " << source->get_name() << " blockID: " << fst << " block size: " << cur_len << ", ret=" << ret << dendl;
 	    return ret;
 	  }
-	} else if (ret == -ENOENT) {
-	  continue;
-	} else {
-	  ldpp_dout(dpp, 0) << "Failed to delete directory entry for: " << source->get_name() << " blockid: " << fst << " block size: " << cur_len << ", ret=" << ret << dendl;
-	  return ret;
 	}
-
-	fst += cur_len;
-      } while (fst < lst);
-
-      if (!objDirty) { // object written to backend  
-	return next->delete_obj(dpp, y, flags);
+      } else if (ret == -ENOENT) {
+	continue;
       } else {
-        std::string key = policy_prefix;
-	if (!(ret = source->driver->get_policy_driver()->get_cache_policy()->erase_dirty_object(dpp, key, y))) {
-	  ldpp_dout(dpp, 0) << "Failed to delete policy object entry for: " << source->get_name() << ", ret=" << ret << dendl;
-	  return -ENOENT;
-        } else {
-          return 0;
-        }
-      }
-    } else { // provided version is a delete marker; remove delete marker block
-      rgw::d4n::CacheBlock deleteBlock;
-      deleteBlock = block;
-      block.cacheObj.objName = source->get_name();
-
-      if (block.version == "null") 
-	deleteBlock.cacheObj.objName = "_:" + deleteBlock.version + "_" + deleteBlock.cacheObj.objName;
-      
-      if (block.prevVersion) { // move previous version to current version and update for head object
-        block.version = block.prevVersion->first;
-        block.deleteMarker = block.prevVersion->second;
-        block.prevVersion = {};
-      }
-
-      if ((ret = blockDir->del(dpp, &deleteBlock, y)) == 0) {
-	if ((ret = blockDir->set(dpp, &block, y)) < 0) {
-	  ldpp_dout(dpp, 0) << "Failed to set head object in block directory for: " << block.cacheObj.objName << ", ret=" << ret << dendl;
-	  return ret;
-        }
-      } else {
-	ldpp_dout(dpp, 0) << "Failed to delete delete marker block in block directory for: " << block.cacheObj.objName << ", ret=" << ret << dendl;
+	ldpp_dout(dpp, 0) << "Failed to delete directory entry for: " << source->get_name() << " blockid: " << fst << " block size: " << cur_len << ", ret=" << ret << dendl;
 	return ret;
       }
-    }
 
-    return 0;
+      fst += cur_len;
+    } while (fst < lst);
+
+    std::string key = policy_prefix;
+    if (!objDirty) {
+      next->params = params;
+      ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): object is not dirty; calling next->delete_obj" << dendl;
+      ret = next->delete_obj(dpp, y, flags);
+      result = next->result;
+      return ret;
+    } else {
+      if (!(ret = source->driver->get_policy_driver()->get_cache_policy()->erase_dirty_object(dpp, key, y))) {
+	ldpp_dout(dpp, 0) << "Failed to delete policy object entry for: " << source->get_name() << ", ret=" << ret << dendl;
+	return -ENOENT;
+      } else {
+	return 0;
+      }
+    }
   }
 }
 

--- a/src/rgw/driver/d4n/rgw_sal_d4n.cc
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.cc
@@ -513,9 +513,10 @@ void D4NFilterObject::set_attrs_from_obj_state(const DoutPrefixProvider* dpp, op
 int D4NFilterObject::calculate_version(const DoutPrefixProvider* dpp, optional_yield y, std::string& version)
 {
   //versioned objects have instance set to versionId, and get_oid() returns oid containing instance, hence using id tag as version for non versioned objects only
+  ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): object name: " << this->get_name() << " instance: " << this->have_instance() << dendl;
   if (! this->have_instance() && version.empty()) {
     bufferlist bl;
-     if (this->get_attr(RGW_ATTR_ID_TAG, bl)) {
+    if (this->get_attr(RGW_ATTR_ID_TAG, bl)) {
       version = bl.c_str();
       ldpp_dout(dpp, 20) << __func__ << " id tag version is: " << version << dendl;
     } else {
@@ -532,10 +533,15 @@ int D4NFilterObject::calculate_version(const DoutPrefixProvider* dpp, optional_y
   return 0;
 }
 
+//This method maintains adds the following entries:
+//1. A hash entry that maintains the latest version for dirty objects (versioned and non-versioned) and non-versioned clean objects.
+//2. A "null" hash entry that maintains the same version as the latest hash entry - this is used when get/delete requests are received
+// for "null" versions, when bucket is non-versioned.
+//3. The "null" hash entry is overwritten when we have a "null" instance when bucket versioning is suspended
+//4. A versioned hash entry for every version for a version enabled bucket - this helps in get/delete requests with version-id specified
 int D4NFilterObject::set_head_obj_dir_entry(const DoutPrefixProvider* dpp, optional_yield y, bool is_latest_version, bool dirty)
 {
   ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): object name: " << this->get_name() << " bucket name: " << this->get_bucket()->get_name() << dendl;
-  // entry that contains latest version for versioned and non-versioned objects
   int ret = -1;
   rgw::d4n::CacheBlock block; 
   rgw::d4n::BlockDirectory* blockDir = this->driver->get_block_dir();
@@ -558,41 +564,71 @@ int D4NFilterObject::set_head_obj_dir_entry(const DoutPrefixProvider* dpp, optio
     block.version = this->get_object_version();
     block.size = 0;
 
-    ret = blockDir->get(dpp, &block, y);
+    rgw::d4n::CacheBlock latest = block;
+    ret = blockDir->get(dpp, &latest, y);
     if (ret == -ENOENT) {
-      ret = blockDir->set(dpp, &block, y);
-      if (ret < 0) {
-	ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object with ret: " << ret << dendl;
+      //adding an entry to maintain latest version, to serve simple get requests (without any version)
+      //but not for a clean object that belongs to a versioned bucket, as we will get the latest version from backend store
+      //to simplify delete object (maintaining correct order of versions)
+      if (dirty || (!dirty && !(this->get_bucket()->versioned()))) {
+        ret = blockDir->set(dpp, &block, y);
+        if (ret < 0) {
+    ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object with ret: " << ret << dendl;
+          return ret;
+        }
+        //bucket is non versioned, set a null instance
+        //even when the bucket is non versioned, a get with "null" version-id returns the latest version, similarly
+        //delete-obj with "null" as version-id deletes the latest version
+        block.cacheObj.objName = "_:null_" + this->get_name();
+        ret = blockDir->set(dpp, &block, y);
+        if (ret < 0) {
+          ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for null head object with ret: " << ret << dendl;
+          return ret;
+        }
       }
-    } else if (ret == 0) { // head object exists; update instead of overwrite
-      if (!this->get_bucket()->versioning_enabled() && block.version == "null") { // null delete markers get overwritten but only if versioning is suspended
-	auto tempBlock = block;
-	tempBlock.cacheObj.objName = "_:null_" + block.cacheObj.objName;
-
-	if ((ret = blockDir->del(dpp, &tempBlock, y)) < 0 && ret != -ENOENT) {
-	  ldpp_dout(dpp, 0) << "Failed to delete delete marker block in block directory for: " << block.cacheObj.objName << ", ret=" << ret << dendl;
-	  return ret;
-	}
-      }
-      block.version = this->get_object_version();
-      block.deleteMarker = false;
-      block.cacheObj.dirty = dirty;
-      block.cacheObj.hostsList.insert({ dpp->get_cct()->_conf->rgw_d4n_l1_datacache_address });
-
-      ret = blockDir->set(dpp, &block, y);
-      if (ret < 0) {
-	ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object with ret: " << ret << dendl;
-      }
-    } else {
+    } else if (ret < 0) {
       ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory get method failed for head object with ret: " << ret << dendl;
+    } else { //head block is found
+        //for clean objects belonging to versioned buckets we will fetch the latest entry from backend store, hence removing latest head entry
+        //once a bucket transitions to a versioned state
+        if (!dirty && this->get_bucket()->versioned()) {
+          ret = blockDir->del(dpp, &block, y);
+          if (ret < 0) {
+            ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object with ret: " << ret << dendl;
+          }
+        }
+        //even if the head block is found, overwrite existing values with new version in case of non-versioned bucket, clean objects
+        // and versioned and non-versioned buckets dirty objects
+        if (dirty || (!dirty && !(this->get_bucket()->versioned()))) {
+          ret = blockDir->set(dpp, &block, y);
+          if (ret < 0) {
+            ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object with ret: " << ret << dendl;
+            return ret;
+          }
+          //bucket is non versioned, set a null instance
+          //even when the bucket is non versioned, a get with "null" version-id returns the latest version, similarly
+          //delete-obj with "null" as version-id deletes the latest version
+          block.cacheObj.objName = "_:null_" + this->get_name();
+          ret = blockDir->set(dpp, &block, y);
+          if (ret < 0) {
+            ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for null head object with ret: " << ret << dendl;
+            return ret;
+          }
+        }//end-if dirty || (!dirty && !(this->get_bucket()->versioned()))
     }
-  }
+  }//end-if latest-version
 
-  // In case of a distributed cache - an entry corresponding to each instance will be needed to locate the head block
+  // An entry corresponding to each instance will be needed to locate the head block
   // this will also be needed for deleting an object from a version enabled bucket.
-  if (this->have_instance()) {
+  if (this->get_bucket()->versioned()) {
+    std::string objName = this->get_oid();
+    // for null version, creating a "null" block specifically to differentiate between the latest entry and the null entry
+    // since oid does not take "null" into account
+    if (this->get_instance() == "null" || !this->get_bucket()->versioning_enabled()) {
+      objName = "_:null_" + this->get_name();
+    }
     rgw::d4n::CacheObj version_object = rgw::d4n::CacheObj{
-    .objName = this->get_oid(),
+    .objName = objName,
     .bucketName = this->get_bucket()->get_bucket_id(),
     .dirty = dirty,
     };
@@ -610,45 +646,7 @@ int D4NFilterObject::set_head_obj_dir_entry(const DoutPrefixProvider* dpp, optio
     if (ret < 0) {
       ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for versioned head object with ret: " << ret << dendl;
     }
-  } else if (!this->get_bucket()->versioned()) {
-    rgw::d4n::CacheObj null_object = rgw::d4n::CacheObj{
-      .objName = "_:null_" + this->get_name(),
-      .bucketName = this->get_bucket()->get_bucket_id(),
-      .dirty = dirty,
-      .hostsList = { dpp->get_cct()->_conf->rgw_d4n_l1_datacache_address },
-    };
-
-    rgw::d4n::CacheBlock null_block = rgw::d4n::CacheBlock{
-      .cacheObj = null_object,
-      .blockID = 0,
-      .version = this->get_object_version(),
-      .size = 0,
-    };
-
-    ret = blockDir->set(dpp, &null_block, y);
-    if (ret < 0) {
-      ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for null head object with ret: " << ret << dendl;
-    }
-  } else if (this->get_bucket()->versioned() && !this->get_bucket()->versioning_enabled()) {
-    rgw::d4n::CacheObj null_object = rgw::d4n::CacheObj{
-      .objName = "_:null_" + this->get_name(),
-      .bucketName = this->get_bucket()->get_name(),
-      .dirty = dirty,
-      .hostsList = { dpp->get_cct()->_conf->rgw_d4n_l1_datacache_address },
-    };
-
-    rgw::d4n::CacheBlock null_block = rgw::d4n::CacheBlock{
-      .cacheObj = null_object,
-      .blockID = 0,
-      .version = "null",
-      .size = 0,
-    };
-
-    ret = blockDir->set(dpp, &null_block, y);
-    if (ret < 0) {
-      ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for null head object with ret: " << ret << dendl;
-    }
-  }
+  }//end-if get_bucket_versioned()
 
   return ret;
 }
@@ -745,10 +743,15 @@ int D4NFilterObject::delete_data_block_cache_entries(const DoutPrefixProvider* d
 
 bool D4NFilterObject::check_head_exists_in_cache_get_oid(const DoutPrefixProvider* dpp, std::string& head_oid_in_cache, rgw::sal::Attrs& attrs, rgw::d4n::CacheBlock& blk, optional_yield y)
 {
-  ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << "(): this->get_oid(): " << this->get_oid() << dendl;
   rgw::d4n::BlockDirectory* blockDir = this->driver->get_block_dir();
+  std::string objName = this->get_oid();
+  //object oid does not contain "null" in case the instance is "null", so explicitly populating that
+  if (this->have_instance() && this->get_instance() == "null") {
+    objName = "_:null_" + this->get_name();
+  }
+  ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << "(): objName: " << objName << dendl;
   rgw::d4n::CacheObj object = rgw::d4n::CacheObj{
-        .objName = this->get_oid(), //version-enabled buckets will not have version for latest version, so this will work even when version is not provided in input
+        .objName = objName, //version-enabled buckets will not have version for latest version, so this will work even when version is not provided in input
         .bucketName = this->get_bucket()->get_bucket_id(),
         };
 
@@ -775,6 +778,7 @@ bool D4NFilterObject::check_head_exists_in_cache_get_oid(const DoutPrefixProvide
 
     //uniform name for versioned and non-versioned objects, since input for versioned objects might not contain version
     ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): Is block dirty: " << block.cacheObj.dirty << dendl;
+    ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): version: " << block.version << dendl;
     head_oid_in_cache = get_cache_block_prefix(this, version, block.cacheObj.dirty);
     ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): Fetching attrs from cache for head obj id: " << head_oid_in_cache << dendl;
     auto ret = this->driver->get_cache_driver()->get_attrs(dpp, head_oid_in_cache, attrs, y);
@@ -824,7 +828,7 @@ int D4NFilterObject::get_obj_attrs(optional_yield y, const DoutPrefixProvider* d
     }
   
     this->load_obj_state(dpp, y);
-    this->obj = this->get_obj();
+    this->obj = *target_obj;
     if (!this->obj.key.instance.empty()) {
       this->set_instance(this->obj.key.instance);
     }
@@ -1829,26 +1833,62 @@ int D4NFilterObject::D4NFilterDeleteOp::delete_obj(const DoutPrefixProvider* dpp
       policy_prefix.erase(0, 2); // remove "D_" prefix from policy key since the policy keys do not hold this information
     }    
 
-    if ((ret = blockDir->del(dpp, &block, y)) == 0) { // delete head object
-      if (objDirty) {
-	if ((ret = delete_from_cache_and_policy(dpp, head_oid_in_cache, policy_prefix, y)) < 0) {
-	  return ret;
-	}
-      }
-    } else if (ret < 0 && ret != -ENOENT) {
-      ldpp_dout(dpp, 0) << "Failed to delete head object in block directory for: " << source->get_key().get_oid() << ", ret=" << ret << dendl;
+    // Versioned buckets - this will delete the head object indexed by version-id (even null)
+    if (source->get_bucket()->versioned()) {
+        //1. clean objects - no latest head entry as latest entry to be retrieved from backend now
+        // hence delete only versioned head object
+        if (!objDirty) {
+          if (source->have_instance()) {
+            if ((ret = blockDir->del(dpp, &block, y)) < 0) {
+              ldpp_dout(dpp, 0) << "Failed to delete head object in block directory for: " << block.cacheObj.objName << ", ret=" << ret << dendl; 
+              return ret;
+            }
+          }
+          // if versioning is suspended, we might have a latest head entry created from when bucket was non-versioned
+          // don't return error as that could already be deleted by set_head_obj_dir_entry
+          if (!source->get_bucket()->versioning_enabled()) {
+            block.cacheObj.objName = source->get_name();
+            if ((ret = blockDir->del(dpp, &block, y)) < 0) {
+      ldpp_dout(dpp, 0) << "Failed to delete head object in block directory for: " << block.cacheObj.objName << ", ret=" << ret << dendl;
+            }
+          }
+        } else if (objDirty) { //2. dirty objects - TBD for now
+          if ((ret = blockDir->del(dpp, &block, y)) == 0) { // delete head object
+            if (objDirty) {
+        if ((ret = delete_from_cache_and_policy(dpp, head_oid_in_cache, policy_prefix, y)) < 0) {
+          return ret;
+        }
+            }
+          } else if (ret < 0 && ret != -ENOENT) {
+            ldpp_dout(dpp, 0) << "Failed to delete head object in block directory for: " << block.cacheObj.objName << ", ret=" << ret << dendl;
+            return ret;
+          }
+        }
+    } //end-if versioned buckets
+
+    //Non-versioned buckets - we will delete the latest entry and the "null" entry
+    if (!source->get_bucket()->versioned()) {
+      if ((ret = blockDir->del(dpp, &block, y)) == 0) {
+        if (objDirty) {
+    if ((ret = delete_from_cache_and_policy(dpp, head_oid_in_cache, policy_prefix, y)) < 0) {
       return ret;
     }
-    
-    if (!source->get_bucket()->versioned()) {
-      std::string name = block.cacheObj.objName;
-      block.cacheObj.objName = "_:null_" + source->get_key().get_oid();
-      if ((ret = blockDir->del(dpp, &block, y)) < 0) { // delete null head object
-	ldpp_dout(dpp, 0) << "Failed to delete head object in block directory for: " << source->get_key().get_oid() << ", ret=" << ret << dendl;
-	return ret;
+        }
+      } else if (ret < 0 && ret != -ENOENT) {
+        ldpp_dout(dpp, 0) << "Failed to delete head object in block directory for: " << block.cacheObj.objName << ", ret=" << ret << dendl;
+        return ret;
       }
-      block.cacheObj.objName = name;
-    }
+      //if we get request for latest head entry, delete the null block and vice versa
+      if (block.cacheObj.objName == source->get_name()) {
+        block.cacheObj.objName = "_:null_" + source->get_name();
+      } else {
+        block.cacheObj.objName = source->get_name();
+      }
+      if ((ret = blockDir->del(dpp, &block, y)) < 0) {
+	ldpp_dout(dpp, 0) << "Failed to delete head object in block directory for: " << block.cacheObj.objName << ", ret=" << ret << dendl;
+        return ret;
+      }
+    } //end-if non-versioned buckets
 
     std::string size;
     if (attrs.find(RGW_CACHE_ATTR_OBJECT_SIZE) != attrs.end()) {
@@ -1857,54 +1897,64 @@ int D4NFilterObject::D4NFilterDeleteOp::delete_obj(const DoutPrefixProvider* dpp
       ldpp_dout(dpp, 0) << "Failed to retrieve size for for: " << block.cacheObj.objName << ", ret=" << ret << dendl;
       return -EINVAL;
     }
-    off_t lst = std::stoi(size);
-    off_t fst = 0;
 
-    do { // loop through the data blocks
-      std::string prefix = get_cache_block_prefix(source, version, false);
-      if (fst >= lst) {
-	break;
-      }
+    // delete data blocks, when,
+    // 1. object is clean, bucket is versioned and there is an instance in the request
+    // 2. object is clean, bucket is non-versioned
+    // 3. object is dirty - TBD
+    if ((!objDirty && source->get_bucket()->versioned() && source->have_instance()) ||
+        (!objDirty && !source->get_bucket()->versioned()) ||
+        objDirty) {
+      off_t lst = std::stoi(size);
+      off_t fst = 0;
 
-      off_t cur_size = std::min<off_t>(fst + dpp->get_cct()->_conf->rgw_max_chunk_size, lst);
-      off_t cur_len = cur_size - fst;
-      block.blockID = static_cast<uint64_t>(fst);
-      block.size = static_cast<uint64_t>(cur_len);
+      do { // loop through the data blocks
+        std::string prefix = get_cache_block_prefix(source, version, false);
+        if (fst >= lst) {
+    break;
+        }
+        //data blocks have cacheObj.objName set to oid always
+        block.cacheObj.objName = source->get_oid();
+        off_t cur_size = std::min<off_t>(fst + dpp->get_cct()->_conf->rgw_max_chunk_size, lst);
+        off_t cur_len = cur_size - fst;
+        block.blockID = static_cast<uint64_t>(fst);
+        block.size = static_cast<uint64_t>(cur_len);
 
-      if ((ret = blockDir->get(dpp, &block, y)) < 0) {
-	if (ret == -ENOENT) {
-	  ldpp_dout(dpp, 0) << "Directory entry for: " << source->get_name() << " blockid: " << fst << " block size: " << cur_len << " does not exist; continuing" << dendl;
-	  fst += cur_len;
-	  if (fst >= lst) {
-	    break;
-	  }
-	  continue;
-	} else {
-	  ldpp_dout(dpp, 0) << "Failed to retrieve directory entry for: " << source->get_name() << " blockid: " << fst << " block size: " << cur_len << ", ret=" << ret << dendl;
-	  return ret;
-	}
-      }
-
-      if ((ret = blockDir->del(dpp, &block, y)) == 0) { 
-	prefix = DIRTY_BLOCK_PREFIX + prefix;
-	std::string oid_in_cache = prefix + CACHE_DELIM + std::to_string(fst) + CACHE_DELIM + std::to_string(cur_len);
-
-	if (objDirty) {
-	  std::string key = policy_prefix + CACHE_DELIM + std::to_string(fst) + CACHE_DELIM + std::to_string(cur_len);
-	  if ((ret = delete_from_cache_and_policy(dpp, oid_in_cache, key, y)) < 0) {
-	    ldpp_dout(dpp, 0) << "ERROR for block " << source->get_name() << " blockID: " << fst << " block size: " << cur_len << ", ret=" << ret << dendl;
-	    return ret;
-	  }
-	}
-      } else if (ret == -ENOENT) {
-	continue;
-      } else {
-	ldpp_dout(dpp, 0) << "Failed to delete directory entry for: " << source->get_name() << " blockid: " << fst << " block size: " << cur_len << ", ret=" << ret << dendl;
-	return ret;
-      }
-
+        if ((ret = blockDir->get(dpp, &block, y)) < 0) {
+    if (ret == -ENOENT) {
+      ldpp_dout(dpp, 0) << "Directory entry for: " << source->get_name() << " blockid: " << fst << " block size: " << cur_len << " does not exist; continuing" << dendl;
       fst += cur_len;
-    } while (fst < lst);
+      if (fst >= lst) {
+        break;
+      }
+      continue;
+    } else {
+      ldpp_dout(dpp, 0) << "Failed to retrieve directory entry for: " << source->get_name() << " blockid: " << fst << " block size: " << cur_len << ", ret=" << ret << dendl;
+      return ret;
+    }
+        }
+
+        if ((ret = blockDir->del(dpp, &block, y)) == 0) { 
+    prefix = DIRTY_BLOCK_PREFIX + prefix;
+    std::string oid_in_cache = prefix + CACHE_DELIM + std::to_string(fst) + CACHE_DELIM + std::to_string(cur_len);
+
+    if (objDirty) {
+      std::string key = policy_prefix + CACHE_DELIM + std::to_string(fst) + CACHE_DELIM + std::to_string(cur_len);
+      if ((ret = delete_from_cache_and_policy(dpp, oid_in_cache, key, y)) < 0) {
+        ldpp_dout(dpp, 0) << "ERROR for block " << source->get_name() << " blockID: " << fst << " block size: " << cur_len << ", ret=" << ret << dendl;
+        return ret;
+      }
+    }
+        } else if (ret == -ENOENT) {
+    continue;
+        } else {
+    ldpp_dout(dpp, 0) << "Failed to delete directory entry for: " << source->get_name() << " blockid: " << fst << " block size: " << cur_len << ", ret=" << ret << dendl;
+    return ret;
+        }
+
+        fst += cur_len;
+      } while (fst < lst);
+    }
 
     std::string key = policy_prefix;
     if (!objDirty) {

--- a/src/rgw/driver/d4n/rgw_sal_d4n.cc
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.cc
@@ -571,9 +571,13 @@ int D4NFilterObject::set_head_obj_dir_entry(const DoutPrefixProvider* dpp, optio
       //but not for a clean object that belongs to a versioned bucket, as we will get the latest version from backend store
       //to simplify delete object (maintaining correct order of versions)
       if (dirty || (!dirty && !(this->get_bucket()->versioned()))) {
+        //start redis transaction using MULTI, to ensure that both latest and null block are added at the same time.
+        blockDir->multi(dpp, y);
+        //we can explore pipelining to send the two 'HSET' commands together
         ret = blockDir->set(dpp, &block, y);
         if (ret < 0) {
     ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object with ret: " << ret << dendl;
+          blockDir->discard(dpp, y);
           return ret;
         }
         //bucket is non versioned, set a null instance
@@ -583,6 +587,14 @@ int D4NFilterObject::set_head_obj_dir_entry(const DoutPrefixProvider* dpp, optio
         ret = blockDir->set(dpp, &block, y);
         if (ret < 0) {
           ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for null head object with ret: " << ret << dendl;
+          blockDir->discard(dpp, y);
+          return ret;
+        }
+        //execute redis transaction using EXEC
+        std::vector<std::string> responses;
+        ret = blockDir->exec(dpp, responses, y);
+        if (ret < 0) {
+          ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory execute method failed for latest and null head object with ret: " << ret << dendl;
           return ret;
         }
       }
@@ -593,16 +605,20 @@ int D4NFilterObject::set_head_obj_dir_entry(const DoutPrefixProvider* dpp, optio
         //once a bucket transitions to a versioned state
         if (!dirty && this->get_bucket()->versioned()) {
           ret = blockDir->del(dpp, &block, y);
-          if (ret < 0) {
+          //Ignore a racing delete that could have deleted the latest block
+          if (ret < 0 && ret != -ENOENT) {
             ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object with ret: " << ret << dendl;
           }
         }
         //even if the head block is found, overwrite existing values with new version in case of non-versioned bucket, clean objects
         // and versioned and non-versioned buckets dirty objects
         if (dirty || (!dirty && !(this->get_bucket()->versioned()))) {
+          //start redis transaction using MULTI, to ensure that both latest and null block are added at the same time.
+          blockDir->multi(dpp, y);
           ret = blockDir->set(dpp, &block, y);
           if (ret < 0) {
             ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object with ret: " << ret << dendl;
+            blockDir->discard(dpp, y);
             return ret;
           }
           //bucket is non versioned, set a null instance
@@ -612,6 +628,14 @@ int D4NFilterObject::set_head_obj_dir_entry(const DoutPrefixProvider* dpp, optio
           ret = blockDir->set(dpp, &block, y);
           if (ret < 0) {
             ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for null head object with ret: " << ret << dendl;
+            blockDir->discard(dpp, y);
+            return ret;
+          }
+          //execute redis transaction using EXEC
+          std::vector<std::string> responses;
+          ret = blockDir->exec(dpp, responses, y);
+          if (ret < 0) {
+            ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory execute method failed for latest and null head object with ret: " << ret << dendl;
             return ret;
           }
         }//end-if dirty || (!dirty && !(this->get_bucket()->versioned()))
@@ -1840,7 +1864,7 @@ int D4NFilterObject::D4NFilterDeleteOp::delete_obj(const DoutPrefixProvider* dpp
         if (!objDirty) {
           if (source->have_instance()) {
             if ((ret = blockDir->del(dpp, &block, y)) < 0) {
-              ldpp_dout(dpp, 0) << "Failed to delete head object in block directory for: " << block.cacheObj.objName << ", ret=" << ret << dendl; 
+              ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Failed to delete head object in block directory for: " << block.cacheObj.objName << ", ret=" << ret << dendl; 
               return ret;
             }
           }
@@ -1849,7 +1873,7 @@ int D4NFilterObject::D4NFilterDeleteOp::delete_obj(const DoutPrefixProvider* dpp
           if (!source->get_bucket()->versioning_enabled()) {
             block.cacheObj.objName = source->get_name();
             if ((ret = blockDir->del(dpp, &block, y)) < 0) {
-      ldpp_dout(dpp, 0) << "Failed to delete head object in block directory for: " << block.cacheObj.objName << ", ret=" << ret << dendl;
+      ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Failed to delete head object in block directory for: " << block.cacheObj.objName << ", ret=" << ret << dendl;
             }
           }
         } else if (objDirty) { //2. dirty objects - TBD for now
@@ -1860,22 +1884,22 @@ int D4NFilterObject::D4NFilterDeleteOp::delete_obj(const DoutPrefixProvider* dpp
         }
             }
           } else if (ret < 0 && ret != -ENOENT) {
-            ldpp_dout(dpp, 0) << "Failed to delete head object in block directory for: " << block.cacheObj.objName << ", ret=" << ret << dendl;
+            ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Failed to delete head object in block directory for: " << block.cacheObj.objName << ", ret=" << ret << dendl;
             return ret;
           }
         }
     } //end-if versioned buckets
 
     //Non-versioned buckets - we will delete the latest entry and the "null" entry
+    //do we need to add "watch" here on the latest entry?
     if (!source->get_bucket()->versioned()) {
-      if ((ret = blockDir->del(dpp, &block, y)) == 0) {
-        if (objDirty) {
-    if ((ret = delete_from_cache_and_policy(dpp, head_oid_in_cache, policy_prefix, y)) < 0) {
-      return ret;
-    }
-        }
-      } else if (ret < 0 && ret != -ENOENT) {
-        ldpp_dout(dpp, 0) << "Failed to delete head object in block directory for: " << block.cacheObj.objName << ", ret=" << ret << dendl;
+      //start redis transaction using MULTI to delete the latest entry and the "null" entry together
+      blockDir->multi(dpp, y);
+      //explore redis pipelining to send the two 'DEL' commands together in a single request
+      ret = blockDir->del(dpp, &block, y, true);
+      if (ret < 0) {
+        ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Failed to Queue delete head object op in block directory for: " << block.cacheObj.objName << ", ret=" << ret << dendl;
+        blockDir->discard(dpp, y);
         return ret;
       }
       //if we get request for latest head entry, delete the null block and vice versa
@@ -1884,9 +1908,22 @@ int D4NFilterObject::D4NFilterDeleteOp::delete_obj(const DoutPrefixProvider* dpp
       } else {
         block.cacheObj.objName = source->get_name();
       }
-      if ((ret = blockDir->del(dpp, &block, y)) < 0) {
-	ldpp_dout(dpp, 0) << "Failed to delete head object in block directory for: " << block.cacheObj.objName << ", ret=" << ret << dendl;
+      ret = blockDir->del(dpp, &block, y, true);
+      if (ret < 0) {
+        ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Failed to Queue delete head object in block directory for: " << block.cacheObj.objName << ", ret=" << ret << dendl;
+        blockDir->discard(dpp, y);
         return ret;
+      }
+      std::vector<std::string> responses;
+      ret = blockDir->exec(dpp, responses, y);
+      if (ret < 0) {
+        ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Failed to execute exec in block directory: " << "ret= " << ret << dendl;
+        return ret;
+      }
+      if (objDirty) {
+        if ((ret = delete_from_cache_and_policy(dpp, head_oid_in_cache, policy_prefix, y)) < 0) {
+          return ret;
+        }
       }
     } //end-if non-versioned buckets
 
@@ -1894,7 +1931,7 @@ int D4NFilterObject::D4NFilterDeleteOp::delete_obj(const DoutPrefixProvider* dpp
     if (attrs.find(RGW_CACHE_ATTR_OBJECT_SIZE) != attrs.end()) {
       size = attrs.find(RGW_CACHE_ATTR_OBJECT_SIZE)->second.to_str();
     } else {
-      ldpp_dout(dpp, 0) << "Failed to retrieve size for for: " << block.cacheObj.objName << ", ret=" << ret << dendl;
+      ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Failed to retrieve size for for: " << block.cacheObj.objName << ", ret=" << ret << dendl;
       return -EINVAL;
     }
 
@@ -1922,14 +1959,14 @@ int D4NFilterObject::D4NFilterDeleteOp::delete_obj(const DoutPrefixProvider* dpp
 
         if ((ret = blockDir->get(dpp, &block, y)) < 0) {
     if (ret == -ENOENT) {
-      ldpp_dout(dpp, 0) << "Directory entry for: " << source->get_name() << " blockid: " << fst << " block size: " << cur_len << " does not exist; continuing" << dendl;
+      ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Directory entry for: " << source->get_name() << " blockid: " << fst << " block size: " << cur_len << " does not exist; continuing" << dendl;
       fst += cur_len;
       if (fst >= lst) {
         break;
       }
       continue;
     } else {
-      ldpp_dout(dpp, 0) << "Failed to retrieve directory entry for: " << source->get_name() << " blockid: " << fst << " block size: " << cur_len << ", ret=" << ret << dendl;
+      ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Failed to retrieve directory entry for: " << source->get_name() << " blockid: " << fst << " block size: " << cur_len << ", ret=" << ret << dendl;
       return ret;
     }
         }
@@ -1941,14 +1978,14 @@ int D4NFilterObject::D4NFilterDeleteOp::delete_obj(const DoutPrefixProvider* dpp
     if (objDirty) {
       std::string key = policy_prefix + CACHE_DELIM + std::to_string(fst) + CACHE_DELIM + std::to_string(cur_len);
       if ((ret = delete_from_cache_and_policy(dpp, oid_in_cache, key, y)) < 0) {
-        ldpp_dout(dpp, 0) << "ERROR for block " << source->get_name() << " blockID: " << fst << " block size: " << cur_len << ", ret=" << ret << dendl;
+        ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): ERROR for block " << source->get_name() << " blockID: " << fst << " block size: " << cur_len << ", ret=" << ret << dendl;
         return ret;
       }
     }
         } else if (ret == -ENOENT) {
     continue;
         } else {
-    ldpp_dout(dpp, 0) << "Failed to delete directory entry for: " << source->get_name() << " blockid: " << fst << " block size: " << cur_len << ", ret=" << ret << dendl;
+    ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Failed to delete directory entry for: " << source->get_name() << " blockid: " << fst << " block size: " << cur_len << ", ret=" << ret << dendl;
     return ret;
         }
 
@@ -1965,7 +2002,7 @@ int D4NFilterObject::D4NFilterDeleteOp::delete_obj(const DoutPrefixProvider* dpp
       return ret;
     } else {
       if (!(ret = source->driver->get_policy_driver()->get_cache_policy()->erase_dirty_object(dpp, key, y))) {
-	ldpp_dout(dpp, 0) << "Failed to delete policy object entry for: " << source->get_name() << ", ret=" << ret << dendl;
+	ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Failed to delete policy object entry for: " << source->get_name() << ", ret=" << ret << dendl;
 	return -ENOENT;
       } else {
 	return 0;

--- a/src/rgw/driver/d4n/rgw_sal_d4n.h
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.h
@@ -183,6 +183,7 @@ class D4NFilterObject : public FilterObject {
       virtual ~D4NFilterDeleteOp() = default;
 
       virtual int delete_obj(const DoutPrefixProvider* dpp, optional_yield y, uint32_t flags) override;
+      int delete_from_cache_and_policy(const DoutPrefixProvider* dpp, std::string oid, std::string prefix, optional_yield y);
     };
 
     D4NFilterObject(std::unique_ptr<Object> _next, D4NFilterDriver* _driver) : FilterObject(std::move(_next)),

--- a/src/rgw/driver/d4n/rgw_sal_d4n.h
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.h
@@ -112,6 +112,7 @@ class D4NFilterObject : public FilterObject {
     rgw::sal::Object* dest_object{nullptr}; //for copy-object
     rgw::sal::Bucket* dest_bucket{nullptr}; //for copy-object
     bool multipart{false};
+    bool delete_marker{false};
 
   public:
     struct D4NFilterReadOp : FilterReadOp {
@@ -245,7 +246,7 @@ class D4NFilterObject : public FilterObject {
     int get_obj_attrs_from_cache(const DoutPrefixProvider* dpp, optional_yield y);
     void set_attrs_from_obj_state(const DoutPrefixProvider* dpp, optional_yield y, rgw::sal::Attrs& attrs);
     int calculate_version(const DoutPrefixProvider* dpp, optional_yield y, std::string& version);
-    int set_head_obj_dir_entry(const DoutPrefixProvider* dpp, optional_yield y, bool is_latest_version = true, bool dirty = false);
+    int set_head_obj_dir_entry(const DoutPrefixProvider* dpp, std::vector<std::string>* exec_responses, optional_yield y, bool is_latest_version = true, bool dirty = false);
     int set_data_block_dir_entries(const DoutPrefixProvider* dpp, optional_yield y, std::string& version, bool dirty = false);
     int delete_data_block_cache_entries(const DoutPrefixProvider* dpp, optional_yield y, std::string& version, bool dirty = false);
     bool check_head_exists_in_cache_get_oid(const DoutPrefixProvider* dpp, std::string& head_oid_in_cache, rgw::sal::Attrs& attrs, rgw::d4n::CacheBlock& blk, optional_yield y);
@@ -253,6 +254,8 @@ class D4NFilterObject : public FilterObject {
     rgw::sal::Object* get_destination_object(const DoutPrefixProvider* dpp) { return dest_object; }
     bool is_multipart() { return multipart; }
     int set_attr_crypt_parts(const DoutPrefixProvider* dpp, optional_yield y, rgw::sal::Attrs& attrs);
+    int create_delete_marker(const DoutPrefixProvider* dpp, optional_yield y);
+    bool is_delete_marker() { return delete_marker; }
 };
 
 class D4NFilterWriter : public FilterWriter {

--- a/src/rgw/driver/d4n/rgw_sal_d4n.h
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.h
@@ -184,7 +184,6 @@ class D4NFilterObject : public FilterObject {
       virtual ~D4NFilterDeleteOp() = default;
 
       virtual int delete_obj(const DoutPrefixProvider* dpp, optional_yield y, uint32_t flags) override;
-      int delete_from_cache_and_policy(const DoutPrefixProvider* dpp, std::string oid, std::string prefix, optional_yield y);
     };
 
     D4NFilterObject(std::unique_ptr<Object> _next, D4NFilterDriver* _driver) : FilterObject(std::move(_next)),

--- a/src/rgw/driver/d4n/rgw_sal_d4n.h
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.h
@@ -243,7 +243,7 @@ class D4NFilterObject : public FilterObject {
     void set_prefix(const std::string& prefix) { this->prefix = prefix; }
     const std::string get_prefix() { return this->prefix; }
     int get_obj_attrs_from_cache(const DoutPrefixProvider* dpp, optional_yield y);
-    void set_attrs_from_obj_state(const DoutPrefixProvider* dpp, optional_yield y, rgw::sal::Attrs& attrs);
+    void set_attrs_from_obj_state(const DoutPrefixProvider* dpp, optional_yield y, rgw::sal::Attrs& attrs, bool dirty = false);
     int calculate_version(const DoutPrefixProvider* dpp, optional_yield y, std::string& version);
     int set_head_obj_dir_entry(const DoutPrefixProvider* dpp, std::vector<std::string>* exec_responses, optional_yield y, bool is_latest_version = true, bool dirty = false);
     int set_data_block_dir_entries(const DoutPrefixProvider* dpp, optional_yield y, std::string& version, bool dirty = false);

--- a/src/rgw/rgw_cache_driver.h
+++ b/src/rgw/rgw_cache_driver.h
@@ -14,6 +14,7 @@ constexpr char RGW_CACHE_ATTR_VERSION_ID[] = "user.rgw.version_id";
 constexpr char RGW_CACHE_ATTR_SOURC_ZONE[] = "user.rgw.source_zone";
 constexpr char RGW_CACHE_ATTR_LOCAL_WEIGHT[] = "user.rgw.localWeight";
 constexpr char RGW_CACHE_ATTR_DELETE_MARKER[] = "user.rgw.deleteMarker";
+constexpr char RGW_CACHE_ATTR_INVALID[] = "user.rgw.invalid";
 
 constexpr char DIRTY_BLOCK_PREFIX[] = "D#";
 constexpr char CACHE_DELIM = '#';
@@ -22,7 +23,7 @@ namespace rgw { namespace cache {
 
 typedef std::function<void(const DoutPrefixProvider* dpp, std::string& key, std::string version, bool dirty, uint64_t size, 
 			    time_t creationTime, const rgw_user user, std::string& etag, const std::string& bucket_name, const std::string& bucket_id,
-			    const rgw_obj_key& obj_key, optional_yield y)> ObjectDataCallback;
+			    const rgw_obj_key& obj_key, optional_yield y, std::string& restore_val)> ObjectDataCallback;
 
 typedef std::function<void(const DoutPrefixProvider* dpp, std::string& key, uint64_t offset, uint64_t len, std::string version,
         bool dirty, optional_yield y, std::string& restore_val)> BlockDataCallback;

--- a/src/rgw/rgw_cache_driver.h
+++ b/src/rgw/rgw_cache_driver.h
@@ -13,6 +13,7 @@ constexpr char RGW_CACHE_ATTR_BUCKET_NAME[] = "user.rgw.bucket_name";
 constexpr char RGW_CACHE_ATTR_VERSION_ID[] = "user.rgw.version_id";
 constexpr char RGW_CACHE_ATTR_SOURC_ZONE[] = "user.rgw.source_zone";
 constexpr char RGW_CACHE_ATTR_LOCAL_WEIGHT[] = "user.rgw.localWeight";
+constexpr char RGW_CACHE_ATTR_DELETE_MARKER[] = "user.rgw.deleteMarker";
 
 constexpr char DIRTY_BLOCK_PREFIX[] = "D#";
 constexpr char CACHE_DELIM = '#';

--- a/src/rgw/rgw_cache_driver.h
+++ b/src/rgw/rgw_cache_driver.h
@@ -15,8 +15,8 @@ constexpr char RGW_CACHE_ATTR_SOURC_ZONE[] = "user.rgw.source_zone";
 constexpr char RGW_CACHE_ATTR_LOCAL_WEIGHT[] = "user.rgw.localWeight";
 constexpr char RGW_CACHE_ATTR_DELETE_MARKER[] = "user.rgw.deleteMarker";
 constexpr char RGW_CACHE_ATTR_INVALID[] = "user.rgw.invalid";
+constexpr char RGW_CACHE_ATTR_DIRTY[] = "user.rgw.dirty";
 
-constexpr char DIRTY_BLOCK_PREFIX[] = "D#";
 constexpr char CACHE_DELIM = '#';
 
 namespace rgw { namespace cache {

--- a/src/rgw/rgw_redis_driver.h
+++ b/src/rgw/rgw_redis_driver.h
@@ -36,7 +36,7 @@ class RedisDriver : public CacheDriver {
                                           const rgw::sal::Attrs& attrs, uint64_t cost, uint64_t id) override;
     virtual int get(const DoutPrefixProvider* dpp, const std::string& key, off_t offset, uint64_t len, bufferlist& bl, rgw::sal::Attrs& attrs, optional_yield y) override;
     virtual rgw::AioResultList get_async(const DoutPrefixProvider* dpp, optional_yield y, rgw::Aio* aio, const std::string& key, off_t ofs, uint64_t len, uint64_t cost, uint64_t id) override;
-    virtual int del(const DoutPrefixProvider* dpp, const std::string& key, optional_yield y) override;
+    virtual int del(const DoutPrefixProvider* dpp, const std::string& key, optional_yield y) override { return -1; } // TODO: implement
     virtual int append_data(const DoutPrefixProvider* dpp, const::std::string& key, const bufferlist& bl_data, optional_yield y) override;
     virtual int delete_data(const DoutPrefixProvider* dpp, const::std::string& key, optional_yield y) override;
     virtual int rename(const DoutPrefixProvider* dpp, const::std::string& oldKey, const::std::string& newKey, optional_yield y) override;

--- a/src/rgw/rgw_ssd_driver.cc
+++ b/src/rgw/rgw_ssd_driver.cc
@@ -275,6 +275,7 @@ int SSDDriver::restore_blocks_objects(const DoutPrefixProvider* dpp, ObjectDataC
                                             time_t creationTime = time_t(nullptr);
                                             rgw_user user;
                                             rgw_obj_key obj_key;
+                                            bool deleteMarker = false;
                                             if (attrs.find(RGW_ATTR_ETAG) != attrs.end()) {
                                                 etag = attrs[RGW_ATTR_ETAG].to_str();
                                                 ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): etag: " << etag << dendl;
@@ -321,8 +322,14 @@ int SSDDriver::restore_blocks_objects(const DoutPrefixProvider* dpp, ObjectDataC
                                                 ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): localWeightStr: " << localWeightStr << dendl;
                                             }
 
+                                            if (attrs.find(RGW_CACHE_ATTR_DELETE_MARKER) != attrs.end()) {
+                                                std::string deleteMarkerStr = attrs[RGW_CACHE_ATTR_LOCAL_WEIGHT].to_str();
+                                                deleteMarker = (deleteMarkerStr == "1") ? true : false;
+                                                ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): deleteMarker: " << deleteMarker << dendl;
+                                            }
+
                                             ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): calling func for: " << key << dendl;
-                                            obj_func(dpp, key, version, dirty, size, creationTime, user, etag, bucket_name, bucket_id, obj_key, null_yield);
+                                            obj_func(dpp, key, version, deleteMarker, size, creationTime, user, etag, bucket_name, bucket_id, obj_key, null_yield);
                                             block_func(dpp, key, offset, len, version, dirty, null_yield, localWeightStr);
                                             parsed = true;
                                         } //end-if part.size() == 2

--- a/src/rgw/rgw_ssd_driver.cc
+++ b/src/rgw/rgw_ssd_driver.cc
@@ -267,6 +267,7 @@ int SSDDriver::restore_blocks_objects(const DoutPrefixProvider* dpp, ObjectDataC
                     
                                         uint64_t len = 0, offset = 0;
                                         std::string localWeightStr;
+					std::string invalidStr;
                                         if (parts.size() == 2) {
                                             rgw::sal::Attrs attrs;
                                             get_attrs(dpp, file_entry.path(), attrs, null_yield);
@@ -328,8 +329,13 @@ int SSDDriver::restore_blocks_objects(const DoutPrefixProvider* dpp, ObjectDataC
                                                 ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): deleteMarker: " << deleteMarker << dendl;
                                             }
 
+                                            if (attrs.find(RGW_CACHE_ATTR_INVALID) != attrs.end()) {
+                                                invalidStr = attrs[RGW_CACHE_ATTR_INVALID].to_str();
+                                                ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): invalidStr: " << invalidStr << dendl;
+                                            }
+
                                             ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): calling func for: " << key << dendl;
-                                            obj_func(dpp, key, version, deleteMarker, size, creationTime, user, etag, bucket_name, bucket_id, obj_key, null_yield);
+                                            obj_func(dpp, key, version, deleteMarker, size, creationTime, user, etag, bucket_name, bucket_id, obj_key, null_yield, invalidStr);
                                             block_func(dpp, key, offset, len, version, dirty, null_yield, localWeightStr);
                                             parsed = true;
                                         } //end-if part.size() == 2

--- a/src/rgw/rgw_ssd_driver.cc
+++ b/src/rgw/rgw_ssd_driver.cc
@@ -18,7 +18,7 @@ static std::atomic<uint64_t> dir_index{0};
 /*
 * Parses key to return directory path and file name
 */
-static void parse_key(const DoutPrefixProvider* dpp, const std::string& location, const std::string& key, std::string& dir_path, std::string& file_name, bool& is_dirty, bool temp = false) {
+static void parse_key(const DoutPrefixProvider* dpp, const std::string& location, const std::string& key, std::string& dir_path, std::string& file_name, bool temp = false) {
     ldpp_dout(dpp, 10) << __func__ << "() key is: " << key << dendl;
     std::stringstream ss(key);
     std::vector<std::string> parts;
@@ -26,32 +26,9 @@ static void parse_key(const DoutPrefixProvider* dpp, const std::string& location
     while (std::getline(ss, part, CACHE_DELIM)) {
         parts.push_back(part);
     }
-    is_dirty = false;
 
     ldpp_dout(dpp, 10) << __func__ << "() parts.size() is " << parts.size() << dendl;
-    //dirty blocks
-    if (parts.size() == 4 || parts.size() == 6) {
-        if (parts[0] == "D") {
-            is_dirty = true;
-            bucket_id = parts[1];
-            ldpp_dout(dpp, 10) <<  __func__ << "() bucket_id is " << bucket_id << dendl;
-            object = parts[3];
-            ldpp_dout(dpp, 10) << __func__  << "() object is " << object << dendl;
-            version = DIRTY_BLOCK_PREFIX + parts[2];
-            if (parts.size() == 6) { //has offset and length
-                version += CACHE_DELIM + parts[4] + CACHE_DELIM + parts[5];
-            }
-            if (temp) {
-                version += "_" + std::to_string(index++);
-            }
-            ldpp_dout(dpp, 10) <<  __func__ << "() version is " << version << dendl;
-            dir_path = location + "/" + bucket_id + "/" + object;
-            file_name = version;
-            ldpp_dout(dpp, 10) <<  __func__ << "() dir_path is " << dir_path << dendl;
-        }
-    }
 
-    //clean blocks
     if (parts.size() == 3 || parts.size() == 5) {
         bucket_id = parts[0];
         ldpp_dout(dpp, 10) <<  __func__ << "() bucket_id is " << bucket_id << dendl;
@@ -115,8 +92,7 @@ static std::string get_file_path(const DoutPrefixProvider* dpp, const std::strin
 static std::string create_dirs_get_filepath_from_key(const DoutPrefixProvider* dpp, const std::string& location, const std::string& key, bool temp=false)
 {
     std::string dir_path, file_name;
-    bool is_dirty;
-    parse_key(dpp, location, key, dir_path, file_name, is_dirty, temp);
+    parse_key(dpp, location, key, dir_path, file_name, temp);
     create_directories(dpp, dir_path);
     return get_file_path(dpp, dir_path, file_name);
 
@@ -233,147 +209,139 @@ int SSDDriver::restore_blocks_objects(const DoutPrefixProvider* dpp, ObjectDataC
                                     parts.push_back(part);
                                 }
                                 ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): parts.size(): " << parts.size() << dendl;
-                                //non-dirty or clean blocks - version in head block and offset, len in data blocks
+  
+				std::string dirtyStr;
+				bool dirty;
+				auto ret = get_attr(dpp, file_entry.path(), RGW_CACHE_ATTR_DIRTY, dirtyStr, null_yield);
+				if (ret == 0 && dirtyStr == "1") {
+				    ldpp_dout(dpp, 10) << "SSDCache: " << __func__ << "(): Dirty xattr retrieved" << dendl;
+                                    dirty = true;
+                                } else if (ret < 0) {
+				    ldpp_dout(dpp, 0) << "SSDCache: " << __func__ << "(): Failed to get attr: " << RGW_CACHE_ATTR_DIRTY << ", ret=" << ret << dendl;
+                                    dirty = false;
+				} else {
+                                    dirty = false;
+                                }
+
                                 if (parts.size() == 1 || parts.size() == 3) {
-                                    std::string version = url_decode(parts[0]);
-                                    ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): version: " << version << dendl;
+				    std::string version = url_decode(parts[0]);
+				    ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): version: " << version << dendl;
 
-                                    std::string key = url_encode(bucket_id, true) + CACHE_DELIM + url_encode(version, true) + CACHE_DELIM + url_encode(object_name, true);
-                                    ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): key: " << key << dendl;
+				    std::string key = url_encode(bucket_id, true) + CACHE_DELIM + url_encode(version, true) + CACHE_DELIM + url_encode(object_name, true);
+				    ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): key: " << key << dendl;
 
-                                    uint64_t offset = 0, len = 0;
-                                    if (parts.size() == 3) {
-                                        offset = std::stoull(parts[1]);
-                                        ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): offset: " << offset << dendl;
+				    uint64_t len = 0, offset = 0;
+				    if (parts.size() == 1) {
+					if (dirtyStr == "0") {
+					    //non-dirty or clean blocks - version in head block and offset, len in data blocks
+					    std::string localWeightStr;
+					    ret = get_attr(dpp, file_entry.path(), RGW_CACHE_ATTR_LOCAL_WEIGHT, localWeightStr, null_yield);
+					    if (ret < 0) {
+						ldpp_dout(dpp, 0) << "SSDCache: " << __func__ << "(): Failed to get attr: " << RGW_CACHE_ATTR_LOCAL_WEIGHT << dendl;
+					    } else {
+						ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): localWeightStr: " << localWeightStr << dendl;
+					    }
+					    block_func(dpp, key, offset, len, version, false, null_yield, localWeightStr);
+					    parsed = true;
+				        } else if (dirtyStr == "1") {
+                                            //dirty blocks - version in head block and offset, len in data blocks
+					    std::string localWeightStr;
+					    std::string invalidStr;
+					    rgw::sal::Attrs attrs;
+					    get_attrs(dpp, file_entry.path(), attrs, null_yield);
+					    std::string etag, bucket_name;
+					    uint64_t size = 0;
+					    time_t creationTime = time_t(nullptr);
+					    rgw_user user;
+					    rgw_obj_key obj_key;
+					    bool deleteMarker = false;
+					    if (attrs.find(RGW_ATTR_ETAG) != attrs.end()) {
+						etag = attrs[RGW_ATTR_ETAG].to_str();
+						ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): etag: " << etag << dendl;
+					    }
+					    if (attrs.find(RGW_CACHE_ATTR_OBJECT_SIZE) != attrs.end()) {
+						size = std::stoull(attrs[RGW_CACHE_ATTR_OBJECT_SIZE].to_str());
+						ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): size: " << size << dendl;
+					    }
+					    if (attrs.find(RGW_CACHE_ATTR_MTIME) != attrs.end()) {
+						creationTime = ceph::real_clock::to_time_t(ceph::real_clock::from_double(std::stod(attrs[RGW_CACHE_ATTR_MTIME].to_str())));
+						ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): creationTime: " << creationTime << dendl;
+					    }
+					    if (attrs.find(RGW_ATTR_ACL) != attrs.end()) {
+						bufferlist bl_acl = attrs[RGW_ATTR_ACL];
+						RGWAccessControlPolicy policy;
+						auto iter = bl_acl.cbegin();
+						try {
+						    policy.decode(iter);
+						} catch (buffer::error& err) {
+						    ldpp_dout(dpp, 0) << "ERROR: could not decode policy, caught buffer::error" << dendl;
+						    continue;
+						}
+						user = std::get<rgw_user>(policy.get_owner().id);
+						ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): rgw_user: " << user.to_str() << dendl;
+					    }
+					    obj_key.name = object_name;
+					    if (attrs.find(RGW_CACHE_ATTR_VERSION_ID) != attrs.end()) {
+						std::string instance = attrs[RGW_CACHE_ATTR_VERSION_ID].to_str();
+						if (instance != "null") {
+						    obj_key.instance = instance;
+						}
+					    }
+					    if (attrs.find(RGW_CACHE_ATTR_OBJECT_NS) != attrs.end()) {
+						obj_key.ns = attrs[RGW_CACHE_ATTR_OBJECT_NS].to_str();
+					    }
+					    ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): rgw_obj_key: " << obj_key.get_oid() << dendl;
+					    if (attrs.find(RGW_CACHE_ATTR_BUCKET_NAME) != attrs.end()) {
+						bucket_name = attrs[RGW_CACHE_ATTR_BUCKET_NAME].to_str();
+						ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): bucket_name: " << bucket_name << dendl;
+					    }
 
-                                        len = std::stoull(parts[2]);
-                                        ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): len: " << len << dendl;
+					    if (attrs.find(RGW_CACHE_ATTR_LOCAL_WEIGHT) != attrs.end()) {
+						localWeightStr = attrs[RGW_CACHE_ATTR_LOCAL_WEIGHT].to_str();
+						ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): localWeightStr: " << localWeightStr << dendl;
+					    }
 
-                                        key = key + CACHE_DELIM + std::to_string(offset) + CACHE_DELIM + std::to_string(len);
-                                        ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): key: " << key << dendl;
-                                    }
-                                    std::string localWeightStr;
-                                    auto ret = get_attr(dpp, file_entry.path(), RGW_CACHE_ATTR_LOCAL_WEIGHT, localWeightStr, null_yield);
-                                    if (ret < 0) {
-                                        ldpp_dout(dpp, 0) << "SSDCache: " << __func__ << "(): Failed to get attr: " << RGW_CACHE_ATTR_LOCAL_WEIGHT << dendl;
-                                    } else {
-                                        ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): localWeightStr: " << localWeightStr << dendl;
-                                    }
-                                    block_func(dpp, key, offset, len, version, false, null_yield, localWeightStr);
-                                    parsed = true;
-                                }
-                                //dirty blocks - "D", version in head block and offset, len in data blocks
-                                if ((parts.size() == 2 || parts.size() == 4) && parts[0] == "D") {
-                                    std::string prefix = DIRTY_BLOCK_PREFIX;
-                                    if (file_name.starts_with(prefix)) {
-                                        bool dirty = true;
+					    if (attrs.find(RGW_CACHE_ATTR_DELETE_MARKER) != attrs.end()) {
+						std::string deleteMarkerStr = attrs[RGW_CACHE_ATTR_LOCAL_WEIGHT].to_str();
+						deleteMarker = (deleteMarkerStr == "1") ? true : false;
+						ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): deleteMarker: " << deleteMarker << dendl;
+					    }
 
-                                        std::string version = url_decode(parts[1]);
-                                        ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): version: " << version << dendl;
+					    if (attrs.find(RGW_CACHE_ATTR_INVALID) != attrs.end()) {
+						invalidStr = attrs[RGW_CACHE_ATTR_INVALID].to_str();
+						ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): invalidStr: " << invalidStr << dendl;
+					    }
 
-                                        std::string key = url_encode(bucket_id, true) + CACHE_DELIM + url_encode(version, true) + CACHE_DELIM + url_encode(object_name, true);
-                                        ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): key: " << key << dendl;
-                    
-                                        uint64_t len = 0, offset = 0;
-                                        std::string localWeightStr;
-					std::string invalidStr;
-                                        if (parts.size() == 2) {
-                                            rgw::sal::Attrs attrs;
-                                            get_attrs(dpp, file_entry.path(), attrs, null_yield);
-                                            std::string etag, bucket_name;
-                                            uint64_t size = 0;
-                                            time_t creationTime = time_t(nullptr);
-                                            rgw_user user;
-                                            rgw_obj_key obj_key;
-                                            bool deleteMarker = false;
-                                            if (attrs.find(RGW_ATTR_ETAG) != attrs.end()) {
-                                                etag = attrs[RGW_ATTR_ETAG].to_str();
-                                                ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): etag: " << etag << dendl;
-                                            }
-                                            if (attrs.find(RGW_CACHE_ATTR_OBJECT_SIZE) != attrs.end()) {
-                                                size = std::stoull(attrs[RGW_CACHE_ATTR_OBJECT_SIZE].to_str());
-                                                ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): size: " << size << dendl;
-                                            }
-                                            if (attrs.find(RGW_CACHE_ATTR_MTIME) != attrs.end()) {
-                                                creationTime = ceph::real_clock::to_time_t(ceph::real_clock::from_double(std::stod(attrs[RGW_CACHE_ATTR_MTIME].to_str())));
-                                                ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): creationTime: " << creationTime << dendl;
-                                            }
-                                            if (attrs.find(RGW_ATTR_ACL) != attrs.end()) {
-                                                bufferlist bl_acl = attrs[RGW_ATTR_ACL];
-                                                RGWAccessControlPolicy policy;
-                                                auto iter = bl_acl.cbegin();
-                                                try {
-                                                    policy.decode(iter);
-                                                } catch (buffer::error& err) {
-                                                    ldpp_dout(dpp, 0) << "ERROR: could not decode policy, caught buffer::error" << dendl;
-                                                    continue;
-                                                }
-                                                user = std::get<rgw_user>(policy.get_owner().id);
-                                                ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): rgw_user: " << user.to_str() << dendl;
-                                            }
-                                            obj_key.name = object_name;
-                                            if (attrs.find(RGW_CACHE_ATTR_VERSION_ID) != attrs.end()) {
-                                                std::string instance = attrs[RGW_CACHE_ATTR_VERSION_ID].to_str();
-                                                if (instance != "null") {
-                                                    obj_key.instance = instance;
-                                                }
-                                            }
-                                            if (attrs.find(RGW_CACHE_ATTR_OBJECT_NS) != attrs.end()) {
-                                                obj_key.ns = attrs[RGW_CACHE_ATTR_OBJECT_NS].to_str();
-                                            }
-                                            ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): rgw_obj_key: " << obj_key.get_oid() << dendl;
-                                            if (attrs.find(RGW_CACHE_ATTR_BUCKET_NAME) != attrs.end()) {
-                                                bucket_name = attrs[RGW_CACHE_ATTR_BUCKET_NAME].to_str();
-                                                ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): bucket_name: " << bucket_name << dendl;
-                                            }
+					    ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): calling func for: " << key << dendl;
+					    obj_func(dpp, key, version, deleteMarker, size, creationTime, user, etag, bucket_name, bucket_id, obj_key, null_yield, invalidStr);
+					    block_func(dpp, key, offset, len, version, dirty, null_yield, localWeightStr);
+					    parsed = true;
+                                        } // end-if dirtyStr == "1"
+				    } else if (parts.size() == 3) { //end-if parts.size() == 1
+					offset = std::stoull(parts[1]);
+					ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): offset: " << offset << dendl;
 
-                                            if (attrs.find(RGW_CACHE_ATTR_LOCAL_WEIGHT) != attrs.end()) {
-                                                localWeightStr = attrs[RGW_CACHE_ATTR_LOCAL_WEIGHT].to_str();
-                                                ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): localWeightStr: " << localWeightStr << dendl;
-                                            }
+					len = std::stoull(parts[2]);
+					ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): len: " << len << dendl;
 
-                                            if (attrs.find(RGW_CACHE_ATTR_DELETE_MARKER) != attrs.end()) {
-                                                std::string deleteMarkerStr = attrs[RGW_CACHE_ATTR_LOCAL_WEIGHT].to_str();
-                                                deleteMarker = (deleteMarkerStr == "1") ? true : false;
-                                                ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): deleteMarker: " << deleteMarker << dendl;
-                                            }
+					key = key + CACHE_DELIM + std::to_string(offset) + CACHE_DELIM + std::to_string(len);
+					ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): key: " << key << dendl;
 
-                                            if (attrs.find(RGW_CACHE_ATTR_INVALID) != attrs.end()) {
-                                                invalidStr = attrs[RGW_CACHE_ATTR_INVALID].to_str();
-                                                ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): invalidStr: " << invalidStr << dendl;
-                                            }
-
-                                            ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): calling func for: " << key << dendl;
-                                            obj_func(dpp, key, version, deleteMarker, size, creationTime, user, etag, bucket_name, bucket_id, obj_key, null_yield, invalidStr);
-                                            block_func(dpp, key, offset, len, version, dirty, null_yield, localWeightStr);
-                                            parsed = true;
-                                        } //end-if part.size() == 2
-                                        if (parts.size() == 4) {
-                                            offset = std::stoull(parts[2]);
-                                            ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): offset: " << offset << dendl;
-
-                                            len = std::stoull(parts[3]);
-                                            ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): len: " << len << dendl;
-
-                                            key = key + CACHE_DELIM + std::to_string(offset) + CACHE_DELIM + std::to_string(len);
-                                            ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): key: " << key << dendl;
-
-                                            std::string localWeightStr;
-                                            auto ret = get_attr(dpp, file_entry.path(), RGW_CACHE_ATTR_LOCAL_WEIGHT, localWeightStr, null_yield);
-                                            if (ret < 0) {
-                                                ldpp_dout(dpp, 0) << "SSDCache: " << __func__ << "(): Failed to get attr: " << RGW_CACHE_ATTR_LOCAL_WEIGHT << dendl;
-                                            } else {
-                                                ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): localWeightStr: " << localWeightStr << dendl;
-                                            }
-                                            block_func(dpp, key, offset, len, version, dirty, null_yield, localWeightStr);
-                                            parsed = true;
-                                        }
-                                    } //end-if file_name.starts_with
-                                } //end-if parts.size() == 2 || parts.size() == 4
-                                if (!parsed) {
-                                    ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): Unable to parse file_name: " << file_name << dendl;
-                                    continue;
-                                }
+					std::string localWeightStr;
+					auto ret = get_attr(dpp, file_entry.path(), RGW_CACHE_ATTR_LOCAL_WEIGHT, localWeightStr, null_yield);
+					if (ret < 0) {
+					    ldpp_dout(dpp, 0) << "SSDCache: " << __func__ << "(): Failed to get attr: " << RGW_CACHE_ATTR_LOCAL_WEIGHT << dendl;
+					} else {
+					    ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): localWeightStr: " << localWeightStr << dendl;
+					}
+					block_func(dpp, key, offset, len, version, dirty, null_yield, localWeightStr);
+					parsed = true;
+				    } 
+				    if (!parsed) {
+					ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): Unable to parse file_name: " << file_name << dendl;
+					continue;
+				    }
+			        }
                             }
                         }//end - try
                         catch(...) {
@@ -631,8 +599,7 @@ rgw::AioResultList SSDDriver::put_async(const DoutPrefixProvider* dpp, optional_
 int SSDDriver::delete_data(const DoutPrefixProvider* dpp, const::std::string& key, optional_yield y)
 {
     std::string dir_path, file_name;
-    bool is_dirty;
-    parse_key(dpp, partition_info.location, key, dir_path, file_name, is_dirty);
+    parse_key(dpp, partition_info.location, key, dir_path, file_name);
     std::string location = get_file_path(dpp, dir_path, file_name);
     ldpp_dout(dpp, 20) << "INFO: delete_data::file to remove: " << location << dendl;
     std::error_code ec;

--- a/src/rgw/rgw_ssd_driver.cc
+++ b/src/rgw/rgw_ssd_driver.cc
@@ -14,6 +14,7 @@ namespace efs = std::filesystem;
 namespace rgw { namespace cache {
 
 static std::atomic<uint64_t> index{0};
+static std::atomic<uint64_t> dir_index{0};
 /*
 * Parses key to return directory path and file name
 */
@@ -74,24 +75,32 @@ static void parse_key(const DoutPrefixProvider* dpp, const std::string& location
 static void create_directories(const DoutPrefixProvider* dpp, const std::string& dir_path)
 {
     std::error_code ec;
+    std::string temp_dir_path = dir_path + "_" + std::to_string(dir_index++);
     if (!efs::exists(dir_path, ec)) {
-        if (!efs::create_directories(dir_path, ec)) {
-            ldpp_dout(dpp, 0) << "initialize::: ERROR creating directory: '" << dir_path <<
+        if (!efs::create_directories(temp_dir_path, ec)) {
+            ldpp_dout(dpp, 0) << "create_directories::: ERROR creating directory: '" << temp_dir_path <<
                             "' : " << ec.value() << dendl;
         } else {
-            uid_t uid = dpp->get_cct()->get_set_uid();
-            gid_t gid = dpp->get_cct()->get_set_gid();
+            efs::rename(temp_dir_path, dir_path, ec);
+            if (ec) {
+                ldpp_dout(dpp, 0) << "create_directories::: ERROR renaming directory: '" << temp_dir_path <<
+                            "' : " << ec.value() << dendl;
+                efs::remove(temp_dir_path, ec);
+            } else {
+                uid_t uid = dpp->get_cct()->get_set_uid();
+                gid_t gid = dpp->get_cct()->get_set_gid();
 
-            ldpp_dout(dpp, 5) << "initialize:: uid is " << uid << " and gid is " << gid << dendl;
-            ldpp_dout(dpp, 5) << "initialize:: changing permissions for directory: " << dendl;
+                ldpp_dout(dpp, 5) << "create_directories:: uid is " << uid << " and gid is " << gid << dendl;
+                ldpp_dout(dpp, 5) << "create_directories:: changing permissions for directory: " << dendl;
 
-            if (uid) { 
-                if (chown(dir_path.c_str(), uid, gid) == -1) {
-                    ldpp_dout(dpp, 5) << "initialize: chown return error: " << strerror(errno) << dendl;
-                }
+                if (uid) {
+                    if (chown(dir_path.c_str(), uid, gid) == -1) {
+                        ldpp_dout(dpp, 5) << "create_directories: chown return error: " << strerror(errno) << dendl;
+                    }
 
-                if (chmod(dir_path.c_str(), S_IRWXU|S_IRWXG|S_IRWXO) == -1) {
-                    ldpp_dout(dpp, 5) << "initialize: chmod return error: " << strerror(errno) << dendl;
+                    if (chmod(dir_path.c_str(), S_IRWXU|S_IRWXG|S_IRWXO) == -1) {
+                        ldpp_dout(dpp, 5) << "create_directories: chmod return error: " << strerror(errno) << dendl;
+                    }
                 }
             }
         }
@@ -380,6 +389,18 @@ int SSDDriver::restore_blocks_objects(const DoutPrefixProvider* dpp, ObjectDataC
     return 0;
 }
 
+uint64_t SSDDriver::get_free_space(const DoutPrefixProvider* dpp)
+{
+    efs::space_info space = efs::space(partition_info.location);
+    return space.available;
+}
+
+void SSDDriver::set_free_space(const DoutPrefixProvider* dpp, uint64_t free_space)
+{
+    std::lock_guard l(cache_lock);
+    this->free_space = free_space;
+}
+
 int SSDDriver::put(const DoutPrefixProvider* dpp, const std::string& key, const bufferlist& bl, uint64_t len, const rgw::sal::Attrs& attrs, optional_yield y)
 {
     ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): key=" << key << dendl;
@@ -467,7 +488,7 @@ int SSDDriver::append_data(const DoutPrefixProvider* dpp, const::std::string& ke
         ldpp_dout(dpp, 0) << "ERROR: append_data::fclose file has return error, errno=" << errno << dendl;
         return -errno;
     }
-
+    std::lock_guard l(cache_lock);
     efs::space_info space = efs::space(partition_info.location);
     this->free_space = space.available;
 
@@ -614,19 +635,20 @@ int SSDDriver::delete_data(const DoutPrefixProvider* dpp, const::std::string& ke
     parse_key(dpp, partition_info.location, key, dir_path, file_name, is_dirty);
     std::string location = get_file_path(dpp, dir_path, file_name);
     ldpp_dout(dpp, 20) << "INFO: delete_data::file to remove: " << location << dendl;
+    std::error_code ec;
 
     //Remove file
-    if (!efs::remove(location)) {
+    if (!efs::remove(location, ec)) {
         ldpp_dout(dpp, 0) << "ERROR: delete_data::remove has failed to remove the file: " << location << dendl;
-        return -EIO;
+        return -ec.value();
     }
 
     //Remove directory if empty, removes object directory
-    if (efs::is_empty(dir_path)) {
-        ldpp_dout(dpp, 20) << "INFO: delete_data::object directory to remove: " << dir_path << dendl;
-        if (!efs::remove(dir_path)) {
-            ldpp_dout(dpp, 0) << "ERROR: delete_data::remove has failed to remove the directory: " << dir_path << dendl;
-            return -EIO;
+    if (efs::is_empty(dir_path, ec)) {
+        ldpp_dout(dpp, 20) << "INFO: delete_data::object directory to remove: " << dir_path << " :" << ec.value() << dendl;
+        if (!efs::remove(dir_path, ec)) {
+            //another version could have been written between the check and removal, hence not returning error from here
+            ldpp_dout(dpp, 0) << "ERROR: delete_data::remove has failed to remove the directory: " << dir_path  << " :" << ec.value() << dendl;
         }
     }
     auto pos = dir_path.find_last_of('/');
@@ -634,14 +656,15 @@ int SSDDriver::delete_data(const DoutPrefixProvider* dpp, const::std::string& ke
         dir_path.erase(pos, (dir_path.length() - pos));
 
         //Remove bucket directory
-        if (efs::is_empty(dir_path)) {
-            ldpp_dout(dpp, 20) << "INFO: delete_data::bucket directory to remove: " << dir_path << dendl;
-            if (!efs::remove(dir_path)) {
-                ldpp_dout(dpp, 0) << "ERROR: delete_data::remove has failed to remove the directory: " << dir_path << dendl;
-                return -EIO;
+        if (efs::is_empty(dir_path, ec)) {
+            ldpp_dout(dpp, 20) << "INFO: delete_data::bucket directory to remove: " << dir_path << " :" << ec.value() << dendl;
+            if (!efs::remove(dir_path, ec)) {
+                //another object could have been written between the check and removal, hence not returning error from here
+                ldpp_dout(dpp, 0) << "ERROR: delete_data::remove has failed to remove the directory: " << dir_path << " :" << ec.value() << dendl;
             }
         }
     }
+
     efs::space_info space = efs::space(partition_info.location);
     this->free_space = space.available;
 
@@ -671,8 +694,25 @@ int SSDDriver::AsyncWriteRequest::prepare_libaio_write_op(const DoutPrefixProvid
     mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
     r = fd = TEMP_FAILURE_RETRY(::open(file_path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, mode));
     if (fd < 0) {
-        ldpp_dout(dpp, 0) << "ERROR: AsyncWriteRequest::prepare_libaio_write_op: open file failed, errno=" << errno << ", location='" << file_path.c_str() << "'" << dendl;
-        return r;
+        //directories might have been deleted by a parallel delete of the last version of an object
+        if (errno == ENOENT) {
+            //retry after creating directories
+            std::string dir_path = file_path;
+            auto pos = dir_path.find_last_of('/');
+            if (pos != std::string::npos) {
+                dir_path.erase(pos, (dir_path.length() - pos));
+            }
+            ldpp_dout(dpp, 20) << "INFO: AsyncWriteRequest::prepare_libaio_write_op: dir_path for creating directories=" << dir_path << dendl;
+            create_directories(dpp, dir_path);
+            r = fd = TEMP_FAILURE_RETRY(::open(file_path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, mode));
+            if (fd < 0) {
+                ldpp_dout(dpp, 0) << "ERROR: AsyncWriteRequest::prepare_libaio_write_op: open file failed, errno=" << errno << ", location='" << file_path.c_str() << "'" << dendl;
+                return r;
+            }
+        } else {
+            ldpp_dout(dpp, 0) << "ERROR: AsyncWriteRequest::prepare_libaio_write_op: open file failed, errno=" << errno << ", location='" << file_path.c_str() << "'" << dendl;
+            return r;
+        }
     }
     if (dpp->get_cct()->_conf->rgw_d4n_l1_fadvise != POSIX_FADV_NORMAL)
         posix_fadvise(fd, 0, 0, dpp->get_cct()->_conf->rgw_d4n_l1_fadvise);
@@ -780,18 +820,16 @@ int SSDDriver::update_attrs(const DoutPrefixProvider* dpp, const std::string& ke
     for (auto& it : attrs) {
         std::string attr_name = it.first;
         std::string attr_val = it.second.to_str();
-        std::string old_attr_val;
-        auto ret = get_attr(dpp, key, attr_name, old_attr_val, y);
-        if (old_attr_val.empty()) {
+        auto ret = setxattr(location.c_str(), attr_name.c_str(), attr_val.c_str(), attr_val.size(), XATTR_REPLACE);
+        if (ret < 0 && errno == ENODATA) {
             ret = setxattr(location.c_str(), attr_name.c_str(), attr_val.c_str(), attr_val.size(), XATTR_CREATE);
-        } else {
-            ret = setxattr(location.c_str(), attr_name.c_str(), attr_val.c_str(), attr_val.size(), XATTR_REPLACE);
         }
         if (ret < 0) {
             ldpp_dout(dpp, 0) << "SSDCache: " << __func__ << "(): could not modify attr value for attr name: " << attr_name << " key: " << key << " ERROR: " << cpp_strerror(errno) <<dendl;
             return ret;
         }
     }
+
     efs::space_info space = efs::space(partition_info.location);
     this->free_space = space.available;
     return 0;
@@ -900,28 +938,42 @@ int SSDDriver::get_attr(const DoutPrefixProvider* dpp, const std::string& key, c
 
     ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): get_attr: key: " << attr_name << dendl;
 
-    int attr_size = getxattr(location.c_str(), attr_name.c_str(), nullptr, 0);
-    if (attr_size < 0) {
-        ldpp_dout(dpp, 0) << "ERROR: could not get attribute " << attr_name << ": " << cpp_strerror(errno) << dendl;
-        attr_val = "";
-        return errno;
-    }
-
-    if (attr_size == 0) {
-        ldpp_dout(dpp, 0) << "ERROR: no attribute value found for attr_name: " << attr_name << dendl;
-        attr_val = "";
+    size_t buffer_size = 256;
+    while (true) {
+        attr_val.resize(buffer_size);
+        ssize_t attr_size = getxattr(location.c_str(), attr_name.c_str(), attr_val.data(), attr_val.size());
+        if (attr_size < 0) {
+            if (errno == ERANGE) {
+                // Buffer too small, get actual size needed
+                attr_size = getxattr(location.c_str(), attr_name.c_str(), nullptr, 0);
+                if (attr_size < 0) {
+                    ldpp_dout(dpp, 0) << "ERROR: could not get attribute " << attr_name << ": " << cpp_strerror(errno) << dendl;
+                    attr_val = "";
+                    return errno;
+                }
+                if (attr_size == 0) {
+                    ldpp_dout(dpp, 0) << "ERROR: no attribute value found for attr_name: " << attr_name << dendl;
+                    attr_val = "";
+                    return 0;
+                }
+                // Resize and try again
+                buffer_size = static_cast<size_t>(attr_size);
+                continue;
+            }
+            ldpp_dout(dpp, 0) << "SSDCache: " << __func__ << "(): could not get attribute " << attr_name << ": " << cpp_strerror(errno) << dendl;
+            attr_val = "";
+            return errno;
+        } //end-if result < 0
+        if (attr_size == 0) {
+            ldpp_dout(dpp, 0) << "ERROR: no attribute value found for attr_name: " << attr_name << dendl;
+            attr_val = "";
+            return 0;
+        } //end-if result == 0
+        // Success - resize buffer to actual data size and return
+        ldpp_dout(dpp, 20) << "INFO: attr_size is: " << attr_size << dendl;
+        attr_val.resize(static_cast<size_t>(attr_size));
         return 0;
     }
-
-    attr_val.resize(attr_size);
-    attr_size = getxattr(location.c_str(), attr_name.c_str(), attr_val.data(), attr_size);
-    if (attr_size < 0) {
-        ldpp_dout(dpp, 0) << "SSDCache: " << __func__ << "(): could not get attr value for attr name: " << attr_name << " key: " << key << dendl;
-        attr_val = "";
-        return errno;
-    }
-
-    return 0;
 }
 
 int SSDDriver::set_attr(const DoutPrefixProvider* dpp, const std::string& key, const std::string& attr_name, const std::string& attr_val, optional_yield y)

--- a/src/rgw/rgw_ssd_driver.cc
+++ b/src/rgw/rgw_ssd_driver.cc
@@ -13,9 +13,104 @@ namespace efs = std::filesystem;
 
 namespace rgw { namespace cache {
 
-static std::string get_file_path(const std::string& location, const std::string& key)
+static std::atomic<uint64_t> index{0};
+/*
+* Parses key to return directory path and file name
+*/
+static void parse_key(const DoutPrefixProvider* dpp, const std::string& location, const std::string& key, std::string& dir_path, std::string& file_name, bool& is_dirty, bool temp = false) {
+    ldpp_dout(dpp, 10) << __func__ << "() key is: " << key << dendl;
+    std::stringstream ss(key);
+    std::vector<std::string> parts;
+    std::string part, bucket_id, object, version;
+    while (std::getline(ss, part, CACHE_DELIM)) {
+        parts.push_back(part);
+    }
+    is_dirty = false;
+
+    ldpp_dout(dpp, 10) << __func__ << "() parts.size() is " << parts.size() << dendl;
+    //dirty blocks
+    if (parts.size() == 4 || parts.size() == 6) {
+        if (parts[0] == "D") {
+            is_dirty = true;
+            bucket_id = parts[1];
+            ldpp_dout(dpp, 10) <<  __func__ << "() bucket_id is " << bucket_id << dendl;
+            object = parts[3];
+            ldpp_dout(dpp, 10) << __func__  << "() object is " << object << dendl;
+            version = DIRTY_BLOCK_PREFIX + parts[2];
+            if (parts.size() == 6) { //has offset and length
+                version += CACHE_DELIM + parts[4] + CACHE_DELIM + parts[5];
+            }
+            if (temp) {
+                version += "_" + std::to_string(index++);
+            }
+            ldpp_dout(dpp, 10) <<  __func__ << "() version is " << version << dendl;
+            dir_path = location + "/" + bucket_id + "/" + object;
+            file_name = version;
+            ldpp_dout(dpp, 10) <<  __func__ << "() dir_path is " << dir_path << dendl;
+        }
+    }
+
+    //clean blocks
+    if (parts.size() == 3 || parts.size() == 5) {
+        bucket_id = parts[0];
+        ldpp_dout(dpp, 10) <<  __func__ << "() bucket_id is " << bucket_id << dendl;
+        object = parts[2];
+        ldpp_dout(dpp, 10) <<  __func__ << "() object is " << object << dendl;
+        version = parts[1];
+        if (parts.size() == 5) { //has offset and length
+            version += CACHE_DELIM + parts[3] + CACHE_DELIM + parts[4];
+        }
+        if (temp) {
+            version += "_" + std::to_string(index++);
+        }
+        ldpp_dout(dpp, 10) <<  __func__ << "() version is " << version << dendl;
+        dir_path = location + "/" + bucket_id + "/" + object;
+        file_name = version;
+        ldpp_dout(dpp, 10) <<  __func__ << "() dir_path is " << dir_path << dendl;
+    }
+    return;
+}
+
+static void create_directories(const DoutPrefixProvider* dpp, const std::string& dir_path)
 {
-    return location + "/" + key;
+    std::error_code ec;
+    if (!efs::exists(dir_path, ec)) {
+        if (!efs::create_directories(dir_path, ec)) {
+            ldpp_dout(dpp, 0) << "initialize::: ERROR creating directory: '" << dir_path <<
+                            "' : " << ec.value() << dendl;
+        } else {
+            uid_t uid = dpp->get_cct()->get_set_uid();
+            gid_t gid = dpp->get_cct()->get_set_gid();
+
+            ldpp_dout(dpp, 5) << "initialize:: uid is " << uid << " and gid is " << gid << dendl;
+            ldpp_dout(dpp, 5) << "initialize:: changing permissions for directory: " << dendl;
+
+            if (uid) { 
+                if (chown(dir_path.c_str(), uid, gid) == -1) {
+                    ldpp_dout(dpp, 5) << "initialize: chown return error: " << strerror(errno) << dendl;
+                }
+
+                if (chmod(dir_path.c_str(), S_IRWXU|S_IRWXG|S_IRWXO) == -1) {
+                    ldpp_dout(dpp, 5) << "initialize: chmod return error: " << strerror(errno) << dendl;
+                }
+            }
+        }
+    }
+}
+
+static std::string get_file_path(const DoutPrefixProvider* dpp, const std::string& dir_path, const std::string& file_name)
+{
+    return dir_path + "/" + file_name;
+}
+
+static std::string create_dirs_get_filepath_from_key(const DoutPrefixProvider* dpp, const std::string& location, const std::string& key, bool temp=false)
+{
+    std::string dir_path, file_name;
+    bool is_dirty;
+    parse_key(dpp, location, key, dir_path, file_name, is_dirty, temp);
+    create_directories(dpp, dir_path);
+    return get_file_path(dpp, dir_path, file_name);
+
 }
 
 int SSDDriver::initialize(const DoutPrefixProvider* dpp)
@@ -100,150 +195,172 @@ int SSDDriver::restore_blocks_objects(const DoutPrefixProvider* dpp, ObjectDataC
     if (dpp->get_cct()->_conf->rgw_d4n_l1_evict_cache_on_start) {
         return 0; //don't do anything as the cache directory must have been evicted during start-up
     }
-    for (auto const& dir_entry : std::filesystem::directory_iterator{partition_info.location}) {
-        ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): dir_entry.path: " << dir_entry.path() << dendl;
-        std::string file_name = dir_entry.path().filename();
-        std::vector<std::string> parts;
-        std::string part;
-        bool parsed = false;
-        ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): filename: " << file_name << dendl;
-        try {
-            std::stringstream ss(file_name);
-            while (std::getline(ss, part, CACHE_DELIM)) {
-                parts.push_back(part);
-            }
-            ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): parts.size(): " << parts.size() << dendl;
-            //non-dirty or clean blocks - bucket_id, version, object_name in head block and offset, len in data blocks
-            if (parts.size() == 3 || parts.size() == 5) {
-                std::string key = file_name;
-                ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): file_name: " << file_name << dendl;
+    std::string cache_location = partition_info.location;
+    if (cache_location.back() == '/') {
+        ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): cache_location: " << cache_location << dendl;
+        cache_location.pop_back();
+    }
+    for (auto const& dir_entry : efs::directory_iterator{partition_info.location}) {
+        std::string bucket_id, object_name;
+        if (dir_entry.is_directory()) {
+            ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): Is directory, path: " << dir_entry.path() << dendl;
+            ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): File Name: " << dir_entry.path().filename() << dendl;
+            bucket_id = dir_entry.path().filename();
+            for (auto const& sub_dir_entry : efs::directory_iterator{dir_entry.path()}) {
+                if (sub_dir_entry.is_directory()) {
+                    ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): Is directory, path: " << sub_dir_entry.path() << dendl;
+                    ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): File Name: " << sub_dir_entry.path().filename() << dendl;
+                    object_name = sub_dir_entry.path().filename();
+                    for (auto const& file_entry : efs::directory_iterator{sub_dir_entry.path()}) {
+                        try {
+                            if (file_entry.is_regular_file()) {
+                                ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): filename: " << file_entry.path().filename() << dendl;
+                                std::string file_name = file_entry.path().filename();
+                                bool parsed = false;
+                                std::vector<std::string> parts;
+                                std::string part;
+                                std::stringstream ss(file_name);
+                                while (std::getline(ss, part, CACHE_DELIM)) {
+                                    parts.push_back(part);
+                                }
+                                ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): parts.size(): " << parts.size() << dendl;
+                                //non-dirty or clean blocks - version in head block and offset, len in data blocks
+                                if (parts.size() == 1 || parts.size() == 3) {
+                                    std::string version = url_decode(parts[0]);
+                                    ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): version: " << version << dendl;
 
-                std::string version = url_decode(parts[1]);
-                ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): version: " << version << dendl;
+                                    std::string key = url_encode(bucket_id, true) + CACHE_DELIM + url_encode(version, true) + CACHE_DELIM + url_encode(object_name, true);
+                                    ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): key: " << key << dendl;
 
-                uint64_t offset = 0, len = 0;
-                if (parts.size() == 5) {
-                    offset = std::stoull(parts[3]);
-                    ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): offset: " << offset << dendl;
+                                    uint64_t offset = 0, len = 0;
+                                    if (parts.size() == 3) {
+                                        offset = std::stoull(parts[1]);
+                                        ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): offset: " << offset << dendl;
 
-                    len = std::stoull(parts[4]);
-                    ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): len: " << len << dendl;
-                }
-                std::string localWeightStr;
-                auto ret = get_attr(dpp, file_name, RGW_CACHE_ATTR_LOCAL_WEIGHT, localWeightStr, null_yield);
-                if (ret < 0) {
-                    ldpp_dout(dpp, 0) << "SSDCache: " << __func__ << "(): Failed to get attr: " << RGW_CACHE_ATTR_LOCAL_WEIGHT << dendl;
-                } else {
-                    ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): localWeightStr: " << localWeightStr << dendl;
-                }
-                block_func(dpp, key, offset, len, version, false, null_yield, localWeightStr);
-                parsed = true;
-            }
-            //dirty blocks - "D", bucket_id, version, object_name in head block and offset, len in data blocks
-            if ((parts.size() == 4 || parts.size() == 6) && parts[0] == "D") {
-                std::string prefix = DIRTY_BLOCK_PREFIX;
-                if (file_name.starts_with(prefix)) {
-                    std::string key = file_name.substr(prefix.length());
-                    ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): key: " << key << dendl;
+                                        len = std::stoull(parts[2]);
+                                        ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): len: " << len << dendl;
 
-                    bool dirty = true;
+                                        key = key + CACHE_DELIM + std::to_string(offset) + CACHE_DELIM + std::to_string(len);
+                                        ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): key: " << key << dendl;
+                                    }
+                                    std::string localWeightStr;
+                                    auto ret = get_attr(dpp, file_entry.path(), RGW_CACHE_ATTR_LOCAL_WEIGHT, localWeightStr, null_yield);
+                                    if (ret < 0) {
+                                        ldpp_dout(dpp, 0) << "SSDCache: " << __func__ << "(): Failed to get attr: " << RGW_CACHE_ATTR_LOCAL_WEIGHT << dendl;
+                                    } else {
+                                        ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): localWeightStr: " << localWeightStr << dendl;
+                                    }
+                                    block_func(dpp, key, offset, len, version, false, null_yield, localWeightStr);
+                                    parsed = true;
+                                }
+                                //dirty blocks - "D", version in head block and offset, len in data blocks
+                                if ((parts.size() == 2 || parts.size() == 4) && parts[0] == "D") {
+                                    std::string prefix = DIRTY_BLOCK_PREFIX;
+                                    if (file_name.starts_with(prefix)) {
+                                        bool dirty = true;
 
-                    std::string bucket_id = url_decode(parts[1]);
-                    ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): bucket_id: " << bucket_id << dendl;
+                                        std::string version = url_decode(parts[1]);
+                                        ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): version: " << version << dendl;
 
-                    std::string version = url_decode(parts[2]);
-                    ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): version: " << version << dendl;
+                                        std::string key = url_encode(bucket_id, true) + CACHE_DELIM + url_encode(version, true) + CACHE_DELIM + url_encode(object_name, true);
+                                        ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): key: " << key << dendl;
+                    
+                                        uint64_t len = 0, offset = 0;
+                                        std::string localWeightStr;
+                                        if (parts.size() == 2) {
+                                            rgw::sal::Attrs attrs;
+                                            get_attrs(dpp, file_entry.path(), attrs, null_yield);
+                                            std::string etag, bucket_name;
+                                            uint64_t size = 0;
+                                            time_t creationTime = time_t(nullptr);
+                                            rgw_user user;
+                                            rgw_obj_key obj_key;
+                                            if (attrs.find(RGW_ATTR_ETAG) != attrs.end()) {
+                                                etag = attrs[RGW_ATTR_ETAG].to_str();
+                                                ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): etag: " << etag << dendl;
+                                            }
+                                            if (attrs.find(RGW_CACHE_ATTR_OBJECT_SIZE) != attrs.end()) {
+                                                size = std::stoull(attrs[RGW_CACHE_ATTR_OBJECT_SIZE].to_str());
+                                                ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): size: " << size << dendl;
+                                            }
+                                            if (attrs.find(RGW_CACHE_ATTR_MTIME) != attrs.end()) {
+                                                creationTime = ceph::real_clock::to_time_t(ceph::real_clock::from_double(std::stod(attrs[RGW_CACHE_ATTR_MTIME].to_str())));
+                                                ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): creationTime: " << creationTime << dendl;
+                                            }
+                                            if (attrs.find(RGW_ATTR_ACL) != attrs.end()) {
+                                                bufferlist bl_acl = attrs[RGW_ATTR_ACL];
+                                                RGWAccessControlPolicy policy;
+                                                auto iter = bl_acl.cbegin();
+                                                try {
+                                                    policy.decode(iter);
+                                                } catch (buffer::error& err) {
+                                                    ldpp_dout(dpp, 0) << "ERROR: could not decode policy, caught buffer::error" << dendl;
+                                                    continue;
+                                                }
+                                                user = std::get<rgw_user>(policy.get_owner().id);
+                                                ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): rgw_user: " << user.to_str() << dendl;
+                                            }
+                                            obj_key.name = object_name;
+                                            if (attrs.find(RGW_CACHE_ATTR_VERSION_ID) != attrs.end()) {
+                                                std::string instance = attrs[RGW_CACHE_ATTR_VERSION_ID].to_str();
+                                                if (instance != "null") {
+                                                    obj_key.instance = instance;
+                                                }
+                                            }
+                                            if (attrs.find(RGW_CACHE_ATTR_OBJECT_NS) != attrs.end()) {
+                                                obj_key.ns = attrs[RGW_CACHE_ATTR_OBJECT_NS].to_str();
+                                            }
+                                            ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): rgw_obj_key: " << obj_key.get_oid() << dendl;
+                                            if (attrs.find(RGW_CACHE_ATTR_BUCKET_NAME) != attrs.end()) {
+                                                bucket_name = attrs[RGW_CACHE_ATTR_BUCKET_NAME].to_str();
+                                                ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): bucket_name: " << bucket_name << dendl;
+                                            }
 
-                    std::string obj_name = url_decode(parts[3]);
-                    ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): obj_name: " << obj_name << dendl;
+                                            if (attrs.find(RGW_CACHE_ATTR_LOCAL_WEIGHT) != attrs.end()) {
+                                                localWeightStr = attrs[RGW_CACHE_ATTR_LOCAL_WEIGHT].to_str();
+                                                ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): localWeightStr: " << localWeightStr << dendl;
+                                            }
 
-                    uint64_t len = 0, offset = 0;
-                    std::string localWeightStr;
-                    if (parts.size() == 4) {
-                        rgw::sal::Attrs attrs;
-                        get_attrs(dpp, file_name, attrs, null_yield);
-                        std::string etag, bucket_name;
-                        uint64_t size = 0;
-                        time_t creationTime = time_t(nullptr);
-                        rgw_user user;
-                        rgw_obj_key obj_key;
-                        if (attrs.find(RGW_ATTR_ETAG) != attrs.end()) {
-                            etag = attrs[RGW_ATTR_ETAG].to_str();
-                            ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): etag: " << etag << dendl;
-                        }
-                        if (attrs.find(RGW_CACHE_ATTR_OBJECT_SIZE) != attrs.end()) {
-                            size = std::stoull(attrs[RGW_CACHE_ATTR_OBJECT_SIZE].to_str());
-                            ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): size: " << size << dendl;
-                        }
-                        if (attrs.find(RGW_CACHE_ATTR_MTIME) != attrs.end()) {
-                            creationTime = ceph::real_clock::to_time_t(ceph::real_clock::from_double(std::stod(attrs[RGW_CACHE_ATTR_MTIME].to_str())));
-                            ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): creationTime: " << creationTime << dendl;
-                        }
-                        if (attrs.find(RGW_ATTR_ACL) != attrs.end()) {
-                            bufferlist bl_acl = attrs[RGW_ATTR_ACL];
-                            RGWAccessControlPolicy policy;
-                            auto iter = bl_acl.cbegin();
-                            try {
-                                policy.decode(iter);
-                            } catch (buffer::error& err) {
-                                ldpp_dout(dpp, 0) << "ERROR: could not decode policy, caught buffer::error" << dendl;
-                                continue;
+                                            ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): calling func for: " << key << dendl;
+                                            obj_func(dpp, key, version, dirty, size, creationTime, user, etag, bucket_name, bucket_id, obj_key, null_yield);
+                                            block_func(dpp, key, offset, len, version, dirty, null_yield, localWeightStr);
+                                            parsed = true;
+                                        } //end-if part.size() == 2
+                                        if (parts.size() == 4) {
+                                            offset = std::stoull(parts[2]);
+                                            ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): offset: " << offset << dendl;
+
+                                            len = std::stoull(parts[3]);
+                                            ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): len: " << len << dendl;
+
+                                            key = key + CACHE_DELIM + std::to_string(offset) + CACHE_DELIM + std::to_string(len);
+                                            ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): key: " << key << dendl;
+
+                                            std::string localWeightStr;
+                                            auto ret = get_attr(dpp, file_entry.path(), RGW_CACHE_ATTR_LOCAL_WEIGHT, localWeightStr, null_yield);
+                                            if (ret < 0) {
+                                                ldpp_dout(dpp, 0) << "SSDCache: " << __func__ << "(): Failed to get attr: " << RGW_CACHE_ATTR_LOCAL_WEIGHT << dendl;
+                                            } else {
+                                                ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): localWeightStr: " << localWeightStr << dendl;
+                                            }
+                                            block_func(dpp, key, offset, len, version, dirty, null_yield, localWeightStr);
+                                            parsed = true;
+                                        }
+                                    } //end-if file_name.starts_with
+                                } //end-if parts.size() == 2 || parts.size() == 4
+                                if (!parsed) {
+                                    ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): Unable to parse file_name: " << file_name << dendl;
+                                    continue;
+                                }
                             }
-                            user = std::get<rgw_user>(policy.get_owner().id);
-                            ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): rgw_user: " << user.to_str() << dendl;
+                        }//end - try
+                        catch(...) {
+                            ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): Execption while parsing entry: " << file_entry.path() << dendl;
+                            continue;
                         }
-                        obj_key.name = obj_name;
-                        if (attrs.find(RGW_CACHE_ATTR_VERSION_ID) != attrs.end()) {
-                            std::string instance = attrs[RGW_CACHE_ATTR_VERSION_ID].to_str();
-                            if (instance != "null") {
-                                obj_key.instance = instance;
-                            }
-                        }
-                        if (attrs.find(RGW_CACHE_ATTR_OBJECT_NS) != attrs.end()) {
-                            obj_key.ns = attrs[RGW_CACHE_ATTR_OBJECT_NS].to_str();
-                        }
-                        ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): rgw_obj_key: " << obj_key.get_oid() << dendl;
-                        if (attrs.find(RGW_CACHE_ATTR_BUCKET_NAME) != attrs.end()) {
-                            bucket_name = attrs[RGW_CACHE_ATTR_BUCKET_NAME].to_str();
-                            ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): bucket_name: " << bucket_name << dendl;
-                        }
-
-                        if (attrs.find(RGW_CACHE_ATTR_LOCAL_WEIGHT) != attrs.end()) {
-                            localWeightStr = attrs[RGW_CACHE_ATTR_LOCAL_WEIGHT].to_str();
-                            ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): localWeightStr: " << localWeightStr << dendl;
-                        }
-
-                        ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): calling func for: " << key << dendl;
-                        obj_func(dpp, key, version, dirty, size, creationTime, user, etag, bucket_name, bucket_id, obj_key, null_yield);
-                        block_func(dpp, key, offset, len, version, dirty, null_yield, localWeightStr);
-                        parsed = true;
-                    } //end-if part.size() == 4
-                    if (parts.size() == 6) {
-                        offset = std::stoull(parts[4]);
-                        ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): offset: " << offset << dendl;
-
-                        len = std::stoull(parts[5]);
-                        ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): len: " << len << dendl;
-                        std::string localWeightStr;
-                        auto ret = get_attr(dpp, file_name, RGW_CACHE_ATTR_LOCAL_WEIGHT, localWeightStr, null_yield);
-                        if (ret < 0) {
-                            ldpp_dout(dpp, 0) << "SSDCache: " << __func__ << "(): Failed to get attr: " << RGW_CACHE_ATTR_LOCAL_WEIGHT << dendl;
-                        } else {
-                            ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): localWeightStr: " << localWeightStr << dendl;
-                        }
-                        block_func(dpp, key, offset, len, version, dirty, null_yield, localWeightStr);
-                        parsed = true;
                     }
-                } //end-if file_name.starts_with
-            } //end-if parts.size() == 4 || parts.size() == 6
-            if (!parsed) {
-                ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): Unable to parse file_name: " << file_name << dendl;
-                continue;
+                }
             }
-        }//end-try
-        catch(...) {
-            ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): Execption while parsing file_name: " << file_name << dendl;
-            continue;
         }
     }
 
@@ -272,7 +389,7 @@ int SSDDriver::put(const DoutPrefixProvider* dpp, const std::string& key, const 
 int SSDDriver::get(const DoutPrefixProvider* dpp, const std::string& key, off_t offset, uint64_t len, bufferlist& bl, rgw::sal::Attrs& attrs, optional_yield y)
 {
     char buffer[len];
-    std::string location = get_file_path(partition_info.location, key);
+    std::string location = create_dirs_get_filepath_from_key(dpp, partition_info.location, key);
     ldpp_dout(dpp, 20) << __func__ << "(): location=" << location << dendl;
     FILE *cache_file = nullptr;
     int r = 0;
@@ -313,7 +430,7 @@ int SSDDriver::get(const DoutPrefixProvider* dpp, const std::string& key, off_t 
 int SSDDriver::append_data(const DoutPrefixProvider* dpp, const::std::string& key, const bufferlist& bl_data, optional_yield y)
 {
     bufferlist src = bl_data;
-    std::string location = get_file_path(partition_info.location, key);
+    std::string location = create_dirs_get_filepath_from_key(dpp, partition_info.location, key);
 
     ldpp_dout(dpp, 20) << __func__ << "(): location=" << location << dendl;
     FILE *cache_file = nullptr;
@@ -371,7 +488,7 @@ auto SSDDriver::get_async(const DoutPrefixProvider *dpp, const Executor& ex, con
     auto p = Op::create(ex, handler);
     auto& op = p->user_data;
 
-    std::string location = get_file_path(partition_info.location, key);
+    std::string location = create_dirs_get_filepath_from_key(dpp, partition_info.location, key);
     ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): location=" << location << dendl;
 
     int ret = op.prepare_libaio_read_op(dpp, location, read_ofs, read_len, p.get());
@@ -401,20 +518,19 @@ void SSDDriver::put_async(const DoutPrefixProvider *dpp, const Executor& ex, con
     auto p = Op::create(ex, handler);
     auto& op = p->user_data;
 
-    std::string location = get_file_path(partition_info.location, key);
-    ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): location=" << location << dendl;
+    op.file_path = create_dirs_get_filepath_from_key(dpp, partition_info.location, key);
+    ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): op.file_path=" << op.file_path << dendl;
+
+    op.temp_file_path = create_dirs_get_filepath_from_key(dpp, partition_info.location, key, true);
+    ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): op.temp_file_path=" << op.temp_file_path << dendl;
 
     int r = 0;
     bufferlist src = bl;
-    std::string temp_key = key + "_" + std::to_string(index++);
-    ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): temp key=" << temp_key << dendl;
-    r = op.prepare_libaio_write_op(dpp, src, len, temp_key, partition_info.location);
+    r = op.prepare_libaio_write_op(dpp, src, len, op.temp_file_path);
     op.cb->aio_sigevent.sigev_notify = SIGEV_THREAD;
     op.cb->aio_sigevent.sigev_notify_function = SSDDriver::AsyncWriteRequest::libaio_write_cb;
     op.cb->aio_sigevent.sigev_notify_attributes = nullptr;
     op.cb->aio_sigevent.sigev_value.sival_ptr = (void*)p.get();
-    op.key = key;
-    op.temp_key = temp_key;
     op.dpp = dpp;
     op.priv_data = this;
     op.attrs = std::move(attrs);
@@ -427,7 +543,7 @@ void SSDDriver::put_async(const DoutPrefixProvider *dpp, const Executor& ex, con
     ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): ::aio_write(), r=" << r << dendl;
     if(r < 0) {
         auto ec = boost::system::error_code{-r, boost::system::system_category()};
-        ceph::async::post(std::move(p), ec);
+        ceph::async::dispatch(std::move(p), ec);
     } else {
         (void)p.release();
     }
@@ -480,13 +596,39 @@ rgw::AioResultList SSDDriver::put_async(const DoutPrefixProvider* dpp, optional_
 
 int SSDDriver::delete_data(const DoutPrefixProvider* dpp, const::std::string& key, optional_yield y)
 {
-    std::string location = get_file_path(partition_info.location, key);
+    std::string dir_path, file_name;
+    bool is_dirty;
+    parse_key(dpp, partition_info.location, key, dir_path, file_name, is_dirty);
+    std::string location = get_file_path(dpp, dir_path, file_name);
+    ldpp_dout(dpp, 20) << "INFO: delete_data::file to remove: " << location << dendl;
 
+    //Remove file
     if (!efs::remove(location)) {
         ldpp_dout(dpp, 0) << "ERROR: delete_data::remove has failed to remove the file: " << location << dendl;
         return -EIO;
     }
 
+    //Remove directory if empty, removes object directory
+    if (efs::is_empty(dir_path)) {
+        ldpp_dout(dpp, 20) << "INFO: delete_data::object directory to remove: " << dir_path << dendl;
+        if (!efs::remove(dir_path)) {
+            ldpp_dout(dpp, 0) << "ERROR: delete_data::remove has failed to remove the directory: " << dir_path << dendl;
+            return -EIO;
+        }
+    }
+    auto pos = dir_path.find_last_of('/');
+    if (pos != std::string::npos) {
+        dir_path.erase(pos, (dir_path.length() - pos));
+
+        //Remove bucket directory
+        if (efs::is_empty(dir_path)) {
+            ldpp_dout(dpp, 20) << "INFO: delete_data::bucket directory to remove: " << dir_path << dendl;
+            if (!efs::remove(dir_path)) {
+                ldpp_dout(dpp, 0) << "ERROR: delete_data::remove has failed to remove the directory: " << dir_path << dendl;
+                return -EIO;
+            }
+        }
+    }
     efs::space_info space = efs::space(partition_info.location);
     this->free_space = space.available;
 
@@ -495,8 +637,8 @@ int SSDDriver::delete_data(const DoutPrefixProvider* dpp, const::std::string& ke
 
 int SSDDriver::rename(const DoutPrefixProvider* dpp, const::std::string& oldKey, const::std::string& newKey, optional_yield y)
 { 
-    std::string old_file_path = get_file_path(partition_info.location, oldKey);
-    std::string new_file_path = get_file_path(partition_info.location, newKey);
+    std::string old_file_path = create_dirs_get_filepath_from_key(dpp, partition_info.location, oldKey);
+    std::string new_file_path = create_dirs_get_filepath_from_key(dpp, partition_info.location, newKey);
     int ret = std::rename(old_file_path.c_str(), new_file_path.c_str());
     if (ret < 0) {
         ldpp_dout(dpp, 0) << "SSDDriver: ERROR: failed to rename the file: " << old_file_path << dendl;
@@ -507,17 +649,16 @@ int SSDDriver::rename(const DoutPrefixProvider* dpp, const::std::string& oldKey,
 }
 
 
-int SSDDriver::AsyncWriteRequest::prepare_libaio_write_op(const DoutPrefixProvider *dpp, bufferlist& bl, unsigned int len, std::string key, std::string cache_location)
+int SSDDriver::AsyncWriteRequest::prepare_libaio_write_op(const DoutPrefixProvider *dpp, bufferlist& bl, unsigned int len, std::string file_path)
 {
-    std::string location = get_file_path(cache_location, key);
     int r = 0;
-    ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): Write To Cache, location=" << location << dendl;
+    ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): Write To Cache, location=" << file_path << dendl;
     cb.reset(new struct aiocb);
     memset(cb.get(), 0, sizeof(struct aiocb));
     mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
-    r = fd = TEMP_FAILURE_RETRY(::open(location.c_str(), O_WRONLY | O_CREAT | O_TRUNC, mode));
+    r = fd = TEMP_FAILURE_RETRY(::open(file_path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, mode));
     if (fd < 0) {
-        ldpp_dout(dpp, 0) << "ERROR: AsyncWriteRequest::prepare_libaio_write_op: open file failed, errno=" << errno << ", location='" << location.c_str() << "'" << dendl;
+        ldpp_dout(dpp, 0) << "ERROR: AsyncWriteRequest::prepare_libaio_write_op: open file failed, errno=" << errno << ", location='" << file_path.c_str() << "'" << dendl;
         return r;
     }
     if (dpp->get_cct()->_conf->rgw_d4n_l1_fadvise != POSIX_FADV_NORMAL)
@@ -539,7 +680,7 @@ int SSDDriver::AsyncWriteRequest::prepare_libaio_write_op(const DoutPrefixProvid
 void SSDDriver::AsyncWriteRequest::libaio_write_cb(sigval sigval) {
     auto p = std::unique_ptr<Completion>{static_cast<Completion*>(sigval.sival_ptr)};
     auto op = std::move(p->user_data);
-    ldpp_dout(op.dpp, 20) << "INFO: AsyncWriteRequest::libaio_write_cb: key: " << op.key << dendl;
+    ldpp_dout(op.dpp, 20) << "INFO: AsyncWriteRequest::libaio_write_cb: key: " << op.file_path << dendl;
     int ret = -aio_error(op.cb.get());
     boost::system::error_code ec;
     if (ret < 0) {
@@ -551,7 +692,7 @@ void SSDDriver::AsyncWriteRequest::libaio_write_cb(sigval sigval) {
     if (op.attrs.size() > 0) {
         //TODO - fix yield_context
         optional_yield y{null_yield};
-        attr_ret = op.priv_data->set_attrs(op.dpp, op.temp_key, op.attrs, y);
+        attr_ret = op.priv_data->set_attrs(op.dpp, op.temp_file_path, op.attrs, y);
         if (attr_ret < 0) {
             ldpp_dout(op.dpp, 0) << "ERROR: AsyncWriteRequest::libaio_write_yield_cb::set_attrs: failed to set attrs, ret = " << attr_ret << dendl;
             ec.assign(-ret, boost::system::system_category());
@@ -564,11 +705,10 @@ void SSDDriver::AsyncWriteRequest::libaio_write_cb(sigval sigval) {
     efs::space_info space = efs::space(partition_info.location);
     op.priv_data->set_free_space(op.dpp, space.available);
 
-    std::string new_path = get_file_path(partition_info.location, op.key);
-    std::string old_path = get_file_path(partition_info.location, op.temp_key);
-    ldpp_dout(op.dpp, 20) << "INFO: AsyncWriteRequest::libaio_write_yield_cb: temp_key: " << op.temp_key << dendl;
+    ldpp_dout(op.dpp, 20) << "INFO: AsyncWriteRequest::libaio_write_yield_cb: new_path: " << op.file_path << dendl;
+    ldpp_dout(op.dpp, 20) << "INFO: AsyncWriteRequest::libaio_write_yield_cb: old_path: " << op.temp_file_path << dendl;
 
-    ret = std::rename(old_path.c_str(), new_path.c_str());
+    ret = std::rename(op.temp_file_path.c_str(), op.file_path.c_str());
     if (ret < 0) {
         ret = errno;
         ldpp_dout(op.dpp, 0) << "ERROR: put::rename: failed to rename file: " << ret << dendl;
@@ -621,7 +761,7 @@ void SSDDriver::AsyncReadOp::libaio_cb_aio_dispatch(sigval sigval)
 
 int SSDDriver::update_attrs(const DoutPrefixProvider* dpp, const std::string& key, const rgw::sal::Attrs& attrs, optional_yield y)
 {
-    std::string location = get_file_path(partition_info.location, key);
+    std::string location = create_dirs_get_filepath_from_key(dpp, partition_info.location, key);
     ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): location=" << location << dendl;
 
     for (auto& it : attrs) {
@@ -646,7 +786,7 @@ int SSDDriver::update_attrs(const DoutPrefixProvider* dpp, const std::string& ke
 
 int SSDDriver::delete_attrs(const DoutPrefixProvider* dpp, const std::string& key, rgw::sal::Attrs& del_attrs, optional_yield y)
 {
-    std::string location = get_file_path(partition_info.location, key);
+    std::string location = create_dirs_get_filepath_from_key(dpp, partition_info.location, key);
     ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): location=" << location << dendl;
 
     for (auto& it : del_attrs) {
@@ -665,7 +805,14 @@ int SSDDriver::delete_attrs(const DoutPrefixProvider* dpp, const std::string& ke
 
 int SSDDriver::get_attrs(const DoutPrefixProvider* dpp, const std::string& key, rgw::sal::Attrs& attrs, optional_yield y)
 {
-    std::string location = get_file_path(partition_info.location, key);
+    std::string location;
+    // a hack to avoid calling create_dirs_get_filepath_from_key in case the path is already formed
+    if(key.find(partition_info.location, 0) == 0) {
+        location = key;
+    } else {
+        location = create_dirs_get_filepath_from_key(dpp, partition_info.location, key);
+    }
+
     ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): location=" << location << dendl;
 
     char namebuf[64 * 1024];
@@ -689,7 +836,7 @@ int SSDDriver::get_attrs(const DoutPrefixProvider* dpp, const std::string& key, 
             continue;
         }
         std::string attr_value;
-        get_attr(dpp, key, attr_name, attr_value, y);
+        get_attr(dpp, location, attr_name, attr_value, y);
         bufferlist bl_value;
         bl_value.append(attr_value);
         attrs.emplace(std::move(attr_name), std::move(bl_value));
@@ -699,7 +846,14 @@ int SSDDriver::get_attrs(const DoutPrefixProvider* dpp, const std::string& key, 
 
 int SSDDriver::set_attrs(const DoutPrefixProvider* dpp, const std::string& key, const rgw::sal::Attrs& attrs, optional_yield y)
 {
-    std::string location = get_file_path(partition_info.location, key);
+    std::string location;
+    // a hack to avoid calling create_dirs_get_filepath_from_key in case the path is already formed
+    if(key.find(partition_info.location, 0) == 0) {
+        location = key;
+    } else {
+        location = create_dirs_get_filepath_from_key(dpp, partition_info.location, key);
+    }
+
     ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): location=" << location << dendl;
 
     for (auto& [attr_name, attr_val_bl] : attrs) {
@@ -721,7 +875,14 @@ int SSDDriver::set_attrs(const DoutPrefixProvider* dpp, const std::string& key, 
 
 int SSDDriver::get_attr(const DoutPrefixProvider* dpp, const std::string& key, const std::string& attr_name, std::string& attr_val, optional_yield y)
 {
-    std::string location = get_file_path(partition_info.location, key);
+    std::string location;
+    // a hack to avoid calling create_dirs_get_filepath_from_key in case the path is already formed
+    if(key.find(partition_info.location, 0) == 0) {
+        location = key;
+    } else {
+        location = create_dirs_get_filepath_from_key(dpp, partition_info.location, key);
+    }
+
     ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): location=" << location << dendl;
 
     ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): get_attr: key: " << attr_name << dendl;
@@ -752,7 +913,14 @@ int SSDDriver::get_attr(const DoutPrefixProvider* dpp, const std::string& key, c
 
 int SSDDriver::set_attr(const DoutPrefixProvider* dpp, const std::string& key, const std::string& attr_name, const std::string& attr_val, optional_yield y)
 {
-    std::string location = get_file_path(partition_info.location, key);
+    std::string location;
+    // a hack to avoid calling create_dirs_get_filepath_from_key in case the path is already formed
+    if(key.find(partition_info.location, 0) == 0) {
+        location = key;
+    } else {
+        location = create_dirs_get_filepath_from_key(dpp, partition_info.location, key);
+    }
+
     ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): location=" << location << dendl;
 
     ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): set_attr: key: " << attr_name << " val: " << attr_val << dendl;
@@ -771,7 +939,7 @@ int SSDDriver::set_attr(const DoutPrefixProvider* dpp, const std::string& key, c
 
 int SSDDriver::delete_attr(const DoutPrefixProvider* dpp, const std::string& key, const std::string& attr_name)
 {
-    std::string location = get_file_path(partition_info.location, key);
+    std::string location = create_dirs_get_filepath_from_key(dpp, partition_info.location, key);
     ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): location=" << location << dendl;
 
     auto ret = removexattr(location.c_str(), attr_name.c_str());

--- a/src/rgw/rgw_ssd_driver.h
+++ b/src/rgw/rgw_ssd_driver.h
@@ -39,7 +39,6 @@ private:
   Partition partition_info;
   uint64_t free_space;
   CephContext* cct;
-  inline static std::atomic<uint64_t> index{0};
 
   struct libaio_read_handler {
     rgw::Aio* throttle = nullptr;
@@ -104,8 +103,8 @@ private:
 
   struct AsyncWriteRequest {
     const DoutPrefixProvider* dpp;
-	  std::string key;
-    std::string temp_key;
+	  std::string file_path;
+    std::string temp_file_path;
 	  void *data;
 	  int fd;
 	  unique_aio_cb_ptr cb;
@@ -115,7 +114,7 @@ private:
     using Signature = void(boost::system::error_code);
     using Completion = ceph::async::Completion<Signature, AsyncWriteRequest>;
 
-	  int prepare_libaio_write_op(const DoutPrefixProvider *dpp, bufferlist& bl, unsigned int len, std::string key, std::string cache_location);
+	  int prepare_libaio_write_op(const DoutPrefixProvider *dpp, bufferlist& bl, unsigned int len, std::string file_path);
     static void libaio_write_cb(sigval sigval);
 
     template <typename Executor1, typename CompletionHandler>

--- a/src/rgw/rgw_ssd_driver.h
+++ b/src/rgw/rgw_ssd_driver.h
@@ -30,8 +30,8 @@ public:
 
   /* Partition */
   virtual Partition get_current_partition_info(const DoutPrefixProvider* dpp) override { return partition_info; }
-  virtual uint64_t get_free_space(const DoutPrefixProvider* dpp) override { return free_space; }
-  void set_free_space(const DoutPrefixProvider* dpp, uint64_t free_space) { this->free_space = free_space; }
+  virtual uint64_t get_free_space(const DoutPrefixProvider* dpp) override;
+  void set_free_space(const DoutPrefixProvider* dpp, uint64_t free_space);
 
   virtual int restore_blocks_objects(const DoutPrefixProvider* dpp, ObjectDataCallback obj_func, BlockDataCallback block_func) override;
 
@@ -39,6 +39,7 @@ private:
   Partition partition_info;
   uint64_t free_space;
   CephContext* cct;
+  std::mutex cache_lock;
 
   struct libaio_read_handler {
     rgw::Aio* throttle = nullptr;

--- a/src/test/rgw/test_d4n_directory.cc
+++ b/src/test/rgw/test_d4n_directory.cc
@@ -699,10 +699,18 @@ TEST_F(BlockDirectoryFixture, MultiExecuteYield)
       }
       {
         request req;
+        response<std::string> resp;
+        req.push("ZADD", "key4", "1", "v1");                  // Command 3
+        conn->async_exec(req, resp, yield[ec]);
+        ASSERT_EQ((bool)ec, false);
+        std::cout << "ZADD value: " << std::get<0>(resp).value() << std::endl;
+      }
+      {
+        request req;
         //string as response here as the command is only getting queued, not executed
         //if response type is changed to int then the operation fails
         response<std::string> resp;
-        req.push("DEL", "key3");                  // Command 3
+        req.push("DEL", "key3");                  // Command 4
         conn->async_exec(req, resp, yield[ec]);
         ASSERT_EQ((bool)ec, false);
         std::cout << "DEL value: " << std::get<0>(resp).value() << std::endl;
@@ -728,6 +736,8 @@ TEST_F(BlockDirectoryFixture, MultiExecuteYield)
       ASSERT_EQ(0, dir->set(env->dpp, block, yield));
       block->cacheObj.objName = "testBlockA";
       ASSERT_EQ(0, dir->del(env->dpp, block, yield, true));
+      block->cacheObj.objName = "testBlockB";
+      ASSERT_EQ(0, dir->zadd(env->dpp, block, 100, "version1", yield, true));
       std::vector<std::string> responses;
       ASSERT_EQ(0, dir->exec(env->dpp, responses, optional_yield{yield}));
       for (auto r : responses) {

--- a/src/test/rgw/test_d4n_directory.cc
+++ b/src/test/rgw/test_d4n_directory.cc
@@ -102,7 +102,6 @@ class BlockDirectoryFixture: public ::testing::Test {
         .blockID = 0,
 	.version = "",
 	.deleteMarker = false,
-	.prevVersion = {},
 	.size = 0
       };
 
@@ -129,9 +128,9 @@ class BlockDirectoryFixture: public ::testing::Test {
     net::io_context io;
     std::shared_ptr<connection> conn;
 
-    std::vector<std::string> vals{"0", "", "0", "", "0", "0", 
+    std::vector<std::string> vals{"0", "", "0", "0", "0", 
                                    "testName", "testBucket", "", "0", env->redisHost};
-    std::vector<std::string> fields{"blockID", "version", "deleteMarker", "prevVersion", "size", "globalWeight", 
+    std::vector<std::string> fields{"blockID", "version", "deleteMarker", "size", "globalWeight", 
 				     "objName", "bucketName", "creationTime", "dirty", "hosts"};
 };
 

--- a/src/test/rgw/test_d4n_directory.cc
+++ b/src/test/rgw/test_d4n_directory.cc
@@ -293,6 +293,100 @@ TEST_F(ObjectDirectoryFixture, UpdateFieldYield)
   io.run();
 }
 
+TEST_F(ObjectDirectoryFixture, ZAddYield)
+{
+  boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
+    auto m_time = real_clock::now();
+    auto score = ceph::real_clock::to_double(m_time);
+    std::string version = "v1";
+    ASSERT_EQ(0, dir->zadd(env->dpp, obj, score, version, yield));
+    {
+      boost::system::error_code ec;
+      request req;
+      req.push("FLUSHALL");
+      response<boost::redis::ignore_t> resp;
+      conn->async_exec(req, resp, yield[ec]);
+      ASSERT_EQ((bool)ec, false);
+    }
+    conn->cancel();
+  }, rethrow);
+
+  io.run();
+}
+
+TEST_F(ObjectDirectoryFixture, ZAddZRevRangeYield)
+{
+  boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
+    {
+      auto m_time = real_clock::now();
+      auto score = ceph::real_clock::to_double(m_time);
+      std::string version = "v2";
+      ASSERT_EQ(0, dir->zadd(env->dpp, obj, score, version, yield));
+    }
+    {
+      auto m_time = real_clock::now();
+      auto score = ceph::real_clock::to_double(m_time);
+      std::string version = "v1";
+      ASSERT_EQ(0, dir->zadd(env->dpp, obj, score, version, yield));
+    }
+    {
+      std::vector<std::string> members;
+      ASSERT_EQ(0, dir->zrevrange(env->dpp, obj, 0, 0, members, yield));
+      ASSERT_EQ(1, members.size());
+      ASSERT_EQ("v1", members[0]);
+    }
+
+    {
+      boost::system::error_code ec;
+      request req;
+      req.push("FLUSHALL");
+      response<boost::redis::ignore_t> resp;
+      conn->async_exec(req, resp, yield[ec]);
+      ASSERT_EQ((bool)ec, false);
+    }
+    conn->cancel();
+  }, rethrow);
+
+  io.run();
+}
+
+TEST_F(ObjectDirectoryFixture, ZAddZRemYield)
+{
+  boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
+    {
+      auto m_time = real_clock::now();
+      auto score = ceph::real_clock::to_double(m_time);
+      std::cout << "Score for v1: " << score << std::endl;
+      std::string version = "v1";
+      ASSERT_EQ(0, dir->zadd(env->dpp, obj, score, version, yield));
+    }
+    {
+      auto m_time = real_clock::now();
+      auto score = ceph::real_clock::to_double(m_time);
+      std::cout << "Score for v2: " << score << std::endl;
+      std::string version = "v2";
+      ASSERT_EQ(0, dir->zadd(env->dpp, obj, score, version, yield));
+    }
+    {
+      ASSERT_EQ(0, dir->zrem(env->dpp, obj, "v2", yield));
+      std::vector<std::string> members;
+      ASSERT_EQ(0, dir->zrevrange(env->dpp, obj, 0, 0, members, yield));
+      ASSERT_EQ(1, members.size());
+      ASSERT_EQ("v1", members[0]);
+    }
+    {
+      boost::system::error_code ec;
+      request req;
+      req.push("FLUSHALL");
+      response<boost::redis::ignore_t> resp;
+      conn->async_exec(req, resp, yield[ec]);
+      ASSERT_EQ((bool)ec, false);
+    }
+    conn->cancel();
+  }, rethrow);
+
+  io.run();
+}
 
 TEST_F(BlockDirectoryFixture, SetYield)
 {

--- a/src/test/rgw/test_d4n_directory.cc
+++ b/src/test/rgw/test_d4n_directory.cc
@@ -585,6 +585,170 @@ TEST_F(BlockDirectoryFixture, RemoveHostYield)
   io.run();
 }
 
+TEST_F(BlockDirectoryFixture, WatchExecuteYield)
+{
+  boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
+  {
+    boost::system::error_code ec;
+    request req;
+    req.push("WATCH", "testBucket");
+    response<std::string> resp;
+
+    conn->async_exec(req, resp, yield[ec]);
+    ASSERT_EQ((bool)ec, false);
+
+    // The number of members added
+    EXPECT_EQ(std::get<0>(resp).value(), "OK");
+  }
+
+  {
+      boost::system::error_code ec;
+      request req;
+      req.push("HSET", "testBucket", "objName", "newoid");
+      response<int> resp;
+
+      conn->async_exec(req, resp, yield[ec]);
+
+      ASSERT_EQ((bool)ec, false);
+      EXPECT_EQ(std::get<0>(resp).value(), 1);
+  }
+
+  {
+      boost::system::error_code ec;
+      request req;
+      req.push("EXEC");
+      response<std::vector<std::string> > resp;
+
+      conn->async_exec(req, resp, yield[ec]);
+
+      ASSERT_EQ((bool)ec, false);
+  }
+
+  {
+      boost::system::error_code ec;
+      request req;
+      req.push("FLUSHALL");
+      response<boost::redis::ignore_t> resp;
+
+      conn->async_exec(req, resp, yield[ec]);
+  }
+
+  conn->cancel();
+  }, rethrow);
+
+  io.run();
+}
+
+TEST_F(BlockDirectoryFixture, IncrYield)
+{
+  boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
+    for (int i = 0; i < 10; i++) {
+      {
+        boost::system::error_code ec;
+        request req;
+        req.push("INCR", "testObject");
+        response<std::string> resp;
+
+        conn->async_exec(req, resp, yield[ec]);
+        ASSERT_EQ((bool)ec, false);
+        std::cout << "thread id: " << std::this_thread::get_id() << std::endl;
+        std::cout << "INCR value: " << std::get<0>(resp).value() << std::endl;
+      }
+    }
+    boost::asio::post(conn->get_executor(), [c = conn] { c->cancel(); });
+  }, rethrow);
+
+  std::vector<std::thread> threads;
+
+  for (int i = 0; i < 10; ++i) {
+    threads.emplace_back([&] { io.run(); });
+  }
+  for (auto& thread : threads) {
+    thread.join();
+  }
+}
+
+TEST_F(BlockDirectoryFixture, MultiExecuteYield)
+{
+  boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
+    {
+      boost::system::error_code ec;
+      {
+        request req;
+        response<std::string> resp;
+        req.push("MULTI");                       // Start transaction
+        conn->async_exec(req, resp, yield[ec]);
+        ASSERT_EQ((bool)ec, false);
+        std::cout << "MULTI value: " << std::get<0>(resp).value() << std::endl;
+      }
+      {
+        request req;
+        response<std::string> resp;
+        req.push("SET", "key1", "value1");       // Command 1
+        conn->async_exec(req, resp, yield[ec]);
+        ASSERT_EQ((bool)ec, false);
+        std::cout << "SET value: " << std::get<0>(resp).value() << std::endl;
+      }
+      {
+        request req;
+        response<std::string> resp;
+        req.push("SET", "key2", "value2");       // Command 2
+        conn->async_exec(req, resp, yield[ec]);
+        ASSERT_EQ((bool)ec, false);
+        std::cout << "SET value: " << std::get<0>(resp).value() << std::endl;
+      }
+      {
+        request req;
+        //string as response here as the command is only getting queued, not executed
+        //if response type is changed to int then the operation fails
+        response<std::string> resp;
+        req.push("DEL", "key3");                  // Command 3
+        conn->async_exec(req, resp, yield[ec]);
+        ASSERT_EQ((bool)ec, false);
+        std::cout << "DEL value: " << std::get<0>(resp).value() << std::endl;
+      }
+      {
+        request req;
+        req.push("EXEC");                        // Execute transaction
+
+        boost::redis::generic_response resp;
+        conn->async_exec(req, resp, yield[ec]);
+        ASSERT_EQ((bool)ec, false);
+        for (uint64_t i = 0; i < resp.value().size(); i++) {
+          std::cout << "EXEC: " << resp.value().front().value << std::endl;
+          boost::redis::consume_one(resp);
+        }
+      }
+    }
+    //test multi/exec using directory methods
+    {
+      ASSERT_EQ(0, dir->multi(env->dpp, optional_yield{yield}));
+      ASSERT_EQ(0, dir->set(env->dpp, block, yield));
+      block->cacheObj.objName = "testBlockNew";
+      ASSERT_EQ(0, dir->set(env->dpp, block, yield));
+      block->cacheObj.objName = "testBlockA";
+      ASSERT_EQ(0, dir->del(env->dpp, block, yield, true));
+      std::vector<std::string> responses;
+      ASSERT_EQ(0, dir->exec(env->dpp, responses, optional_yield{yield}));
+      for (auto r : responses) {
+        std::cout << "EXEC: " << r << std::endl;
+      }
+    }
+    {
+      boost::system::error_code ec;
+      request req;
+      req.push("FLUSHALL");
+      response<boost::redis::ignore_t> resp;
+
+      conn->async_exec(req, resp, yield[ec]);
+    }
+
+    conn->cancel();
+  }, rethrow);
+
+  io.run();
+}
+
 int main(int argc, char *argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
 

--- a/src/test/rgw/test_d4n_policy.cc
+++ b/src/test/rgw/test_d4n_policy.cc
@@ -212,7 +212,6 @@ TEST_F(LFUDAPolicyFixture, RemoteGetBlockYield)
       .blockID = 0,
       .version = "",
       .deleteMarker = false,
-      .prevVersion = {},
       .size = bl.length(),
       .globalWeight = 5,
     };

--- a/src/test/rgw/test_d4n_policy.cc
+++ b/src/test/rgw/test_d4n_policy.cc
@@ -56,7 +56,7 @@ class LFUDAPolicyFixture : public ::testing::Test {
 	  .hostsList = { env->redisHost }
 	},
         .blockID = 0,
-	.version = "",
+	.version = "version",
 	.deleteMarker = false,
 	.size = bl.length(),
 	.globalWeight = 0
@@ -99,7 +99,7 @@ class LFUDAPolicyFixture : public ::testing::Test {
     }
 
     std::string build_index(std::string bucketName, std::string oid, uint64_t offset, uint64_t size) {
-      return bucketName + "_" + oid + "_" + std::to_string(offset) + "_" + std::to_string(size);
+      return bucketName + "#" + oid + "#" + std::to_string(offset) + "#" + std::to_string(size);
     }
 
     int lfuda(const DoutPrefixProvider* dpp, rgw::d4n::CacheBlock* block, rgw::cache::CacheDriver* cacheDriver, optional_yield y) {
@@ -169,7 +169,7 @@ TEST_F(LFUDAPolicyFixture, LocalGetBlockYield)
     dynamic_cast<rgw::d4n::LFUDAPolicy*>(policyDriver->get_cache_policy())->save_y(optional_yield{yield});
     policyDriver->get_cache_policy()->init(env->cct, env->dpp, io, driver);
 
-    std::string key = block->cacheObj.bucketName + "_" + block->cacheObj.objName + "_" + std::to_string(block->blockID) + "_" + std::to_string(block->size);
+    std::string key = block->cacheObj.bucketName + "#" + block->cacheObj.objName + "#" + std::to_string(block->blockID) + "#" + std::to_string(block->size);
     ASSERT_EQ(0, cacheDriver->put(env->dpp, key, bl, bl.length(), attrs, optional_yield{yield}));
     policyDriver->get_cache_policy()->update(env->dpp, key, 0, bl.length(), "", false, rgw::d4n::REFCOUNT_NOOP, optional_yield{yield});
 
@@ -179,7 +179,7 @@ TEST_F(LFUDAPolicyFixture, LocalGetBlockYield)
 
     boost::system::error_code ec;
     request req;
-    req.push("HGET", "RedisCache/testBucket_testName_0_0", RGW_CACHE_ATTR_LOCAL_WEIGHT);
+    req.push("HGET", "RedisCache/testBucket#testName#0#0", RGW_CACHE_ATTR_LOCAL_WEIGHT);
     req.push("FLUSHALL");
 
     response<std::string, boost::redis::ignore_t> resp;
@@ -210,7 +210,7 @@ TEST_F(LFUDAPolicyFixture, RemoteGetBlockYield)
 	.hostsList = { env->redisHost }
       },
       .blockID = 0,
-      .version = "",
+      .version = "version",
       .deleteMarker = false,
       .size = bl.length(),
       .globalWeight = 5,
@@ -229,8 +229,14 @@ TEST_F(LFUDAPolicyFixture, RemoteGetBlockYield)
 
     ASSERT_EQ(0, dir->set(env->dpp, &victim, optional_yield{yield}));
     std::string victimKey = victim.cacheObj.bucketName + "_version_" + victim.cacheObj.objName + "_" + std::to_string(victim.blockID) + "_" + std::to_string(victim.size);
-    ASSERT_EQ(0, cacheDriver->put(env->dpp, victimKey, bl, bl.length(), attrs, optional_yield{yield}));
-    policyDriver->get_cache_policy()->update(env->dpp, victimKey, 0, bl.length(), "", false, rgw::d4n::REFCOUNT_NOOP, optional_yield{yield});
+    std::string victimKeyInCache = victim.cacheObj.bucketName + "#version#" + victim.cacheObj.objName + "#" + std::to_string(victim.blockID) + "#" + std::to_string(victim.size);
+    ASSERT_EQ(0, cacheDriver->put(env->dpp, victimKeyInCache, bl, bl.length(), attrs, optional_yield{yield}));
+    policyDriver->get_cache_policy()->update(env->dpp, victimKeyInCache, 0, bl.length(), "", false, rgw::d4n::REFCOUNT_NOOP, optional_yield{yield});
+
+    /* Set head blocks */
+    std::string victimHeadObj = victim.cacheObj.bucketName + "#version#" + victim.cacheObj.objName + "#0#0";
+    ASSERT_EQ(0, cacheDriver->put(env->dpp, victimHeadObj, bl, bl.length(), attrs, optional_yield{yield}));
+    policyDriver->get_cache_policy()->update(env->dpp, victimHeadObj, 0, bl.length(), "", false, rgw::d4n::REFCOUNT_NOOP, optional_yield{yield});
 
     /* Remote block */
     block->size = cacheDriver->get_free_space(env->dpp) + 1; /* To trigger eviction */
@@ -258,12 +264,12 @@ TEST_F(LFUDAPolicyFixture, RemoteGetBlockYield)
     std::string key = block->cacheObj.bucketName + "_" + block->cacheObj.objName + "_" + std::to_string(block->blockID) + "_" + std::to_string(block->size);
     boost::system::error_code ec;
     request req;
-    req.push("EXISTS", "RedisCache/" + victimKey);
+    req.push("EXISTS", "RedisCache/" + victimKeyInCache);
     req.push("EXISTS", victimKey, "globalWeight");
     req.push("HGET", key, "globalWeight");
     req.push("FLUSHALL");
 
-    response<int, int, std::string, std::string, 
+    response<int, int, std::string, 
              boost::redis::ignore_t> resp;
 
     conn->async_exec(req, resp, yield[ec]);

--- a/src/test/rgw/test_d4n_policy.cc
+++ b/src/test/rgw/test_d4n_policy.cc
@@ -107,7 +107,7 @@ class LFUDAPolicyFixture : public ::testing::Test {
       std::string oid = build_index(block->cacheObj.bucketName, block->cacheObj.objName, block->blockID, block->size);
 
       if (this->policyDriver->get_cache_policy()->exist_key(build_index(block->cacheObj.bucketName, block->cacheObj.objName, block->blockID, block->size))) { /* Local copy */
-	policyDriver->get_cache_policy()->update(env->dpp, oid, 0, bl.length(), "", false, y);
+	policyDriver->get_cache_policy()->update(env->dpp, oid, 0, bl.length(), "", false, rgw::d4n::REFCOUNT_NOOP, y);
         return 0;
       } else {
 	if (this->policyDriver->get_cache_policy()->eviction(dpp, block->size, y) < 0)
@@ -135,7 +135,7 @@ class LFUDAPolicyFixture : public ::testing::Test {
 	  if (dir->set(env->dpp, block, y) < 0)
 	    return -1;
 
-	  this->policyDriver->get_cache_policy()->update(dpp, oid, 0, bl.length(), "", false, y);
+	  this->policyDriver->get_cache_policy()->update(dpp, oid, 0, bl.length(), "", false, rgw::d4n::REFCOUNT_NOOP, y);
 	  if (cacheDriver->put(dpp, oid, bl, bl.length(), attrs, y) < 0)
             return -1;
 	  return cacheDriver->set_attr(dpp, oid, "localWeight", std::to_string(age), y);
@@ -171,7 +171,7 @@ TEST_F(LFUDAPolicyFixture, LocalGetBlockYield)
 
     std::string key = block->cacheObj.bucketName + "_" + block->cacheObj.objName + "_" + std::to_string(block->blockID) + "_" + std::to_string(block->size);
     ASSERT_EQ(0, cacheDriver->put(env->dpp, key, bl, bl.length(), attrs, optional_yield{yield}));
-    policyDriver->get_cache_policy()->update(env->dpp, key, 0, bl.length(), "", false, optional_yield{yield});
+    policyDriver->get_cache_policy()->update(env->dpp, key, 0, bl.length(), "", false, rgw::d4n::REFCOUNT_NOOP, optional_yield{yield});
 
     ASSERT_EQ(lfuda(env->dpp, block, cacheDriver, yield), 0);
 
@@ -230,7 +230,7 @@ TEST_F(LFUDAPolicyFixture, RemoteGetBlockYield)
     ASSERT_EQ(0, dir->set(env->dpp, &victim, optional_yield{yield}));
     std::string victimKey = victim.cacheObj.bucketName + "_version_" + victim.cacheObj.objName + "_" + std::to_string(victim.blockID) + "_" + std::to_string(victim.size);
     ASSERT_EQ(0, cacheDriver->put(env->dpp, victimKey, bl, bl.length(), attrs, optional_yield{yield}));
-    policyDriver->get_cache_policy()->update(env->dpp, victimKey, 0, bl.length(), "", false, optional_yield{yield});
+    policyDriver->get_cache_policy()->update(env->dpp, victimKey, 0, bl.length(), "", false, rgw::d4n::REFCOUNT_NOOP, optional_yield{yield});
 
     /* Remote block */
     block->size = cacheDriver->get_free_space(env->dpp) + 1; /* To trigger eviction */

--- a/src/test/rgw/test_ssd_driver.cc
+++ b/src/test/rgw/test_ssd_driver.cc
@@ -51,6 +51,15 @@ int drain(const DoutPrefixProvider* dpp, rgw::Aio* aio) {
   return flush(dpp, std::move(c));
 }
 
+int flush(const DoutPrefixProvider* dpp, rgw::AioResultList&& results, optional_yield y) {
+  int r = rgw::check_for_errors(results);
+
+  if (r < 0) {
+    return r;
+  }
+  return 0;
+}
+
 class Environment* env;
 
 class Environment : public ::testing::Environment {
@@ -120,10 +129,10 @@ TEST_F(SSDDriverFixture, PutAndGet)
 {
     boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
         rgw::sal::Attrs attrs = {};
-        ASSERT_EQ(0, cacheDriver->put(env->dpp, "testPutGet", bl, bl.length(), attrs, yield));
+        ASSERT_EQ(0, cacheDriver->put(env->dpp, "bucketid#version#objName#0#4096", bl, bl.length(), attrs, yield));
         bufferlist ret;
         rgw::sal::Attrs get_attrs;
-        ASSERT_EQ(0, cacheDriver->get(env->dpp, "testPutGet", 0, bl.length(), ret, get_attrs, yield));
+        ASSERT_EQ(0, cacheDriver->get(env->dpp, "bucketid#version#objName#0#4096", 0, bl.length(), ret, get_attrs, yield));
         EXPECT_EQ(ret, bl);
         EXPECT_EQ(get_attrs.size(), 0);
     }, rethrow);
@@ -135,16 +144,16 @@ TEST_F(SSDDriverFixture, AppendData)
 {
     boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
         rgw::sal::Attrs attrs = {};
-        ASSERT_EQ(0, cacheDriver->put(env->dpp, "testAppend", bl, bl.length(), attrs, yield));
+        ASSERT_EQ(0, cacheDriver->put(env->dpp, "bucketid#version#testAppend#0#4096", bl, bl.length(), attrs, yield));
     
         bufferlist bl_append;
         bl_append.append(" xyz");
-        ASSERT_EQ(0, cacheDriver->append_data(env->dpp, "testAppend", bl_append, yield));
+        ASSERT_EQ(0, cacheDriver->append_data(env->dpp, "bucketid#version#testAppend#0#4096", bl_append, yield));
     
         bufferlist ret;
         bl.append(bl_append);
         rgw::sal::Attrs get_attrs;
-        ASSERT_EQ(0, cacheDriver->get(env->dpp, "testAppend", 0, bl.length(), ret, get_attrs, yield));
+        ASSERT_EQ(0, cacheDriver->get(env->dpp, "bucketid#version#testAppend#0#4096", 0, bl.length(), ret, get_attrs, yield));
         EXPECT_EQ(ret, bl);
         EXPECT_EQ(get_attrs.size(), 0);
     }, rethrow);
@@ -155,10 +164,10 @@ TEST_F(SSDDriverFixture, AppendData)
 TEST_F(SSDDriverFixture, SetGetAttrs)
 {
     boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
-        ASSERT_EQ(0, cacheDriver->put(env->dpp, "testSetGetAttrs", bl, bl.length(), attrs, yield));
+        ASSERT_EQ(0, cacheDriver->put(env->dpp, "bucketid#version#testSetGetAttrs", bl, bl.length(), attrs, yield));
         bufferlist ret;
         rgw::sal::Attrs ret_attrs;
-        ASSERT_EQ(0, cacheDriver->get(env->dpp, "testSetGetAttrs", 0, bl.length(), ret, ret_attrs, yield));
+        ASSERT_EQ(0, cacheDriver->get(env->dpp, "bucketid#version#testSetGetAttrs", 0, bl.length(), ret, ret_attrs, yield));
         EXPECT_EQ(ret, bl);
         EXPECT_EQ(ret_attrs.size(), 1);
         for (auto& it : ret_attrs) {
@@ -173,10 +182,10 @@ TEST_F(SSDDriverFixture, SetGetAttrs)
 TEST_F(SSDDriverFixture, UpdateAttrs)
 {
     boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
-        ASSERT_EQ(0, cacheDriver->put(env->dpp, "testUpdateAttrs", bl, bl.length(), attrs, yield));
-        ASSERT_EQ(0, cacheDriver->update_attrs(env->dpp, "testUpdateAttrs", update_attrs, yield));
+        ASSERT_EQ(0, cacheDriver->put(env->dpp, "bucketid#version#testUpdateAttrs", bl, bl.length(), attrs, yield));
+        ASSERT_EQ(0, cacheDriver->update_attrs(env->dpp, "bucketid#version#testUpdateAttrs", update_attrs, yield));
         rgw::sal::Attrs get_attrs;
-        ASSERT_EQ(0, cacheDriver->get_attrs(env->dpp, "testUpdateAttrs", get_attrs, yield));
+        ASSERT_EQ(0, cacheDriver->get_attrs(env->dpp, "bucketid#version#testUpdateAttrs", get_attrs, yield));
         EXPECT_EQ(get_attrs.size(), 2);
         EXPECT_EQ(get_attrs["user.rgw.attrName"], updateAttrVal1);
         EXPECT_EQ(get_attrs["user.rgw.testAttr"], updateAttrVal2);
@@ -189,12 +198,12 @@ TEST_F(SSDDriverFixture, SetGetAttr)
 {
     boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
       rgw::sal::Attrs attrs = {};
-      ASSERT_EQ(0, cacheDriver->put(env->dpp, "testSetGetAttr", bl, bl.length(), attrs, yield));
+      ASSERT_EQ(0, cacheDriver->put(env->dpp, "bucketid#version#testSetGetAttr", bl, bl.length(), attrs, yield));
       std::string attr_name = "user.ssd.testattr";
       std::string attr_val = "testattrVal";
-      ASSERT_EQ(0, cacheDriver->set_attr(env->dpp, "testSetGetAttr", attr_name, attr_val, yield));
+      ASSERT_EQ(0, cacheDriver->set_attr(env->dpp, "bucketid#version#testSetGetAttr", attr_name, attr_val, yield));
       std::string attr_val_ret;
-      ASSERT_EQ(0, cacheDriver->get_attr(env->dpp, "testSetGetAttr", attr_name, attr_val_ret, yield));
+      ASSERT_EQ(0, cacheDriver->get_attr(env->dpp, "bucketid#version#testSetGetAttr", attr_name, attr_val_ret, yield));
       ASSERT_EQ(attr_val, attr_val_ret);
     }, rethrow);
 
@@ -205,17 +214,17 @@ TEST_F(SSDDriverFixture, DeleteAttr)
 {
     boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
       rgw::sal::Attrs attrs = {};
-      ASSERT_EQ(0, cacheDriver->put(env->dpp, "testDeleteAttr", bl, bl.length(), attrs, yield));
+      ASSERT_EQ(0, cacheDriver->put(env->dpp, "bucketid#version#testDeleteAttr", bl, bl.length(), attrs, yield));
       std::string attr_name = "user.ssd.testattr";
       std::string attr_val = "testattrVal";
-      ASSERT_EQ(0, cacheDriver->set_attr(env->dpp, "testDeleteAttr", attr_name, attr_val, yield));
+      ASSERT_EQ(0, cacheDriver->set_attr(env->dpp, "bucketid#version#testDeleteAttr", attr_name, attr_val, yield));
       std::string attr_val_ret;
-      ASSERT_EQ(0, cacheDriver->get_attr(env->dpp, "testDeleteAttr", attr_name, attr_val_ret, yield));
+      ASSERT_EQ(0, cacheDriver->get_attr(env->dpp, "bucketid#version#testDeleteAttr", attr_name, attr_val_ret, yield));
       ASSERT_EQ(attr_val, attr_val_ret);
 
       attr_val_ret.clear();
-      ASSERT_EQ(0, cacheDriver->delete_attr(env->dpp, "testDeleteAttr", attr_name));
-      ASSERT_EQ(ENODATA, cacheDriver->get_attr(env->dpp, "testDeleteAttr", attr_name, attr_val_ret, yield));
+      ASSERT_EQ(0, cacheDriver->delete_attr(env->dpp, "bucketid#version#testDeleteAttr", attr_name));
+      ASSERT_EQ(ENODATA, cacheDriver->get_attr(env->dpp, "bucketid#version#testDeleteAttr", attr_name, attr_val_ret, yield));
       ASSERT_EQ("", attr_val_ret);
     }, rethrow);
 
@@ -225,18 +234,18 @@ TEST_F(SSDDriverFixture, DeleteAttr)
 TEST_F(SSDDriverFixture, DeleteAttrs)
 {
     boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
-      ASSERT_EQ(0, cacheDriver->put(env->dpp, "testDeleteAttr", bl, bl.length(), attrs, yield));
+      ASSERT_EQ(0, cacheDriver->put(env->dpp, "bucketid#version#testDeleteAttr", bl, bl.length(), attrs, yield));
       rgw::sal::Attrs ret_attrs;
-      ASSERT_EQ(0, cacheDriver->get_attrs(env->dpp, "testDeleteAttr", ret_attrs, yield));
+      ASSERT_EQ(0, cacheDriver->get_attrs(env->dpp, "bucketid#version#testDeleteAttr", ret_attrs, yield));
       EXPECT_EQ(ret_attrs.size(), 1);
       for (auto& it : ret_attrs) {
         EXPECT_EQ(it.first, "user.rgw.attrName");
         EXPECT_EQ(it.second, attrVal);
       }
 
-      ASSERT_EQ(0, cacheDriver->delete_attrs(env->dpp, "testDeleteAttr", del_attrs, yield));
+      ASSERT_EQ(0, cacheDriver->delete_attrs(env->dpp, "bucketid#version#testDeleteAttr", del_attrs, yield));
       ret_attrs.clear();
-      ASSERT_EQ(0, cacheDriver->get_attrs(env->dpp, "testDeleteAttr", del_attrs, yield));
+      ASSERT_EQ(0, cacheDriver->get_attrs(env->dpp, "bucketid#version#testDeleteAttr", del_attrs, yield));
       EXPECT_EQ(ret_attrs.size(), 0);
     }, rethrow);
 
@@ -247,14 +256,14 @@ TEST_F(SSDDriverFixture, DeleteData)
 {
     boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
         rgw::sal::Attrs attrs = {};
-        ASSERT_EQ(0, cacheDriver->put(env->dpp, "testDeleteData", bl, bl.length(), attrs, yield));
+        ASSERT_EQ(0, cacheDriver->put(env->dpp, "bucketid#version#testDeleteData", bl, bl.length(), attrs, yield));
         bufferlist ret;
         rgw::sal::Attrs get_attrs;
-        ASSERT_EQ(0, cacheDriver->get(env->dpp, "testDeleteData", 0, bl.length(), ret, get_attrs, yield));
+        ASSERT_EQ(0, cacheDriver->get(env->dpp, "bucketid#version#testDeleteData", 0, bl.length(), ret, get_attrs, yield));
         EXPECT_EQ(ret, bl);
         EXPECT_EQ(get_attrs.size(), 0);
-        ASSERT_EQ(0, cacheDriver->delete_data(env->dpp, "testDeleteData", yield));
-        ASSERT_EQ(-ENOENT, cacheDriver->get(env->dpp, "testDeleteData", 0, bl.length(), ret, get_attrs, yield));
+        ASSERT_EQ(0, cacheDriver->delete_data(env->dpp, "bucketid#version#testDeleteData", yield));
+        ASSERT_EQ(-ENOENT, cacheDriver->get(env->dpp, "bucketid#version#testDeleteData", 0, bl.length(), ret, get_attrs, yield));
     }, rethrow);
 
     io.run();
@@ -266,8 +275,10 @@ TEST_F(SSDDriverFixture, PutAsync)
         rgw::sal::Attrs attrs = {};
         const uint64_t window_size = env->cct->_conf->rgw_put_obj_min_window_size;
         std::unique_ptr<rgw::Aio> aio = rgw::make_throttle(window_size, yield);
-        auto results = cacheDriver->put_async(env->dpp, yield, aio.get(), "testPutAsync", bl, bl.length(), attrs, bl.length(), 0);
+        auto results = cacheDriver->put_async(env->dpp, yield, aio.get(), "bucketid#version#testPutAsync", bl, bl.length(), attrs, bl.length(), 0);
+        auto r = flush(env->dpp, std::move(results), yield);
         drain(env->dpp, aio.get());
+        EXPECT_EQ(r, 0);
     }, rethrow);
 
     io.run();


### PR DESCRIPTION
Includes commits to do the following:
1. Remove the dirty prefix from the D4N logic
2. Remove the `del` method's implementation from the RedisDriver and replace `del` with a `delete` call in the RedisDriver unit test
3. Update the D4N policy test by correcting the cache key to use the correct delimiter and add checks for the cache blocks