### PR TITLE
(DRAFT) Wip d4n remote eviction

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -4617,6 +4617,15 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgw_d4n_remote_cache_address
+  type: str
+  level: advanced
+  desc: Address of the remote cache driver 
+  services: 
+  - rgw
+  flags:
+  - startup
+  with_legacy: true
 - name: rgw_bucket_persistent_notif_num_shards
   type: uint
   level: advanced

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3974,6 +3974,15 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgw_d4n_l1_datacache_free_threshold
+  type: uint
+  level: advanced
+  desc: amount of free disk space to decide if an object should be deleted or wait for cleaning
+  long_desc: Upon receiving a delete request, D4N uses this option to decide if an object should be deleted right away or wait for cleaning process to delete the object later.
+  default: 1073741824
+  services:
+  - rgw
+  with_legacy: true
 - name: rgw_d4n_l1_evict_cache_on_start
   type: bool
   level: advanced
@@ -4060,6 +4069,22 @@ options:
   - rgw
   flags:
   - startup
+  with_legacy: true
+- name: rgw_d4n_remote_delete_enabled
+  type: bool
+  level: advanced
+  desc: option to enable/diasble remote delete operations
+  default: true
+  services:
+  - rgw
+  with_legacy: true
+- name: rgw_d4n_remote_requests_num
+  type: int
+  level: advanced
+  desc: specifies the maximum number of simultaneous I/O requests that can be sent to a remote cache.
+  default: 10
+  services:
+  - rgw
   with_legacy: true
 - name: rgw_d4n_async_remote_put
   type: bool

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -4061,6 +4061,29 @@ options:
   flags:
   - startup
   with_legacy: true
+- name: rgw_d4n_async_remote_put
+  type: bool
+  level: advanced
+  desc: option to asynchronously write to a remote cache, off by default.
+  default: false
+  services:
+  - rgw
+  with_legacy: true
+- name: rgw_d4n_thread_pool_size
+  type: int
+  level: advanced
+  desc: size of thread pool used to asynchronously write a request to a remote cache
+  services:
+  - rgw
+  with_legacy: true
+- name: rgw_d4n_remote_put
+  type: bool
+  level: advanced
+  desc: debug option to enable/disable remote put, enabled by default
+  default: true
+  services:
+  - rgw
+  with_legacy: true
 - name: rgw_backend_store
   type: str
   level: advanced

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -4109,6 +4109,14 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgw_d4n_remote_async_get
+  type: bool
+  level: advanced
+  desc: debug option to enable/disable remote async get, disabled by default
+  default: false
+  services:
+  - rgw
+  with_legacy: true
 - name: rgw_backend_store
   type: str
   level: advanced

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -4373,20 +4373,6 @@ options:
   default: true
   services:
   - rgw
-- name: rgw_d4n_address
-  type: str
-  level: advanced
-  desc: address for the D4N Redis connection
-  long_desc: The current D4N implementation supports one Redis node
-    which the D4N directory, policy, and overall filter communicate
-    with. This default value is also the address that a Redis server 
-    with no additional configuration will use.
-  default: 127.0.0.1:6379
-  services: 
-  - rgw
-  flags:
-  - startup
-  with_legacy: true
 - name: rgw_d4n_cache_cleaning_interval
   type: int
   level: advanced

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -282,6 +282,7 @@ if(WITH_RADOSGW_D4N)
         rgw_ssd_driver.cc
         driver/d4n/d4n_directory.cc
         driver/d4n/d4n_policy.cc
+        driver/d4n/d4n_remote_cache_manager.cc
         driver/d4n/rgw_sal_d4n.cc)
 endif()
 

--- a/src/rgw/driver/d4n/d4n_directory.cc
+++ b/src/rgw/driver/d4n/d4n_directory.cc
@@ -448,7 +448,8 @@ int ObjectDirectory::set(const DoutPrefixProvider* dpp, CacheObj* object, option
   redisValues.push_back(object->user_id);
   redisValues.push_back("displayName");
   redisValues.push_back(object->display_name);
-
+  redisValues.push_back("acl");
+  redisValues.push_back(object->acl);
   try {
     boost::system::error_code ec;
     response<ignore_t> resp;
@@ -484,6 +485,7 @@ int ObjectDirectory::get(const DoutPrefixProvider* dpp, CacheObj* object, option
   fields.push_back("objSize");
   fields.push_back("userId");
   fields.push_back("displayName");
+  fields.push_back("acl");
 
   try {
     boost::system::error_code ec;
@@ -513,6 +515,7 @@ int ObjectDirectory::get(const DoutPrefixProvider* dpp, CacheObj* object, option
     object->size = std::stoull(std::get<0>(resp).value()[std::size_t(Fields::ObjSize)]);
     object->user_id = std::get<0>(resp).value()[std::size_t(Fields::UserID)];
     object->display_name = std::get<0>(resp).value()[std::size_t(Fields::DisplayName)];
+    object->acl = std::get<0>(resp).value()[std::size_t(Fields::Acl)];
   } catch (std::exception &e) {
     ldpp_dout(dpp, 0) << "ObjectDirectory::" << __func__ << "() ERROR: " << e.what() << dendl;
     return -EINVAL;
@@ -972,6 +975,8 @@ int BlockDirectory::set_values(const DoutPrefixProvider* dpp, CacheBlock& block,
   redisValues.push_back(block.cacheObj.user_id);
   redisValues.push_back("displayName");
   redisValues.push_back(block.cacheObj.display_name);
+  redisValues.push_back("acl");
+  redisValues.push_back(block.cacheObj.acl);
 
   return 0;
 }
@@ -1125,6 +1130,7 @@ int BlockDirectory::get(const DoutPrefixProvider* dpp, std::vector<CacheBlock>& 
     fields.push_back("objSize");
     fields.push_back("userId");
     fields.push_back("displayName");
+    fields.push_back("acl");
 
     try {
       req.push_range("HMGET", key, fields);
@@ -1173,6 +1179,7 @@ int BlockDirectory::get(const DoutPrefixProvider* dpp, std::vector<CacheBlock>& 
     block->cacheObj.size = std::stoull(vec[std::size_t(Fields::ObjSize)]);
     block->cacheObj.user_id = vec[std::size_t(Fields::UserID)];
     block->cacheObj.display_name = vec[std::size_t(Fields::DisplayName)];
+    block->cacheObj.display_name = vec[std::size_t(Fields::Acl)];
   }
 
   return 0;
@@ -1199,6 +1206,7 @@ int BlockDirectory::get(const DoutPrefixProvider* dpp, CacheBlock* block, option
   fields.push_back("objSize");
   fields.push_back("userId");
   fields.push_back("displayName");
+  fields.push_back("acl");
 
   try {
     boost::system::error_code ec;
@@ -1232,6 +1240,7 @@ int BlockDirectory::get(const DoutPrefixProvider* dpp, CacheBlock* block, option
     block->cacheObj.size = std::stoull(std::get<0>(resp).value().value()[11]);
     block->cacheObj.user_id = std::get<0>(resp).value().value()[12];
     block->cacheObj.display_name = std::get<0>(resp).value().value()[13];
+    block->cacheObj.acl = std::get<0>(resp).value().value()[14];
   } catch (std::exception &e) {
     ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() ERROR: " << e.what() << dendl;
     return -EINVAL;
@@ -1264,6 +1273,7 @@ int BlockDirectory::get(const DoutPrefixProvider* dpp, std::vector<CacheBlock>& 
     fields.push_back("objSize");
     fields.push_back("userId");
     fields.push_back("displayName");
+    fields.push_back("acl");
 
     try {
       req.push("HGETALL", key);
@@ -1311,7 +1321,7 @@ int BlockDirectory::get(const DoutPrefixProvider* dpp, std::vector<CacheBlock>& 
               element.value == "size" || element.value == "globalWeight" || element.value == "objName" ||
               element.value == "bucketName" || element.value == "creationTime" || element.value == "dirty" ||
               element.value == "hosts" || element.value == "etag" || element.value == "objSize" ||
-              element.value == "userId" || element.value == "displayName") {
+              element.value == "userId" || element.value == "displayName" || element.value == "acl") {
             prev_val = element.value;
             ldpp_dout(dpp, 10) << "BlockDirectory::" << __func__ << "() field key: " << prev_val << dendl;
             field_key = false;
@@ -1348,6 +1358,8 @@ int BlockDirectory::get(const DoutPrefixProvider* dpp, std::vector<CacheBlock>& 
             block->cacheObj.user_id = element.value;
           } else if (prev_val == "displayName") {
             block->cacheObj.display_name = element.value;
+          } else if (prev_val == "acl") {
+            block->cacheObj.acl = element.value;
           }
           j++;
           field_key= true;

--- a/src/rgw/driver/d4n/d4n_directory.cc
+++ b/src/rgw/driver/d4n/d4n_directory.cc
@@ -1579,8 +1579,13 @@ int BlockDirectory::remove_host(const DoutPrefixProvider* dpp, CacheBlock* block
 	result.erase(result.length() - 1, 1);
       }
 
-      if (result.length() == 0) /* Last host, delete entirely */
-	return del(dpp, block, y); 
+      if (result.length() == 0) { /* Last host, delete entirely */
+        int ret = del(dpp, block, y); 
+        if (ret < 0) {
+		  ldpp_dout(dpp, 10) << "BlockDirectory::" << __func__ << "(): Failed to delete entire block, ret=" << ret << dendl;
+        }
+		return ret;
+      }
 
   value = result;
     }

--- a/src/rgw/driver/d4n/d4n_directory.cc
+++ b/src/rgw/driver/d4n/d4n_directory.cc
@@ -917,16 +917,14 @@ int BlockDirectory::exist_key(const DoutPrefixProvider* dpp, CacheBlock* block, 
   return std::get<0>(resp).value();
 }
 
-template<SeqContainer Container>
+template<AssociativeContainer Container>
 int BlockDirectory::set_values(const DoutPrefixProvider* dpp, CacheBlock& block, Container& redisValues, optional_yield y)
 {
   std::string hosts;
   /* Creating a redisValues of the entry's properties */
-  redisValues.push_back("blockID");
-  redisValues.push_back(std::to_string(block.blockID));
-  redisValues.push_back("version");
-  redisValues.push_back(block.version);
-  redisValues.push_back("deleteMarker");
+  redisValues["blockID"] = std::to_string(block.blockID);
+  redisValues["version"] = block.version;
+
   int ret = -1;
   if ((ret = check_bool(std::to_string(block.deleteMarker))) != -EINVAL) {
     block.deleteMarker = (ret != 0);
@@ -934,26 +932,20 @@ int BlockDirectory::set_values(const DoutPrefixProvider* dpp, CacheBlock& block,
     ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() ERROR: Invalid bool value for delete marker" << dendl;
     return -EINVAL;
   }
-  redisValues.push_back(std::to_string(block.deleteMarker));
-  redisValues.push_back("size");
-  redisValues.push_back(std::to_string(block.size));
-  redisValues.push_back("globalWeight");
-  redisValues.push_back(std::to_string(block.globalWeight));
-  redisValues.push_back("objName");
-  redisValues.push_back(block.cacheObj.objName);
-  redisValues.push_back("bucketName");
-  redisValues.push_back(block.cacheObj.bucketName);
-  redisValues.push_back("creationTime");
-  redisValues.push_back(block.cacheObj.creationTime);
-  redisValues.push_back("dirty");
+  redisValues["deleteMarker"] = std::to_string(block.deleteMarker);
+  redisValues["size"] = std::to_string(block.size);
+  redisValues["globalWeight"] = std::to_string(block.globalWeight);
+  redisValues["objName"] = block.cacheObj.objName;
+  redisValues["bucketName"] = block.cacheObj.bucketName;
+  redisValues["creationTime"] = block.cacheObj.creationTime;
+
   if ((ret = check_bool(std::to_string(block.cacheObj.dirty))) != -EINVAL) {
     block.cacheObj.dirty = (ret != 0);
   } else {
     ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() ERROR: Invalid bool value" << dendl;
     return -EINVAL;
   }
-  redisValues.push_back(std::to_string(block.cacheObj.dirty));
-  redisValues.push_back("hosts");
+  redisValues["dirty"] = std::to_string(block.cacheObj.dirty);
 
   hosts.clear();
   for (auto const& host : block.cacheObj.hostsList) {
@@ -964,20 +956,19 @@ int BlockDirectory::set_values(const DoutPrefixProvider* dpp, CacheBlock& block,
   }
 
   if (!hosts.empty())
-  hosts.pop_back();
+    hosts.pop_back();
 
-  redisValues.push_back(hosts);
-  redisValues.push_back("etag");
-  redisValues.push_back(block.cacheObj.etag);
-  redisValues.push_back("objSize");
-  redisValues.push_back(std::to_string(block.cacheObj.size));
-  redisValues.push_back("userId");
-  redisValues.push_back(block.cacheObj.user_id);
-  redisValues.push_back("displayName");
-  redisValues.push_back(block.cacheObj.display_name);
-  redisValues.push_back("acl");
-  redisValues.push_back(block.cacheObj.acl);
+  redisValues["hosts"] = hosts;
+  redisValues["etag"] = block.cacheObj.etag;
+  redisValues["objSize"] = std::to_string(block.cacheObj.size);
+  redisValues["userId"] = block.cacheObj.user_id;
+  redisValues["displayName"] = block.cacheObj.display_name;
+  redisValues["acl"] = block.cacheObj.acl;
 
+  redisValues["attrsCount"]   = std::to_string(block.cacheObj.attrs.size());
+  for (auto const& [key, bl] : block.cacheObj.attrs) {
+    redisValues["attr_" + key] = bl.to_str();
+  }
   return 0;
 }
 
@@ -988,7 +979,7 @@ int BlockDirectory::set(const DoutPrefixProvider* dpp, CacheBlock* block, option
   std::string key = build_index(block);
   ldpp_dout(dpp, 10) << "BlockDirectory::" << __func__ << "(): index is: " << key << dendl;
 
-  std::vector<std::string> redisValues;
+  std::map<std::string, std::string> redisValues;
 
   auto ret = set_values(dpp, *block, redisValues, y);
   if (ret < 0) {
@@ -1000,10 +991,10 @@ int BlockDirectory::set(const DoutPrefixProvider* dpp, CacheBlock* block, option
     response<ignore_t> resp;
     if (pipeline && pipeline->is_pipeline()) {
       request& req = pipeline->get_request();
-      req.push_range("HSET", key, redisValues);
+      req.push_range("HSET", key, std::cbegin(redisValues), std::cend(redisValues));
     } else {
       request req;
-      req.push_range("HSET", key, redisValues);
+      req.push_range("HSET", key, std::cbegin(redisValues), std::cend(redisValues));
 
       redis_exec_connection_pool(dpp, redis_pool, conn, ec, req, resp, y);
       if (ec) {
@@ -1026,13 +1017,12 @@ int BlockDirectory::set(const DoutPrefixProvider* dpp, std::vector<CacheBlock>& 
     std::string key = build_index(&block);
     ldpp_dout(dpp, 10) << "BlockDirectory::" << __func__ << "(): index is: " << key << dendl;
 
-    //std::string hosts;
-    std::list<std::string> redisValues;
+    std::map<std::string, std::string> redisValues;
     auto ret = set_values(dpp, block, redisValues, y);
     if (ret < 0) {
       return ret;
     }
-    req.push_range("HSET", key, redisValues);
+    req.push_range("HSET", key, std::cbegin(redisValues), std::cend(redisValues));
   }
 
   try {
@@ -1188,31 +1178,13 @@ int BlockDirectory::get(const DoutPrefixProvider* dpp, std::vector<CacheBlock>& 
 int BlockDirectory::get(const DoutPrefixProvider* dpp, CacheBlock* block, optional_yield y) 
 {
   std::string key = build_index(block);
-  std::vector<std::string> fields;
   ldpp_dout(dpp, 10) << "BlockDirectory::" << __func__ << "(): index is: " << key << dendl;
-
-  fields.push_back("blockID");
-  fields.push_back("version");
-  fields.push_back("deleteMarker");
-  fields.push_back("size");
-  fields.push_back("globalWeight");
-
-  fields.push_back("objName");
-  fields.push_back("bucketName");
-  fields.push_back("creationTime");
-  fields.push_back("dirty");
-  fields.push_back("hosts");
-  fields.push_back("etag");
-  fields.push_back("objSize");
-  fields.push_back("userId");
-  fields.push_back("displayName");
-  fields.push_back("acl");
 
   try {
     boost::system::error_code ec;
-    response< std::optional<std::vector<std::string>> > resp;
+    response< std::optional<std::map<std::string, std::string>> > resp;
     request req;
-    req.push_range("HMGET", key, fields);
+    req.push("HGETALL", key);
 
     redis_exec_connection_pool(dpp, redis_pool, conn, ec, req, resp, y);
 
@@ -1221,26 +1193,51 @@ int BlockDirectory::get(const DoutPrefixProvider* dpp, CacheBlock* block, option
       return -ec.value();
     }
 
-    if (std::get<0>(resp).value().value().empty()) {
+    const auto& result = std::get<0>(resp);
+    if (!result.has_value()) {
       ldpp_dout(dpp, 10) << "BlockDirectory::" << __func__ << "(): No values returned for key=" << key << dendl;
       return -ENOENT;
-    } 
+    }
 
-    block->blockID = std::stoull(std::get<0>(resp).value().value()[0]);
-    block->version = std::get<0>(resp).value().value()[1];
-    block->deleteMarker = (std::stoi(std::get<0>(resp).value().value()[2]) != 0);
-    block->size = std::stoull(std::get<0>(resp).value().value()[3]);
-    block->globalWeight = std::stoull(std::get<0>(resp).value().value()[4]);
-    block->cacheObj.objName = std::get<0>(resp).value().value()[5];
-    block->cacheObj.bucketName = std::get<0>(resp).value().value()[6];
-    block->cacheObj.creationTime = std::get<0>(resp).value().value()[7];
-    block->cacheObj.dirty = (std::stoi(std::get<0>(resp).value().value()[8]) != 0);
-    boost::split(block->cacheObj.hostsList, std::get<0>(resp).value().value()[9], boost::is_any_of("_"));
-    block->cacheObj.etag = std::get<0>(resp).value().value()[10];
-    block->cacheObj.size = std::stoull(std::get<0>(resp).value().value()[11]);
-    block->cacheObj.user_id = std::get<0>(resp).value().value()[12];
-    block->cacheObj.display_name = std::get<0>(resp).value().value()[13];
-    block->cacheObj.acl = std::get<0>(resp).value().value()[14];
+    const auto& opt = result.value();
+    if (!opt.has_value() || opt.value().empty()) {
+      ldpp_dout(dpp, 10) << "BlockDirectory::" << __func__ << "(): No values returned for key=" << key << dendl;
+      return -ENOENT;
+    }
+    const std::map<std::string, std::string>& fieldMap = opt.value();
+    block->blockID = std::stoull(fieldMap.at("blockID"));
+    block->version = fieldMap.at("version");
+    block->deleteMarker = (std::stoi(fieldMap.at("deleteMarker")) != 0);
+    block->size = std::stoull(fieldMap.at("size"));
+    block->globalWeight = std::stoull(fieldMap.at("globalWeight"));
+    block->cacheObj.objName = fieldMap.at("objName");
+    block->cacheObj.bucketName = fieldMap.at("bucketName");
+    block->cacheObj.creationTime = fieldMap.at("creationTime");
+    block->cacheObj.dirty = (std::stoi(fieldMap.at("dirty")) != 0);
+    boost::split(block->cacheObj.hostsList, fieldMap.at("hosts"), boost::is_any_of("_"));
+    block->cacheObj.etag = fieldMap.at("etag");
+    block->cacheObj.size = std::stoull(fieldMap.at("objSize"));
+    block->cacheObj.user_id = fieldMap.at("userId");
+    block->cacheObj.display_name = fieldMap.at("displayName");
+    block->cacheObj.acl = fieldMap.at("acl");
+
+    size_t attrsCount = std::stoull(fieldMap.at("attrsCount"));
+    size_t found = 0;
+    for (auto const& [field, value] : fieldMap) {
+      if (field.starts_with("attr_")) {
+        std::string attrKey = field.substr(5);
+        ceph::buffer::list bl;
+        bl.append(value);
+        block->cacheObj.attrs[attrKey] = std::move(bl);
+
+        if (++found == attrsCount) break;
+      }
+    }
+
+    if (found != attrsCount) {
+      ldpp_dout(dpp, 10) << "BlockDirectory::" << __func__ << "() ERROR: expected " << attrsCount << " attrs but found " << found << dendl;
+      return -EINVAL;
+    }
   } catch (std::exception &e) {
     ldpp_dout(dpp, 0) << "BlockDirectory::" << __func__ << "() ERROR: " << e.what() << dendl;
     return -EINVAL;
@@ -1321,7 +1318,8 @@ int BlockDirectory::get(const DoutPrefixProvider* dpp, std::vector<CacheBlock>& 
               element.value == "size" || element.value == "globalWeight" || element.value == "objName" ||
               element.value == "bucketName" || element.value == "creationTime" || element.value == "dirty" ||
               element.value == "hosts" || element.value == "etag" || element.value == "objSize" ||
-              element.value == "userId" || element.value == "displayName" || element.value == "acl") {
+              element.value == "userId" || element.value == "displayName" || element.value == "acl" ||
+              element.value == "attrsCount" || element.value.starts_with("attr_")) {
             prev_val = element.value;
             ldpp_dout(dpp, 10) << "BlockDirectory::" << __func__ << "() field key: " << prev_val << dendl;
             field_key = false;
@@ -1360,6 +1358,13 @@ int BlockDirectory::get(const DoutPrefixProvider* dpp, std::vector<CacheBlock>& 
             block->cacheObj.display_name = element.value;
           } else if (prev_val == "acl") {
             block->cacheObj.acl = element.value;
+          } else if (prev_val == "attrsCount") {
+            size_t attrsCount = std::stoi(element.value);
+          } else if (prev_val.starts_with("attr_")) {
+            std::string attrKey = prev_val.substr(5);
+            ceph::buffer::list bl;
+            bl.append(element.value);
+            block->cacheObj.attrs[attrKey] = std::move(bl);
           }
           j++;
           field_key= true;

--- a/src/rgw/driver/d4n/d4n_directory.h
+++ b/src/rgw/driver/d4n/d4n_directory.h
@@ -104,7 +104,8 @@ enum class ObjectFields { // Fields stored in object directory
   Etag,
   ObjSize,
   UserID,
-  DisplayName
+  DisplayName,
+  Acl
 };
 
 enum class BlockFields { // Fields stored in block directory 
@@ -121,7 +122,8 @@ enum class BlockFields { // Fields stored in block directory
   Etag,
   ObjSize,
   UserID,
-  DisplayName
+  DisplayName,
+  Acl
 };
 
 struct CacheObj {
@@ -134,6 +136,7 @@ struct CacheObj {
   uint64_t size; //total object size (and not block size), needed for list objects
   std::string user_id; // id of user, needed for list object versions
   std::string display_name; // display name of owner, needed for list object versions
+  std::string acl;
 };
 
 struct CacheBlock {

--- a/src/rgw/driver/d4n/d4n_directory.h
+++ b/src/rgw/driver/d4n/d4n_directory.h
@@ -137,6 +137,7 @@ struct CacheObj {
   std::string user_id; // id of user, needed for list object versions
   std::string display_name; // display name of owner, needed for list object versions
   std::string acl;
+  rgw::sal::Attrs attrs; // attrs for a head block
 };
 
 struct CacheBlock {
@@ -217,6 +218,13 @@ class ObjectDirectory: public Directory {
     std::string build_index(CacheObj* object);
 };
 
+template<typename C>
+concept AssociativeContainer = requires(C c, typename C::key_type k) {
+    typename C::key_type;
+    { c.find(k) } -> std::convertible_to<typename C::iterator>;
+    { c.count(k) } -> std::convertible_to<std::size_t>;
+};
+
 class BlockDirectory: public Directory {
   public:
     BlockDirectory(std::shared_ptr<connection>& conn) : conn(conn) {}
@@ -247,7 +255,7 @@ class BlockDirectory: public Directory {
     std::shared_ptr<connection> conn;
     std::string build_index(CacheBlock* block);
 
-    template<SeqContainer Container>
+    template<AssociativeContainer Container>
     int set_values(const DoutPrefixProvider* dpp, CacheBlock& block, Container& redisValues, optional_yield y);
 };
 

--- a/src/rgw/driver/d4n/d4n_policy.cc
+++ b/src/rgw/driver/d4n/d4n_policy.cc
@@ -2,7 +2,6 @@
 
 #include "../../../common/async/yield_context.h"
 #include "common/async/blocked_completion.h"
-#include "common/split.h"
 #include "rgw_perf_counters.h"
 
 namespace rgw { namespace d4n {
@@ -110,8 +109,8 @@ int LFUDAPolicy::init(CephContext* cct, const DoutPrefixProvider* dpp, asio::io_
   };
 
   static auto block_callback = [this](
-          const DoutPrefixProvider* dpp, const std::string& key, uint64_t offset, uint64_t len, const std::string& version, bool dirty, const rgw_user user, optional_yield y, std::string& restore_val) {
-    update(dpp, key, offset, len, version, dirty, user, RefCount::NOOP, y, restore_val);
+          const DoutPrefixProvider* dpp, const std::string& key, uint64_t offset, uint64_t len, const std::string& version, bool dirty, const rgw_user user, const std::string& bucketName, optional_yield y, std::string& restore_val) {
+    update(dpp, key, offset, len, version, dirty, user, bucketName, RefCount::NOOP, y, restore_val);
   };
 
   cacheDriver->restore_blocks_objects(dpp, obj_callback, block_callback);
@@ -168,24 +167,28 @@ int LFUDAPolicy::getMinAvgWeight(const DoutPrefixProvider* dpp, int *minAvgWeigh
     redis_exec(conn, ec, req, resp, y);
 
     if (ec) {
-      ldpp_dout(dpp, 10) << "AMIN " << __func__ << "() Error: " << ec.value() << dendl;
+      ldpp_dout(dpp, 10) << __func__ << "(): Error: " << ec.value() << dendl;
       return -ec.value();
     }
   } catch (std::exception &e) {
-    ldpp_dout(dpp, 10) << "AMIN " << __func__ << "() Error: " << "EINVAL" << dendl;
+    ldpp_dout(dpp, 10) << __func__ << "(): Error: " << "EINVAL" << dendl;
     return -EINVAL;
   }
 
-  ldpp_dout(dpp, 10) << "AMIN " << __func__ << "() resp<0> is " << std::get<0>(resp).value() << dendl;
-  ldpp_dout(dpp, 10) << "AMIN " << __func__ << "() resp<1> is " << std::get<1>(resp).value() << dendl;
-  ldpp_dout(dpp, 10) << "AMIN " << __func__ << "() resp<2> is " << std::get<2>(resp).value() << dendl;
+  *minAvgWeight = 0; 
+  if (std::get<0>(resp).has_value() && std::get<1>(resp).has_value()) {
+	try {
+	  int lw_size = std::stoi(std::get<1>(resp).value());
+      if (lw_size > 0) {
+		*minAvgWeight =  std::stoi(std::get<0>(resp).value()) / lw_size;
+      }
+	} catch (std::exception &e) {
+	  return -EINVAL;
+	}
+  }
 
-  if (std::stoi(std::get<1>(resp).value()) > 0)
-    *minAvgWeight =  std::stoi(std::get<0>(resp).value()) / std::stoi(std::get<1>(resp).value());
-  else
-    *minAvgWeight = 0; 
   *cache_address =  std::get<2>(resp).value();
-  ldpp_dout(dpp, 10) << "AMIN " << __func__ << "() cache_address is " << cache_address << dendl;
+  ldpp_dout(dpp, 20) << __func__ << "(): Cache address with minimum local weight is " << *cache_address << dendl;
   return 0;
 }
 
@@ -363,39 +366,28 @@ bool LFUDAPolicy::invalidate_dirty_object(const DoutPrefixProvider* dpp, const s
   return false;
 }
 
-CacheBlock* LFUDAPolicy::get_victim_block(const DoutPrefixProvider* dpp, optional_yield y) {
-  if (entries_heap.empty()) {
-    return nullptr;
-  }
+int LFUDAPolicy::get_victim_block(const DoutPrefixProvider* dpp, CacheBlock* victim, optional_yield y) {
+  if (entries_heap.empty())
+    return -ENOENT;
 
   /* Get victim cache block */
-  LFUDAEntry* entry = entries_heap.top();
+  auto entry = entries_heap.top();
   std::string key = entry->key;
-  CacheBlock* victim = new CacheBlock();
 
-  auto parts = split(key, "#");
-  std::vector<std::string> block_info;
-  block_info.assign(parts.begin(), parts.end());
-  
-  if (block_info.size() != 5) {
-    ldpp_dout(dpp, 0) << "LFUDAPolicy::" << __func__ << "(): Key of the top entry in the min heap has not been constructed correctly." << dendl;
-    return nullptr;
+  if (rgw::sal::parse_block_from_cache(key).has_value()) {
+    *victim = rgw::sal::parse_block_from_cache(key).value(); 
+  } else {
+    return -ENOENT;
   }
-
-  victim->cacheObj.bucketName = block_info[0]; 
-  victim->version = block_info[1]; 
-  victim->cacheObj.objName = block_info[2]; 
-  victim->blockID = std::stoull(block_info[3]); 
-  victim->size = std::stoull(block_info[4]); 
 
   /* check dirty flag of entry to be evicted, if the flag is dirty, all entries on the local node are dirty
     check refcount also, if refcount > 0 then no entries are available for eviction */
   if (entry->dirty || entry->refcount > 0) {
     ldpp_dout(dpp, 0) << "LFUDAPolicy::" << __func__ << "(): Top entry in min heap is dirty or with positive refcount, no entry is available for eviction!" << dendl;
-    return nullptr;
+    return -ENOENT;
   }
 
-  return victim;
+  return 0;
 }
 
 int LFUDAPolicy::exist_key(const std::string& key) {
@@ -407,248 +399,132 @@ int LFUDAPolicy::exist_key(const std::string& key) {
   return false;
 }
 
-int LFUDAPolicy::sendRemote(const DoutPrefixProvider* dpp, CacheBlock* victim, std::string remoteCacheAddress, std::string key, bufferlist* out_bl, optional_yield y)
-{
-  bufferlist in_bl;
-  rgw::sal::RGWRemoteD4NGetCB cb(&in_bl);
-  std::string bucketName = victim->cacheObj.bucketName;
- 
-  RGWAccessKey accessKey;
-  std::string findKey;
-  
-  if (key[0] == 'D') {
-    findKey = key.substr(2, key.length());
-  } else {
-    findKey = key;
-  }
-  
-  auto it = entries_map.find(findKey);
-  if (it == entries_map.end()) {
-    return -ENOENT;
-  }
-  auto user = it->second->user;
-  std::unique_ptr<rgw::sal::User> c_user = driver->get_user(user);
-  int ret = c_user->load_user(dpp, y);
-  if (ret < 0) {
-    return -EPERM;
-  }
-
-  if (c_user->get_info().access_keys.empty()) {
-    return -EINVAL;
-  }
-
-  accessKey.id = c_user->get_info().access_keys.begin()->second.id;
-  accessKey.key = c_user->get_info().access_keys.begin()->second.key;
-
-  HostStyle host_style = PathStyle;
-  std::map<std::string, std::string> extra_headers;                                                            
-
-  auto sender = new RGWRESTStreamRWRequest(dpp->get_cct(), "PUT", remoteCacheAddress, &cb, NULL, NULL, "", host_style);
-
-  ret = sender->send_request(dpp, &accessKey, extra_headers, "admin/remoted4n/"+bucketName+"/"+key, nullptr, out_bl);                 
-  if (ret < 0) {                                                                                      
-    delete sender;                                                                                       
-    return ret;                                                                                       
-  }                                                                                                   
-  
-  std::string etag;
-  std::map<std::string, std::string> pattrs;
-  ret = sender->complete_request(dpp, y, &etag, 0, 0, &pattrs, &pattrs);                                                            
-  if (ret < 0){
-    delete sender;                                                                                   
-    return ret;
-   }
-
-  return 0;
-}	
-
 int LFUDAPolicy::eviction(const DoutPrefixProvider* dpp, uint64_t size, optional_yield y) {
   int ret = -1;
-  uint64_t freeSpace = cacheDriver->get_free_space(dpp, y);
+  std::vector<LFUDAEntry> to_delete;
 
-  while (freeSpace < size) { // TODO: Think about parallel reads and writes; can this turn into an infinite loop?
-    std::unique_lock<std::mutex> l(lfuda_lock);
-    CacheBlock* victim = get_victim_block(dpp, y);
-  
-    if (victim == nullptr) {
-      ldpp_dout(dpp, 0) << "LFUDAPolicy::" << __func__ << "(): Could not retrieve victim block." << dendl;
-      delete victim;
-      l.unlock();
-      return -ENOSPC;
-    }
+  // Under lfuda_lock, select victims until enough space is freed, delete them from the heap and map so that they do not get 
+  // selected again by another thread when the lock is released
+  {
+    std::unique_lock<std::mutex> lfuda_l(lfuda_lock);
 
-    std::string key = entries_heap.top()->key;
-    auto it = entries_map.find(key);
-    if (it == entries_map.end()) {
-      delete victim;
-      l.unlock();
-      return -ENOENT;
-    } else {//victim block is getting read, no suitable block to evict
-      if (it->second->read_flag == 1){
-        ldpp_dout(dpp, 20) << "AMIN: " << __func__ << "(): " << __LINE__ << " Error: the Block is getting read!" << dendl;
-        delete victim;
-        l.unlock();
-        return -ENOENT;
+    uint64_t freed = 0;
+    while (freed < size) {
+	  CacheBlock victim;
+	  ret = get_victim_block(dpp, &victim, y);
+      if (ret == -ENOENT) {
+        ldpp_dout(dpp, 0) << "LFUDAPolicy::" << __func__ << "(): Could not retrieve victim block." << dendl;
+        return -ENOSPC;
       }
+
+	  std::string victim_key = entries_heap.top()->key;
+	  auto it = entries_map.find(victim_key);
+	  if (it == entries_map.end()) {
+        ldpp_dout(dpp, 0) << "LFUDAPolicy::" << __func__ << "(): Could not locate victim block entry in entries_map." << dendl;
+		return -ENOENT;
+	  }
+
+      uint64_t victim_size = victim.size;
+      to_delete.push_back(*it->second);
+      _erase(dpp, victim_key, y);
+      freed += victim_size;
     }
+  } // lfuda_lock released
 
-    set_read_flag(dpp, key, 2); //it is getting deleted.
-
+  // Outside both locks, do expensive I/O
+  for (auto& entry : to_delete) {
+    rgw::d4n::CacheBlock block = rgw::sal::parse_block_from_cache(entry.key).value();
     std::string globalWeight;
-    int localAvgWeight = weightSum / entries_map.size();
+    bool update_global_weight = true;
 
     //FIXME: remoteCacheAddress is getting overriden by a new cache. it should be updates instead.
     int avgWeight;
     std::string remoteCacheAddress;
-    if (getMinAvgWeight(dpp, &avgWeight, &remoteCacheAddress, y) < 0){
+    if (getMinAvgWeight(dpp, &avgWeight, &remoteCacheAddress, y) < 0) {
       ldpp_dout(dpp, 10) << "LFUDAPolicy::" << __func__ << "(): Could not retrieve min average weight." << dendl;
-      delete victim;
       return -ENOENT;
+    } else if (remoteCacheAddress == dpp->get_cct()->_conf->rgw_d4n_local_rgw_address) {
+      remoteCacheAddress.clear(); // evict normally without remote put 
     }
-    //remove this after the fix
-    remoteCacheAddress = dpp->get_cct()->_conf->rgw_d4n_remote_cache_address;
 
-    ldpp_dout(dpp, 20) << "AMIN: " << __func__ << "(): " << __LINE__ << " remote cache address is " << remoteCacheAddress << dendl;
-    ldpp_dout(dpp, 20) << "AMIN: " << __func__ << "(): " << __LINE__ << " victim host list size is " << victim->cacheObj.hostsList.size() << dendl;
-    ldpp_dout(dpp, 20) << "AMIN: " << __func__ << "(): " << __LINE__ << " victim host list is " << *(victim->cacheObj.hostsList.begin()) << dendl;
-
-    /* the following part takes care of updating the weight (globalWeight) of the block if this is the last copy in a remote setup and is pushed out to a remote cache where space is available */
-
-    if (victim->cacheObj.hostsList.size() == 1 && *(victim->cacheObj.hostsList.begin()) == dpp->get_cct()->_conf->rgw_d4n_local_rgw_address) { // Last copy 
-      ldpp_dout(dpp, 20) << "AMIN: " << __func__ << "(): " << __LINE__ << dendl;
-      if (victim->globalWeight) {
-	it->second->localWeight += victim->globalWeight;
-        (*it->second->handle)->localWeight = it->second->localWeight;
-	entries_heap.decrease(it->second->handle);
-
-	if (int ret = cacheDriver->set_attr(dpp, key, "user.rgw.localWeight", std::to_string(it->second->localWeight), y) < 0) { 
-	  delete victim;
+	if ((ret = blockDir->get(dpp, &block, y)) < 0) {
+      ldpp_dout(dpp, 10) << "LFUDAPolicy::" << __func__ << "(): Unable to retrieve victim block's hostsList." << dendl;
 	  return ret;
-        }
-
-	victim->globalWeight = 0;
-	globalWeight = std::to_string(victim->globalWeight);
-	if (int ret = blockDir->update_field(dpp, victim, "globalWeight", globalWeight, y) < 0) {
-	  delete victim;
-	  return ret;
-        }
-      }
-
-  //FIXME: AMIN uncomment this
-     /*
-     if (!remoteCacheAddress.empty()){
-      if (it->second->localWeight > avgWeight) {
-        ldpp_dout(dpp, 20) << "AMIN: " << __func__ << "(): " << __LINE__ << dendl;
-	// TODO: push victim block to remote cache
-	// add remote cache host to host list
-	bufferlist out_bl;
-        rgw::sal::Attrs obj_attrs;
-
-	std::string remoteKey = key;
-	if (it->second->dirty == true)
-	  remoteKey = "D_"+key; //TODO: AMIN: we should not delete dirty data. it should be cleaned first.
-
-	
-        ldpp_dout(dpp, 20) << "AMIN: " << __func__ << "(): " << __LINE__ << " size is " << size << dendl;
-        ldpp_dout(dpp, 20) << "AMIN: " << __func__ << "(): " << __LINE__ << " remote cache address is " << remoteCacheAddress << dendl;
-    	cacheDriver->get(dpp, key, 0, it->second->len, out_bl, obj_attrs, y);
-	if (int ret = sendRemote(dpp, victim, remoteCacheAddress, remoteKey, &out_bl, y) < 0){
-          ldpp_dout(dpp, 0) << "ERROR: " << __func__ << "(): " << __LINE__ << " sending to remote has failed: " << remoteCacheAddress << dendl;
-          delete victim;
-          return ret;
-        }
-        ldpp_dout(dpp, 20) << "AMIN: " << __func__ << "(): " << __LINE__ << " sending to remote is done: " << remoteCacheAddress << dendl;
-        if (int ret = dir->update_field(victim, "blockHosts", remoteCacheAddress, y) < 0){
-
-          ldpp_dout(dpp, 0) << "ERROR: " << __func__ << "(): " << __LINE__ << " updating directory has failed!" << dendl;
-          delete victim;
-          return ret;
-        }
-        ldpp_dout(dpp, 20) << "AMIN: " << __func__ << "(): " << __LINE__  << dendl;
-	
-      }
-     }
-    */
-
-     //If the block still the candidate, if not,choose another one
-     std::string key_top = entries_heap.top()->key;
-     if (key_top != key){
-       ldpp_dout(dpp, 20) << "AMIN: " << __func__ << "(): " << __LINE__  << " There is a better block to evict: " << key << dendl;
-       delete victim;
-       continue;
-     }
-     else{
-       ldpp_dout(dpp, 20) << "AMIN: " << __func__ << "(): " << __LINE__  << " Still the best candidate: " << key << dendl;
-     }
-    }
-
-
-    victim->globalWeight += it->second->localWeight;
-    globalWeight = std::to_string(victim->globalWeight);
-    if (int ret = blockDir->update_field(dpp, victim, "globalWeight", globalWeight, y) < 0) {
-      delete victim;
-      return ret;
-    }
-
-    ldpp_dout(dpp, 20) << "AMIN: " << __func__ << "(): " << __LINE__  << " key: " << key << dendl;
-
-    auto localWeight = it->second->localWeight;
-    _erase(dpp, key, y);
-    l.unlock();
-
-    bool deleted = false;
-    ldpp_dout(dpp, 20) << "AMIN: " << __func__ << "(): " << __LINE__  << " key: " << key << dendl;
-
-
-    l.unlock();
-
-    //Need to get and then update the host atomically in a remote setup
-    if ((ret = blockDir->remove_host(dpp, victim, dpp->get_cct()->_conf->rgw_d4n_local_rgw_address, y)) < 0) {
-      delete victim;
-      return ret;
-    }
-
-    delete victim;
-
-    if ((ret = cacheDriver->delete_data(dpp, key, y)) < 0) {
-      return ret;
-    }
-
-    /* AMIN: FIXME: we need to delete head objects
-    ldpp_dout(dpp, 20) << "AMIN: " << __func__ << "(): " << __LINE__ << " after delete data: " << key << dendl;
-    if (deleted) { // last data block
-      std::string head_oid_in_cache = victim->cacheObj.bucketName + "_" + victim->version + "_" + victim->cacheObj.objName;
-      delete victim;
-      ldpp_dout(dpp, 10) << "LFUDAPolicy::" << __func__ << "(): Deleting head object " << head_oid_in_cache << "." << dendl;
-      // delete head object in cache
-      if ((ret = cacheDriver->delete_data(dpp, head_oid_in_cache, null_yield)) == 0) { 
-	if (!(ret = erase(dpp, head_oid_in_cache, null_yield))) { // TODO: Is a lock needed here when one is in the erase method already?
-	  ldpp_dout(dpp, 0) << "Failed to delete head policy entry for: " << head_oid_in_cache << ", ret=" << ret << dendl;
-	  return -EINVAL;
 	}
-      } else {
-	ldpp_dout(dpp, 0) << "Failed to delete head object for: " << head_oid_in_cache << ", ret=" << ret << dendl;
-	return -EINVAL;
+
+    ldpp_dout(dpp, 20) << __func__ << "(): " << __LINE__ << " Victim host list size is " << block.cacheObj.hostsList.size() << dendl;
+
+    //the following part takes care of updating the weight (globalWeight) of the block if this is the last copy in a remote setup
+    //and is pushed out to a remote cache where space is available
+    if (block.cacheObj.hostsList.size() == 1 && *(block.cacheObj.hostsList.begin()) == dpp->get_cct()->_conf->rgw_d4n_local_rgw_address) { // Last copy 
+	  update_global_weight = false;
+      if (block.globalWeight) {
+		entry.localWeight += block.globalWeight;
+		block.globalWeight = 0;
       }
+
+	  if (!remoteCacheAddress.empty()) {
+		if (entry.localWeight > avgWeight) {
+		  // Write the victim block to the remote cache
+		  bufferlist out_bl;
+		  rgw::sal::Attrs obj_attrs;
+
+		  int ret = cacheDriver->get(dpp, entry.key, block.blockID, block.size, out_bl, obj_attrs, y);
+		  if (ret < 0) {
+			ldpp_dout(dpp, 0) << "ERROR: " << __func__ << "(): " << __LINE__ << " Failed to retrieve victim data block from cache." << dendl;
+			return ret;
+		  } else {
+			rgw::d4n::RemoteCachePutOp::RemoteCachePutOpData op {
+			  entry.bucketName,
+			  block.cacheObj.objName,
+			  block.blockID,
+			  block.size,
+			  block.version,
+			  false,
+			  entry.user,
+			  remoteCacheAddress,
+			  block.cacheObj.size
+			};
+			std::unique_ptr<rgw::d4n::RemoteCachePutOp> remote_put = std::make_unique<rgw::d4n::RemoteCachePutOp>(driver, op, true);
+			if ((ret = remote_put->send_and_complete_request(dpp, y, &out_bl)) < 0){
+			  ldpp_dout(dpp, 0) << "ERROR: " << __func__ << "(): " << __LINE__ << " Sending to remote has failed: " << remoteCacheAddress << dendl;
+			  return ret;
+			}
+			ldpp_dout(dpp, 20) << __func__ << "(): " << __LINE__ << " Sending to remote is done." << dendl;
+			update_global_weight = true;
+		  } 
+	    }
+	  }
     }
-    AMIN END  */
 
-    //set_read_flag(dpp, key, 0); //FIXME: AMIN: is this line needed?
+	// Only update victim block's global weight if the block wasn't completely evicted 
+    if (update_global_weight) {
+	  block.globalWeight += entry.localWeight;
+	  globalWeight = std::to_string(block.globalWeight);
+	  if (int ret = blockDir->update_field(dpp, &block, "globalWeight", globalWeight, y) < 0) {
+		return ret;
+	  }
 
-    ldpp_dout(dpp, 10) << "LFUDAPolicy::" << __func__ << "(): Block " << key << " has been evicted." << dendl;
+	  //Need to get and then update the host atomically in a remote setup
+	  if ((ret = blockDir->remove_host(dpp, &block, dpp->get_cct()->_conf->rgw_d4n_local_rgw_address, y)) < 0) {
+		ldpp_dout(dpp, 0) << "ERROR: " << __func__ << "(): " << __LINE__ << " Failed to remove local host from victim block." << dendl;
+		return ret;
+	  }
+    }
 
-    //erase also updates weightSum, is the following needed?
-    weightSum = (avgWeight * entries_map.size()) - it->second->localWeight;
 
-    age = std::max(it->second->localWeight, age);
+    if ((ret = cacheDriver->delete_data(dpp, entry.key, y)) < 0) {
+      ldpp_dout(dpp, 0) << "ERROR: " << __func__ << "(): " << __LINE__ << " Failed to delete victim block from cache." << dendl;
+      return ret;
+    }
 
+    ldpp_dout(dpp, 10) << "LFUDAPolicy::" << __func__ << "(): Block " << block.cacheObj.objName << " has been evicted." << dendl;
 
     if (perfcounter) {
       perfcounter->inc(l_rgw_d4n_cache_evictions);
     }
-    freeSpace = cacheDriver->get_free_space(dpp, y);
   }
-  
+
   return 0;
 }
 
@@ -677,7 +553,7 @@ bool LFUDAPolicy::update_refcount_if_key_exists(const DoutPrefixProvider* dpp, c
   return true;
 }
 
-void LFUDAPolicy::update(const DoutPrefixProvider* dpp, const std::string& key, uint64_t offset, uint64_t len, const std::string& version, std::optional<bool> dirty, const rgw_user user, uint8_t op, optional_yield y, std::string& restore_val)
+void LFUDAPolicy::update(const DoutPrefixProvider* dpp, const std::string& key, uint64_t offset, uint64_t len, const std::string& version, std::optional<bool> dirty, const rgw_user user, const std::string& bucketName, uint8_t op, optional_yield y, std::string& restore_val)
 {
   ldpp_dout(dpp, 10) << "LFUDAPolicy::" << __func__ << "(): updating entry: " << key << dendl;
   using handle_type = boost::heap::fibonacci_heap<LFUDAEntry*, boost::heap::compare<EntryComparator<LFUDAEntry>>>::handle_type;
@@ -736,7 +612,7 @@ void LFUDAPolicy::update(const DoutPrefixProvider* dpp, const std::string& key, 
     entry->localWeight = localWeight;
     entries_heap.update(entry->handle, entry);
   } else {
-    LFUDAEntry* e = new LFUDAEntry(key, offset, len, version, is_dirty, refcount, user, localWeight);
+    LFUDAEntry* e = new LFUDAEntry(key, offset, len, version, is_dirty, refcount, user, localWeight, bucketName);
     handle_type handle = entries_heap.push(e);
     e->set_handle(handle);
     entries_map.emplace(key, e);
@@ -1104,7 +980,7 @@ void LFUDAPolicy::cleaning(const DoutPrefixProvider* dpp)
 	    std::string oid_in_cache = rgw::sal::get_key_in_cache(e->key, std::to_string(fst), std::to_string(cur_len));
 	    ldpp_dout(dpp, 20) << __func__ << "(): oid_in_cache =" << oid_in_cache << dendl;
 	    //Update in-memory data structure for each block
-	    this->update(dpp, oid_in_cache, 0, 0, e->version, false, e->user, 0, y);
+			this->update(dpp, oid_in_cache, 0, 0, e->version, false, e->user, e->bucket_name, 0, y);
 
 	    rgw::d4n::CacheBlock block;
 	    block.cacheObj.bucketName = c_obj->get_bucket()->get_bucket_id();
@@ -1128,7 +1004,7 @@ void LFUDAPolicy::cleaning(const DoutPrefixProvider* dpp)
   //head block exists only for delete marker
   if (e->delete_marker) {
     //invoke update() with dirty flag set to false, to update in-memory metadata for head
-    this->update(dpp, e->key, 0, 0, e->version, false, e->user, 0, y);
+		this->update(dpp, e->key, 0, 0, e->version, false, e->user, e->bucket_name, 0, y);
     if ((ret = cacheDriver->set_attr(dpp, e->key, RGW_CACHE_ATTR_DIRTY, "0", y)) < 0) {
       ldpp_dout(dpp, 0) << __func__ << "(): Failed to update dirty attr in cache, ret=" << op_ret << dendl;
     }
@@ -1252,28 +1128,6 @@ void LFUDAPolicy::cleaning(const DoutPrefixProvider* dpp)
   } //end-while true
 }
 
-void LFUDAPolicy::set_read_flag(const DoutPrefixProvider* dpp, std::string key, int value)
-{
-  auto it = entries_map.find(key);
-  if (it == entries_map.end()) {
-    return;
-  }
-  
-  it->second->read_flag = value;
-  ldpp_dout(dpp, 20) << "AMIN: " << __func__ << "(): " << __LINE__ << " key: " << key  << " read flag is set to: " << value << dendl;
-  return;
-}
-
-int LFUDAPolicy::get_read_flag(const DoutPrefixProvider* dpp, std::string key)
-{
-  auto it = entries_map.find(key);
-  if (it == entries_map.end()) {
-    return -1;
-  }
-  
-  return it->second->read_flag;
-}
-
 int LRUPolicy::exist_key(const std::string& key)
 {
   const std::lock_guard l(lru_lock);
@@ -1304,7 +1158,7 @@ int LRUPolicy::eviction(const DoutPrefixProvider* dpp, uint64_t size, optional_y
   return 0;
 }
 
-void LRUPolicy::update(const DoutPrefixProvider* dpp, const std::string& key, uint64_t offset, uint64_t len, const std::string& version, std::optional<bool> dirty, const rgw_user user, uint8_t op, optional_yield y, std::string& restore_val)
+void LRUPolicy::update(const DoutPrefixProvider* dpp, const std::string& key, uint64_t offset, uint64_t len, const std::string& version, std::optional<bool> dirty, const rgw_user user, const std::string& bucketName, uint8_t op, optional_yield y, std::string& restore_val)
 {
   const std::lock_guard l(lru_lock);
   _erase(dpp, key, y);
@@ -1312,7 +1166,7 @@ void LRUPolicy::update(const DoutPrefixProvider* dpp, const std::string& key, ui
   if (dirty.has_value()) {
     is_dirty = dirty.value();
   }
-  Entry* e = new Entry(key, offset, len, version, is_dirty, 0, user);
+  Entry* e = new Entry(key, offset, len, version, is_dirty, 0, user, bucketName);
   entries_lru_list.push_back(*e);
   entries_map.emplace(key, e);
 }

--- a/src/rgw/driver/d4n/d4n_policy.cc
+++ b/src/rgw/driver/d4n/d4n_policy.cc
@@ -110,8 +110,8 @@ int LFUDAPolicy::init(CephContext* cct, const DoutPrefixProvider* dpp, asio::io_
   };
 
   static auto block_callback = [this](
-          const DoutPrefixProvider* dpp, const std::string& key, uint64_t offset, uint64_t len, const std::string& version, bool dirty, optional_yield y, std::string& restore_val) {
-    update(dpp, key, offset, len, version, dirty, RefCount::NOOP, y, restore_val);
+          const DoutPrefixProvider* dpp, const std::string& key, uint64_t offset, uint64_t len, const std::string& version, bool dirty, const rgw_user user, optional_yield y, std::string& restore_val) {
+    update(dpp, key, offset, len, version, dirty, user, RefCount::NOOP, y, restore_val);
   };
 
   cacheDriver->restore_blocks_objects(dpp, obj_callback, block_callback);
@@ -152,6 +152,40 @@ int LFUDAPolicy::init(CephContext* cct, const DoutPrefixProvider* dpp, asio::io_
   asio::co_spawn(io_context.get_executor(),
 		   redis_sync(dpp, y), asio::detached);
 
+  return 0;
+}
+
+int LFUDAPolicy::getMinAvgWeight(const DoutPrefixProvider* dpp, int *minAvgWeight, std::string *cache_address, optional_yield y) {
+  response<std::string, std::string, std::string> resp;
+
+  try { 
+    boost::system::error_code ec;
+    request req;
+    req.push("HGET", "lfuda", "minLocalWeights_sum");
+    req.push("HGET", "lfuda", "minLocalWeights_size");
+    req.push("HGET", "lfuda", "minLocalWeights_address");
+      
+    redis_exec(conn, ec, req, resp, y);
+
+    if (ec) {
+      ldpp_dout(dpp, 10) << "AMIN " << __func__ << "() Error: " << ec.value() << dendl;
+      return -ec.value();
+    }
+  } catch (std::exception &e) {
+    ldpp_dout(dpp, 10) << "AMIN " << __func__ << "() Error: " << "EINVAL" << dendl;
+    return -EINVAL;
+  }
+
+  ldpp_dout(dpp, 10) << "AMIN " << __func__ << "() resp<0> is " << std::get<0>(resp).value() << dendl;
+  ldpp_dout(dpp, 10) << "AMIN " << __func__ << "() resp<1> is " << std::get<1>(resp).value() << dendl;
+  ldpp_dout(dpp, 10) << "AMIN " << __func__ << "() resp<2> is " << std::get<2>(resp).value() << dendl;
+
+  if (std::stoi(std::get<1>(resp).value()) > 0)
+    *minAvgWeight =  std::stoi(std::get<0>(resp).value()) / std::stoi(std::get<1>(resp).value());
+  else
+    *minAvgWeight = 0; 
+  *cache_address =  std::get<2>(resp).value();
+  ldpp_dout(dpp, 10) << "AMIN " << __func__ << "() cache_address is " << cache_address << dendl;
   return 0;
 }
 
@@ -373,6 +407,61 @@ int LFUDAPolicy::exist_key(const std::string& key) {
   return false;
 }
 
+int LFUDAPolicy::sendRemote(const DoutPrefixProvider* dpp, CacheBlock* victim, std::string remoteCacheAddress, std::string key, bufferlist* out_bl, optional_yield y)
+{
+  bufferlist in_bl;
+  rgw::sal::RGWRemoteD4NGetCB cb(&in_bl);
+  std::string bucketName = victim->cacheObj.bucketName;
+ 
+  RGWAccessKey accessKey;
+  std::string findKey;
+  
+  if (key[0] == 'D') {
+    findKey = key.substr(2, key.length());
+  } else {
+    findKey = key;
+  }
+  
+  auto it = entries_map.find(findKey);
+  if (it == entries_map.end()) {
+    return -ENOENT;
+  }
+  auto user = it->second->user;
+  std::unique_ptr<rgw::sal::User> c_user = driver->get_user(user);
+  int ret = c_user->load_user(dpp, y);
+  if (ret < 0) {
+    return -EPERM;
+  }
+
+  if (c_user->get_info().access_keys.empty()) {
+    return -EINVAL;
+  }
+
+  accessKey.id = c_user->get_info().access_keys.begin()->second.id;
+  accessKey.key = c_user->get_info().access_keys.begin()->second.key;
+
+  HostStyle host_style = PathStyle;
+  std::map<std::string, std::string> extra_headers;                                                            
+
+  auto sender = new RGWRESTStreamRWRequest(dpp->get_cct(), "PUT", remoteCacheAddress, &cb, NULL, NULL, "", host_style);
+
+  ret = sender->send_request(dpp, &accessKey, extra_headers, "admin/remoted4n/"+bucketName+"/"+key, nullptr, out_bl);                 
+  if (ret < 0) {                                                                                      
+    delete sender;                                                                                       
+    return ret;                                                                                       
+  }                                                                                                   
+  
+  std::string etag;
+  std::map<std::string, std::string> pattrs;
+  ret = sender->complete_request(dpp, y, &etag, 0, 0, &pattrs, &pattrs);                                                            
+  if (ret < 0){
+    delete sender;                                                                                   
+    return ret;
+   }
+
+  return 0;
+}	
+
 int LFUDAPolicy::eviction(const DoutPrefixProvider* dpp, uint64_t size, optional_yield y) {
   int ret = -1;
   uint64_t freeSpace = cacheDriver->get_free_space(dpp, y);
@@ -394,42 +483,122 @@ int LFUDAPolicy::eviction(const DoutPrefixProvider* dpp, uint64_t size, optional
       delete victim;
       l.unlock();
       return -ENOENT;
+    } else {//victim block is getting read, no suitable block to evict
+      if (it->second->read_flag == 1){
+        ldpp_dout(dpp, 20) << "AMIN: " << __func__ << "(): " << __LINE__ << " Error: the Block is getting read!" << dendl;
+        delete victim;
+        l.unlock();
+        return -ENOENT;
+      }
     }
 
-    int avgWeight = weightSum / entries_map.size();
-    /* the following part takes care of updating the weight (globalWeight) of the block if this is the last copy in a remote setup
-       and is pushed out to a remote cache where space is available */
-#if 0
-    if (victim->cacheObj.hostsList.size() == 1 && *(victim->cacheObj.hostsList.begin()) == dpp->get_cct()->_conf->rgw_d4n_local_rgw_address) { /* Last copy */
+    set_read_flag(dpp, key, 2); //it is getting deleted.
+
+    std::string globalWeight;
+    int localAvgWeight = weightSum / entries_map.size();
+
+    //FIXME: remoteCacheAddress is getting overriden by a new cache. it should be updates instead.
+    int avgWeight;
+    std::string remoteCacheAddress;
+    if (getMinAvgWeight(dpp, &avgWeight, &remoteCacheAddress, y) < 0){
+      ldpp_dout(dpp, 10) << "LFUDAPolicy::" << __func__ << "(): Could not retrieve min average weight." << dendl;
+      delete victim;
+      return -ENOENT;
+    }
+    //remove this after the fix
+    remoteCacheAddress = dpp->get_cct()->_conf->rgw_d4n_remote_cache_address;
+
+    ldpp_dout(dpp, 20) << "AMIN: " << __func__ << "(): " << __LINE__ << " remote cache address is " << remoteCacheAddress << dendl;
+    ldpp_dout(dpp, 20) << "AMIN: " << __func__ << "(): " << __LINE__ << " victim host list size is " << victim->cacheObj.hostsList.size() << dendl;
+    ldpp_dout(dpp, 20) << "AMIN: " << __func__ << "(): " << __LINE__ << " victim host list is " << *(victim->cacheObj.hostsList.begin()) << dendl;
+
+    /* the following part takes care of updating the weight (globalWeight) of the block if this is the last copy in a remote setup and is pushed out to a remote cache where space is available */
+
+    if (victim->cacheObj.hostsList.size() == 1 && *(victim->cacheObj.hostsList.begin()) == dpp->get_cct()->_conf->rgw_d4n_local_rgw_address) { // Last copy 
+      ldpp_dout(dpp, 20) << "AMIN: " << __func__ << "(): " << __LINE__ << dendl;
       if (victim->globalWeight) {
 	it->second->localWeight += victim->globalWeight;
         (*it->second->handle)->localWeight = it->second->localWeight;
-	entries_heap.decrease(it->second->handle); // larger value means node must be decreased to maintain min heap 
-	if ((ret = cacheDriver->set_attr(dpp, key, RGW_CACHE_ATTR_LOCAL_WEIGHT, std::to_string(it->second->localWeight), y)) < 0) { 
+	entries_heap.decrease(it->second->handle);
+
+	if (int ret = cacheDriver->set_attr(dpp, key, "user.rgw.localWeight", std::to_string(it->second->localWeight), y) < 0) { 
 	  delete victim;
 	  return ret;
         }
 
 	victim->globalWeight = 0;
+	globalWeight = std::to_string(victim->globalWeight);
+	if (int ret = blockDir->update_field(dpp, victim, "globalWeight", globalWeight, y) < 0) {
+	  delete victim;
+	  return ret;
+        }
       }
 
+  //FIXME: AMIN uncomment this
+     /*
+     if (!remoteCacheAddress.empty()){
       if (it->second->localWeight > avgWeight) {
+        ldpp_dout(dpp, 20) << "AMIN: " << __func__ << "(): " << __LINE__ << dendl;
 	// TODO: push victim block to remote cache
 	// add remote cache host to host list
+	bufferlist out_bl;
+        rgw::sal::Attrs obj_attrs;
+
+	std::string remoteKey = key;
+	if (it->second->dirty == true)
+	  remoteKey = "D_"+key; //TODO: AMIN: we should not delete dirty data. it should be cleaned first.
+
+	
+        ldpp_dout(dpp, 20) << "AMIN: " << __func__ << "(): " << __LINE__ << " size is " << size << dendl;
+        ldpp_dout(dpp, 20) << "AMIN: " << __func__ << "(): " << __LINE__ << " remote cache address is " << remoteCacheAddress << dendl;
+    	cacheDriver->get(dpp, key, 0, it->second->len, out_bl, obj_attrs, y);
+	if (int ret = sendRemote(dpp, victim, remoteCacheAddress, remoteKey, &out_bl, y) < 0){
+          ldpp_dout(dpp, 0) << "ERROR: " << __func__ << "(): " << __LINE__ << " sending to remote has failed: " << remoteCacheAddress << dendl;
+          delete victim;
+          return ret;
+        }
+        ldpp_dout(dpp, 20) << "AMIN: " << __func__ << "(): " << __LINE__ << " sending to remote is done: " << remoteCacheAddress << dendl;
+        if (int ret = dir->update_field(victim, "blockHosts", remoteCacheAddress, y) < 0){
+
+          ldpp_dout(dpp, 0) << "ERROR: " << __func__ << "(): " << __LINE__ << " updating directory has failed!" << dendl;
+          delete victim;
+          return ret;
+        }
+        ldpp_dout(dpp, 20) << "AMIN: " << __func__ << "(): " << __LINE__  << dendl;
+	
       }
+     }
+    */
+
+     //If the block still the candidate, if not,choose another one
+     std::string key_top = entries_heap.top()->key;
+     if (key_top != key){
+       ldpp_dout(dpp, 20) << "AMIN: " << __func__ << "(): " << __LINE__  << " There is a better block to evict: " << key << dendl;
+       delete victim;
+       continue;
+     }
+     else{
+       ldpp_dout(dpp, 20) << "AMIN: " << __func__ << "(): " << __LINE__  << " Still the best candidate: " << key << dendl;
+     }
     }
 
+
     victim->globalWeight += it->second->localWeight;
-    if ((ret = blockDir->update_field(dpp, victim, "globalWeight", std::to_string(victim->globalWeight), y)) < 0) {
+    globalWeight = std::to_string(victim->globalWeight);
+    if (int ret = blockDir->update_field(dpp, victim, "globalWeight", globalWeight, y) < 0) {
       delete victim;
       return ret;
     }
-#endif
-    //erase also updates weightSum, is the following needed?
-    weightSum = (avgWeight * entries_map.size()) - it->second->localWeight;
 
-    age = std::max(it->second->localWeight, age);
+    ldpp_dout(dpp, 20) << "AMIN: " << __func__ << "(): " << __LINE__  << " key: " << key << dendl;
+
+    auto localWeight = it->second->localWeight;
     _erase(dpp, key, y);
+    l.unlock();
+
+    bool deleted = false;
+    ldpp_dout(dpp, 20) << "AMIN: " << __func__ << "(): " << __LINE__  << " key: " << key << dendl;
+
 
     l.unlock();
 
@@ -445,7 +614,34 @@ int LFUDAPolicy::eviction(const DoutPrefixProvider* dpp, uint64_t size, optional
       return ret;
     }
 
+    /* AMIN: FIXME: we need to delete head objects
+    ldpp_dout(dpp, 20) << "AMIN: " << __func__ << "(): " << __LINE__ << " after delete data: " << key << dendl;
+    if (deleted) { // last data block
+      std::string head_oid_in_cache = victim->cacheObj.bucketName + "_" + victim->version + "_" + victim->cacheObj.objName;
+      delete victim;
+      ldpp_dout(dpp, 10) << "LFUDAPolicy::" << __func__ << "(): Deleting head object " << head_oid_in_cache << "." << dendl;
+      // delete head object in cache
+      if ((ret = cacheDriver->delete_data(dpp, head_oid_in_cache, null_yield)) == 0) { 
+	if (!(ret = erase(dpp, head_oid_in_cache, null_yield))) { // TODO: Is a lock needed here when one is in the erase method already?
+	  ldpp_dout(dpp, 0) << "Failed to delete head policy entry for: " << head_oid_in_cache << ", ret=" << ret << dendl;
+	  return -EINVAL;
+	}
+      } else {
+	ldpp_dout(dpp, 0) << "Failed to delete head object for: " << head_oid_in_cache << ", ret=" << ret << dendl;
+	return -EINVAL;
+      }
+    }
+    AMIN END  */
+
+    //set_read_flag(dpp, key, 0); //FIXME: AMIN: is this line needed?
+
     ldpp_dout(dpp, 10) << "LFUDAPolicy::" << __func__ << "(): Block " << key << " has been evicted." << dendl;
+
+    //erase also updates weightSum, is the following needed?
+    weightSum = (avgWeight * entries_map.size()) - it->second->localWeight;
+
+    age = std::max(it->second->localWeight, age);
+
 
     if (perfcounter) {
       perfcounter->inc(l_rgw_d4n_cache_evictions);
@@ -481,7 +677,7 @@ bool LFUDAPolicy::update_refcount_if_key_exists(const DoutPrefixProvider* dpp, c
   return true;
 }
 
-void LFUDAPolicy::update(const DoutPrefixProvider* dpp, const std::string& key, uint64_t offset, uint64_t len, const std::string& version, std::optional<bool> dirty, uint8_t op, optional_yield y, std::string& restore_val)
+void LFUDAPolicy::update(const DoutPrefixProvider* dpp, const std::string& key, uint64_t offset, uint64_t len, const std::string& version, std::optional<bool> dirty, const rgw_user user, uint8_t op, optional_yield y, std::string& restore_val)
 {
   ldpp_dout(dpp, 10) << "LFUDAPolicy::" << __func__ << "(): updating entry: " << key << dendl;
   using handle_type = boost::heap::fibonacci_heap<LFUDAEntry*, boost::heap::compare<EntryComparator<LFUDAEntry>>>::handle_type;
@@ -540,7 +736,7 @@ void LFUDAPolicy::update(const DoutPrefixProvider* dpp, const std::string& key, 
     entry->localWeight = localWeight;
     entries_heap.update(entry->handle, entry);
   } else {
-    LFUDAEntry* e = new LFUDAEntry(key, offset, len, version, is_dirty, refcount, localWeight);
+    LFUDAEntry* e = new LFUDAEntry(key, offset, len, version, is_dirty, refcount, user, localWeight);
     handle_type handle = entries_heap.push(e);
     e->set_handle(handle);
     entries_map.emplace(key, e);
@@ -908,7 +1104,7 @@ void LFUDAPolicy::cleaning(const DoutPrefixProvider* dpp)
 	    std::string oid_in_cache = rgw::sal::get_key_in_cache(e->key, std::to_string(fst), std::to_string(cur_len));
 	    ldpp_dout(dpp, 20) << __func__ << "(): oid_in_cache =" << oid_in_cache << dendl;
 	    //Update in-memory data structure for each block
-	    this->update(dpp, oid_in_cache, 0, 0, e->version, false, 0, y);
+	    this->update(dpp, oid_in_cache, 0, 0, e->version, false, e->user, 0, y);
 
 	    rgw::d4n::CacheBlock block;
 	    block.cacheObj.bucketName = c_obj->get_bucket()->get_bucket_id();
@@ -916,7 +1112,7 @@ void LFUDAPolicy::cleaning(const DoutPrefixProvider* dpp)
 	    block.size = cur_len;
 	    block.blockID = fst;
             if ((op_ret = cacheDriver->set_attr(dpp, oid_in_cache, RGW_CACHE_ATTR_DIRTY, "0", y)) == 0) {
-        std::string dirty = "false";
+	      std::string dirty = "false";
 	      op_ret = blockDir->update_field(dpp, &block, "dirty", dirty, null_yield);
 	      if (op_ret < 0) {
 		ldpp_dout(dpp, 0) << __func__ << "updating dirty flag in block directory failed, ret=" << op_ret << dendl;
@@ -932,7 +1128,7 @@ void LFUDAPolicy::cleaning(const DoutPrefixProvider* dpp)
   //head block exists only for delete marker
   if (e->delete_marker) {
     //invoke update() with dirty flag set to false, to update in-memory metadata for head
-    this->update(dpp, e->key, 0, 0, e->version, false, 0, y);
+    this->update(dpp, e->key, 0, 0, e->version, false, e->user, 0, y);
     if ((ret = cacheDriver->set_attr(dpp, e->key, RGW_CACHE_ATTR_DIRTY, "0", y)) < 0) {
       ldpp_dout(dpp, 0) << __func__ << "(): Failed to update dirty attr in cache, ret=" << op_ret << dendl;
     }
@@ -1056,6 +1252,28 @@ void LFUDAPolicy::cleaning(const DoutPrefixProvider* dpp)
   } //end-while true
 }
 
+void LFUDAPolicy::set_read_flag(const DoutPrefixProvider* dpp, std::string key, int value)
+{
+  auto it = entries_map.find(key);
+  if (it == entries_map.end()) {
+    return;
+  }
+  
+  it->second->read_flag = value;
+  ldpp_dout(dpp, 20) << "AMIN: " << __func__ << "(): " << __LINE__ << " key: " << key  << " read flag is set to: " << value << dendl;
+  return;
+}
+
+int LFUDAPolicy::get_read_flag(const DoutPrefixProvider* dpp, std::string key)
+{
+  auto it = entries_map.find(key);
+  if (it == entries_map.end()) {
+    return -1;
+  }
+  
+  return it->second->read_flag;
+}
+
 int LRUPolicy::exist_key(const std::string& key)
 {
   const std::lock_guard l(lru_lock);
@@ -1086,7 +1304,7 @@ int LRUPolicy::eviction(const DoutPrefixProvider* dpp, uint64_t size, optional_y
   return 0;
 }
 
-void LRUPolicy::update(const DoutPrefixProvider* dpp, const std::string& key, uint64_t offset, uint64_t len, const std::string& version, std::optional<bool> dirty, uint8_t op, optional_yield y, std::string& restore_val)
+void LRUPolicy::update(const DoutPrefixProvider* dpp, const std::string& key, uint64_t offset, uint64_t len, const std::string& version, std::optional<bool> dirty, const rgw_user user, uint8_t op, optional_yield y, std::string& restore_val)
 {
   const std::lock_guard l(lru_lock);
   _erase(dpp, key, y);
@@ -1094,7 +1312,7 @@ void LRUPolicy::update(const DoutPrefixProvider* dpp, const std::string& key, ui
   if (dirty.has_value()) {
     is_dirty = dirty.value();
   }
-  Entry* e = new Entry(key, offset, len, version, is_dirty, 0);
+  Entry* e = new Entry(key, offset, len, version, is_dirty, 0, user);
   entries_lru_list.push_back(*e);
   entries_map.emplace(key, e);
 }

--- a/src/rgw/driver/d4n/d4n_policy.cc
+++ b/src/rgw/driver/d4n/d4n_policy.cc
@@ -52,10 +52,61 @@ static inline void redis_exec(std::shared_ptr<connection> conn,
 int LFUDAPolicy::init(CephContext* cct, const DoutPrefixProvider* dpp, asio::io_context& io_context, rgw::sal::Driver* _driver) {
   response<int, int, int, int> resp;
   static auto obj_callback = [this](
-          const DoutPrefixProvider* dpp, const std::string& key, const std::string& version, bool deleteMarker, uint64_t size, 
-			    double creationTime, const rgw_user user, const std::string& etag, const std::string& bucket_name, const std::string& bucket_id,
-			    const rgw_obj_key& obj_key, optional_yield y, std::string& restore_val) {
-    update_dirty_object(dpp, key, version, deleteMarker, size, creationTime, user, etag, bucket_name, bucket_id, obj_key, RefCount::NOOP, y, restore_val);
+          const DoutPrefixProvider* dpp, const std::string& key, const std::string& version, bool deleteMarker, const std::string& bucket_id,
+			    const rgw_obj_key& obj_key, const std::string& instance, optional_yield y, std::string& restore_val) {
+    std::string dirty_obj_key = rgw::sal::get_cache_block_prefix(bucket_id, obj_key.name, version);
+    if (!find_obj_entry(dirty_obj_key)) {
+      rgw::d4n::CacheBlock block;
+      if (instance == "null") {
+        block.cacheObj.objName = "_:null_" + obj_key.name;
+      } else {
+        block.cacheObj.objName = obj_key.get_oid();
+      }
+      block.cacheObj.bucketName = bucket_id;
+      block.blockID = 0;
+      block.size = 0;
+      auto ret = blockDir->get(dpp, &block, y);
+      if (ret < 0) {
+        //this can happen for invalid dirty objects (have been deleted)
+        ldpp_dout(dpp, 0) << "LFUDAPolicy::" << __func__ << "() blockDir->get() failed: " << ret << dendl;
+        return;
+      }
+      rgw::sal::Attrs attrs = std::move(block.cacheObj.attrs);
+      std::string etag;
+      if (auto i = attrs.find(RGW_ATTR_ETAG); i != attrs.end()) {
+        etag = i->second.to_str();
+        ldpp_dout(dpp, 20) << "LFUDAPolicy: " << __func__ << "(): etag: " << etag << dendl;
+      }
+      uint64_t size = 0;
+      if (auto i = attrs.find(RGW_CACHE_ATTR_OBJECT_SIZE); i != attrs.end()) {
+        size = std::stoull(i->second.to_str());
+        ldpp_dout(dpp, 20) << "LFUDAPolicy: " << __func__ << "(): size: " << size << dendl;
+      }
+      double creationTime = 0;
+      if (auto i = attrs.find(RGW_CACHE_ATTR_MTIME); i != attrs.end()) {
+        creationTime = std::stod(i->second.to_str());
+        ldpp_dout(dpp, 20) << "LFUDAPolicy: " << __func__ << "(): creationTime: " << creationTime << dendl;
+      }
+      rgw_user user;
+      if (auto i = attrs.find(RGW_ATTR_ACL); i != attrs.end()) {
+        bufferlist bl_acl = i->second;
+        RGWAccessControlPolicy policy;
+        auto iter = bl_acl.cbegin();
+        try {
+          policy.decode(iter);
+        } catch (buffer::error& err) {
+          ldpp_dout(dpp, 0) << "ERROR: could not decode policy, caught buffer::error" << dendl;
+        }
+        user = std::get<rgw_user>(policy.get_owner().id);
+        ldpp_dout(dpp, 20) << "LFUDAPolicy: " << __func__ << "(): rgw_user: " << user.to_str() << dendl;
+      }
+      std::string bucket_name;
+      if (auto i = attrs.find(RGW_CACHE_ATTR_BUCKET_NAME); i != attrs.end()) {
+        bucket_name = i->second.to_str();
+        ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): bucket_name: " << bucket_name << dendl;
+      }
+      update_dirty_object(dpp, dirty_obj_key, version, deleteMarker, size, creationTime, user, etag, bucket_name, bucket_id, obj_key, RefCount::NOOP, y, restore_val);
+    }
   };
 
   static auto block_callback = [this](
@@ -263,10 +314,12 @@ bool LFUDAPolicy::invalidate_dirty_object(const DoutPrefixProvider* dpp, const s
   if (p->second.second == State::INIT) {
     ldpp_dout(dpp, 10) << "LFUDAPolicy::" << __func__ << "(): Setting State::INVALID for key=" << key << dendl;
     p->second.second = State::INVALID;
-    int ret = cacheDriver->set_attr(dpp, key, RGW_CACHE_ATTR_INVALID, "1", y);
-    if (ret < 0) {
-      ldpp_dout(dpp, 0) << "LFUDAPolicy::" << __func__ << "(): Failed to set xattr, ret=" << ret << dendl;
-      return false;
+    //head block is only for delete marker
+    if(p->second.first->delete_marker) {
+      if(int ret = cacheDriver->set_attr(dpp, key, RGW_CACHE_ATTR_INVALID, "1", y); ret < 0) {
+        ldpp_dout(dpp, 0) << "LFUDAPolicy::" << __func__ << "(): Failed to set xattr, ret=" << ret << dendl;
+        return false;
+      }
     }
     return true;
   } else if (p->second.second == State::IN_PROGRESS) {
@@ -659,13 +712,15 @@ void LFUDAPolicy::cleaning(const DoutPrefixProvider* dpp)
 	    continue;
 	  }
 	  ll.unlock();
-	  if ((ret = cacheDriver->delete_data(dpp, e->key, y)) == 0) {
-	    if (!(ret = erase(dpp, e->key, y))) {
-	      ldpp_dout(dpp, 0) << "Failed to delete head policy entry for: " << e->key << ", ret=" << ret << dendl; // TODO: what must occur during failure?
-	    }
-	  } else {
-	    ldpp_dout(dpp, 0) << "Failed to delete head object for: " << e->key << ", ret=" << ret << dendl;
-	  }
+    if (e->delete_marker) {
+      if ((ret = cacheDriver->delete_data(dpp, e->key, y)) == 0) {
+        if (!(ret = erase(dpp, e->key, y))) {
+          ldpp_dout(dpp, 0) << "Failed to delete head policy entry for: " << e->key << ", ret=" << ret << dendl; // TODO: what must occur during failure?
+        }
+      } else {
+        ldpp_dout(dpp, 0) << "Failed to delete head object for: " << e->key << ", ret=" << ret << dendl;
+      }
+    }
 	} else {
 	  //ignore if block not found, as it could have been deleted earlier when refcount for it was 0
 	  ll.unlock();
@@ -763,6 +818,7 @@ void LFUDAPolicy::cleaning(const DoutPrefixProvider* dpp)
 	  off_t ofs = 0;
 
 	  rgw::sal::DataProcessor* filter = processor.get();
+    #if 0
 	  bufferlist bl;
 	  op_ret = cacheDriver->get_attrs(dpp, e->key, obj_attrs, null_yield); //get obj attrs from head
 	  if (op_ret < 0) {
@@ -770,6 +826,17 @@ void LFUDAPolicy::cleaning(const DoutPrefixProvider* dpp)
 	    erase_dirty_object(dpp, e->key, null_yield);
 	    continue;
 	  }
+    #endif
+    rgw::d4n::CacheBlock block;
+    block.cacheObj.objName = e->obj_key.get_oid();
+    block.cacheObj.bucketName = e->bucket_id;
+    block.blockID = 0;
+    block.size = 0;
+    auto ret = blockDir->get(dpp, &block, null_yield);
+    if (ret < 0) {
+      ldpp_dout(dpp, 0) << "LFUDAPolicy::" << __func__ << "() blockDir->get() failed: " << ret << dendl;
+    }
+    obj_attrs = std::move(block.cacheObj.attrs);
 	  obj_attrs.erase(RGW_CACHE_ATTR_MTIME);
 	  obj_attrs.erase(RGW_CACHE_ATTR_OBJECT_SIZE);
 	  obj_attrs.erase(RGW_CACHE_ATTR_ACCOUNTED_SIZE);
@@ -862,13 +929,14 @@ void LFUDAPolicy::cleaning(const DoutPrefixProvider* dpp)
 	  } while(fst < lst);
 	} //end-else if delete_marker
 
-	//invoke update() with dirty flag set to false, to update in-memory metadata for head
-	this->update(dpp, e->key, 0, 0, e->version, false, 0, y);
-         
-        if ((ret = cacheDriver->set_attr(dpp, e->key, RGW_CACHE_ATTR_DIRTY, "0", y)) < 0) {
-	  ldpp_dout(dpp, 0) << __func__ << "(): Failed to update dirty attr in cache, ret=" << op_ret << dendl;
-        }
-
+  //head block exists only for delete marker
+  if (e->delete_marker) {
+    //invoke update() with dirty flag set to false, to update in-memory metadata for head
+    this->update(dpp, e->key, 0, 0, e->version, false, 0, y);
+    if ((ret = cacheDriver->set_attr(dpp, e->key, RGW_CACHE_ATTR_DIRTY, "0", y)) < 0) {
+      ldpp_dout(dpp, 0) << __func__ << "(): Failed to update dirty attr in cache, ret=" << op_ret << dendl;
+    }
+  }
 	if (null_instance) {
 	  //restore instance for directory data processing in later steps
 	  c_obj->set_instance("null");

--- a/src/rgw/driver/d4n/d4n_policy.cc
+++ b/src/rgw/driver/d4n/d4n_policy.cc
@@ -387,6 +387,7 @@ int LFUDAPolicy::get_victim_block(const DoutPrefixProvider* dpp, CacheBlock* vic
     return -ENOENT;
   }
 
+  ldpp_dout(dpp, 0) << "LFUDAPolicy::" << __func__ << "(): Victim name: " << victim->cacheObj.objName << dendl;
   return 0;
 }
 
@@ -400,6 +401,10 @@ int LFUDAPolicy::exist_key(const std::string& key) {
 }
 
 int LFUDAPolicy::eviction(const DoutPrefixProvider* dpp, uint64_t size, optional_yield y) {
+  if (dpp->get_cct()->_conf->rgw_d4n_local_rgw_address == "127.0.0.1:8001") {
+    return 0;
+  }
+
   int ret = -1;
   std::vector<LFUDAEntry> to_delete;
 
@@ -409,12 +414,13 @@ int LFUDAPolicy::eviction(const DoutPrefixProvider* dpp, uint64_t size, optional
     std::unique_lock<std::mutex> lfuda_l(lfuda_lock);
 
     uint64_t freed = 0;
-    while (freed < size) {
+   // while (freed < size) {
 	  CacheBlock victim;
 	  ret = get_victim_block(dpp, &victim, y);
       if (ret == -ENOENT) {
         ldpp_dout(dpp, 0) << "LFUDAPolicy::" << __func__ << "(): Could not retrieve victim block." << dendl;
-        return -ENOSPC;
+		return 0;
+		//return -ENOSPC;
       }
 
 	  std::string victim_key = entries_heap.top()->key;
@@ -429,7 +435,7 @@ int LFUDAPolicy::eviction(const DoutPrefixProvider* dpp, uint64_t size, optional
       _erase(dpp, victim_key, y);
       freed += victim_size;
     }
-  } // lfuda_lock released
+  //} // lfuda_lock released
 
   // Outside both locks, do expensive I/O
   for (auto& entry : to_delete) {

--- a/src/rgw/driver/d4n/d4n_policy.h
+++ b/src/rgw/driver/d4n/d4n_policy.h
@@ -38,8 +38,10 @@ class CachePolicy {
       std::string version;
       bool dirty;
       uint64_t refcount{0};
-      Entry(const std::string& key, uint64_t offset, uint64_t len, const std::string& version, bool dirty, uint64_t refcount) : key(key), offset(offset), 
-											        len(len), version(version), dirty(dirty), refcount(refcount) {}
+      rgw_user user;
+      int read_flag = 0;
+      Entry(const std::string& key, uint64_t offset, uint64_t len, const std::string& version, bool dirty, uint64_t refcount, rgw_user user) : key(key), offset(offset), 
+											        len(len), version(version), dirty(dirty), refcount(refcount), user(user) {}
       };
    
     //The disposer object function
@@ -76,7 +78,7 @@ class CachePolicy {
     virtual int exist_key(const std::string& key) = 0;
     virtual int eviction(const DoutPrefixProvider* dpp, uint64_t size, optional_yield y) = 0;
     virtual bool update_refcount_if_key_exists(const DoutPrefixProvider* dpp, const std::string& key, uint8_t op, optional_yield y) = 0;
-    virtual void update(const DoutPrefixProvider* dpp, const std::string& key, uint64_t offset, uint64_t len, const std::string& version, std::optional<bool> dirty, uint8_t op, optional_yield y, std::string& restore_val=empty) = 0;
+    virtual void update(const DoutPrefixProvider* dpp, const std::string& key, uint64_t offset, uint64_t len, const std::string& version, std::optional<bool> dirty, const rgw_user user, uint8_t op, optional_yield y, std::string& restore_val=empty) = 0;
     virtual void update_dirty_object(const DoutPrefixProvider* dpp, const std::string& key, const std::string& version, bool deleteMarker, uint64_t size, 
 			    double creationTime, const rgw_user& user, const std::string& etag, const std::string& bucket_name, const std::string& bucket_id,
 			    const rgw_obj_key& obj_key, uint8_t op, optional_yield y, std::string& restore_val=empty) = 0;
@@ -84,6 +86,8 @@ class CachePolicy {
     virtual bool erase_dirty_object(const DoutPrefixProvider* dpp, const std::string& key, optional_yield y) = 0;
     virtual bool invalidate_dirty_object(const DoutPrefixProvider* dpp, const std::string& key) = 0;
     virtual void cleaning(const DoutPrefixProvider* dpp) = 0;
+    virtual void set_read_flag(const DoutPrefixProvider* dpp, std::string key, int value) = 0;
+    virtual int get_read_flag(const DoutPrefixProvider* dpp, std::string key) = 0;
 };
 
 class LFUDAPolicy : public CachePolicy {
@@ -121,8 +125,8 @@ class LFUDAPolicy : public CachePolicy {
       using handle_type = boost::heap::fibonacci_heap<LFUDAEntry*, boost::heap::compare<EntryComparator<LFUDAEntry>>>::handle_type;
       handle_type handle;
 
-      LFUDAEntry(const std::string& key, uint64_t offset, uint64_t len, const std::string& version, bool dirty, uint64_t refcount, int localWeight) : Entry(key, offset, len, version, dirty, refcount), 
-														       localWeight(localWeight) {}
+      LFUDAEntry(const std::string& key, uint64_t offset, uint64_t len, const std::string& version, bool dirty, uint64_t refcount, rgw_user user, int localWeight) : Entry(key, offset, len, 
+                                                                                                                                version, dirty, refcount, user), localWeight(localWeight) {}
       
       void set_handle(handle_type handle_) { handle = handle_; }
     };
@@ -203,9 +207,11 @@ class LFUDAPolicy : public CachePolicy {
 
     virtual int init(CephContext *cct, const DoutPrefixProvider* dpp, asio::io_context& io_context, rgw::sal::Driver *_driver);
     virtual int exist_key(const std::string& key) override;
+    int sendRemote(const DoutPrefixProvider* dpp, CacheBlock* victim, std::string remoteCacheAddress, std::string key, bufferlist* out_bl, optional_yield y);
+    int getMinAvgWeight(const DoutPrefixProvider* dpp, int* minAvgWeight, std::string* cache_address, optional_yield y);
     virtual int eviction(const DoutPrefixProvider* dpp, uint64_t size, optional_yield y) override;
     virtual bool update_refcount_if_key_exists(const DoutPrefixProvider* dpp, const std::string& key, uint8_t op, optional_yield y) override;
-    virtual void update(const DoutPrefixProvider* dpp, const std::string& key, uint64_t offset, uint64_t len, const std::string& version, std::optional<bool> dirty, uint8_t op, optional_yield y, std::string& restore_val=empty) override;
+    virtual void update(const DoutPrefixProvider* dpp, const std::string& key, uint64_t offset, uint64_t len, const std::string& version, std::optional<bool> dirty, const rgw_user user, uint8_t op, optional_yield y, std::string& restore_val=empty) override;
     virtual bool erase(const DoutPrefixProvider* dpp, const std::string& key, optional_yield y) override;
     virtual bool _erase(const DoutPrefixProvider* dpp, const std::string& key, optional_yield y);
     virtual void update_dirty_object(const DoutPrefixProvider* dpp, const std::string& key, const std::string& version, bool deleteMarker, uint64_t size, 
@@ -214,6 +220,8 @@ class LFUDAPolicy : public CachePolicy {
     virtual bool erase_dirty_object(const DoutPrefixProvider* dpp, const std::string& key, optional_yield y) override;
     virtual bool invalidate_dirty_object(const DoutPrefixProvider* dpp, const std::string& key) override;
     virtual void cleaning(const DoutPrefixProvider* dpp) override;
+    virtual void set_read_flag(const DoutPrefixProvider* dpp, std::string key, int value) override;
+    virtual int get_read_flag(const DoutPrefixProvider* dpp, std::string key) override;
     LFUDAObjEntry* find_obj_entry(const std::string& key) {
       auto it = o_entries_map.find(key);
       if (it == o_entries_map.end()) {
@@ -243,7 +251,7 @@ class LRUPolicy : public CachePolicy {
     virtual int exist_key(const std::string& key) override;
     virtual int eviction(const DoutPrefixProvider* dpp, uint64_t size, optional_yield y) override;
     virtual bool update_refcount_if_key_exists(const DoutPrefixProvider* dpp, const std::string& key, uint8_t op, optional_yield y) override { return false; }
-    virtual void update(const DoutPrefixProvider* dpp, const std::string& key, uint64_t offset, uint64_t len, const std::string& version, std::optional<bool> dirty, uint8_t op, optional_yield y, std::string& restore_val=empty) override;
+    virtual void update(const DoutPrefixProvider* dpp, const std::string& key, uint64_t offset, uint64_t len, const std::string& version, std::optional<bool> dirty, const rgw_user user, uint8_t op, optional_yield y, std::string& restore_val=empty) override;
     virtual void update_dirty_object(const DoutPrefixProvider* dpp, const std::string& key, const std::string& version, bool deleteMarker, uint64_t size, 
 			    double creationTime, const rgw_user& user, const std::string& etag, const std::string& bucket_name, const std::string& bucket_id,
     			    const rgw_obj_key& obj_key, uint8_t op, optional_yield y, std::string& restore_val=empty) override;
@@ -251,6 +259,8 @@ class LRUPolicy : public CachePolicy {
     virtual bool erase_dirty_object(const DoutPrefixProvider* dpp, const std::string& key, optional_yield y) override;
     virtual bool invalidate_dirty_object(const DoutPrefixProvider* dpp, const std::string& key) override { return false; }
     virtual void cleaning(const DoutPrefixProvider* dpp) override {}
+    virtual void set_read_flag(const DoutPrefixProvider* dpp, std::string key, int value) override {}
+    virtual int get_read_flag(const DoutPrefixProvider* dpp, std::string key) override { return 0; }
 };
 
 class PolicyDriver {

--- a/src/rgw/driver/d4n/d4n_policy.h
+++ b/src/rgw/driver/d4n/d4n_policy.h
@@ -39,9 +39,9 @@ class CachePolicy {
       bool dirty;
       uint64_t refcount{0};
       rgw_user user;
-      int read_flag = 0;
-      Entry(const std::string& key, uint64_t offset, uint64_t len, const std::string& version, bool dirty, uint64_t refcount, rgw_user user) : key(key), offset(offset), 
-											        len(len), version(version), dirty(dirty), refcount(refcount), user(user) {}
+      std::string bucketName;
+      Entry(const std::string& key, uint64_t offset, uint64_t len, const std::string& version, bool dirty, uint64_t refcount, rgw_user user, std::string bucketName) : key(key), offset(offset), 
+											        len(len), version(version), dirty(dirty), refcount(refcount), user(user), bucketName(bucketName) {}
       };
    
     //The disposer object function
@@ -78,7 +78,7 @@ class CachePolicy {
     virtual int exist_key(const std::string& key) = 0;
     virtual int eviction(const DoutPrefixProvider* dpp, uint64_t size, optional_yield y) = 0;
     virtual bool update_refcount_if_key_exists(const DoutPrefixProvider* dpp, const std::string& key, uint8_t op, optional_yield y) = 0;
-    virtual void update(const DoutPrefixProvider* dpp, const std::string& key, uint64_t offset, uint64_t len, const std::string& version, std::optional<bool> dirty, const rgw_user user, uint8_t op, optional_yield y, std::string& restore_val=empty) = 0;
+    virtual void update(const DoutPrefixProvider* dpp, const std::string& key, uint64_t offset, uint64_t len, const std::string& version, std::optional<bool> dirty, const rgw_user user, const std::string& bucketName, uint8_t op, optional_yield y, std::string& restore_val=empty) = 0;
     virtual void update_dirty_object(const DoutPrefixProvider* dpp, const std::string& key, const std::string& version, bool deleteMarker, uint64_t size, 
 			    double creationTime, const rgw_user& user, const std::string& etag, const std::string& bucket_name, const std::string& bucket_id,
 			    const rgw_obj_key& obj_key, uint8_t op, optional_yield y, std::string& restore_val=empty) = 0;
@@ -86,8 +86,6 @@ class CachePolicy {
     virtual bool erase_dirty_object(const DoutPrefixProvider* dpp, const std::string& key, optional_yield y) = 0;
     virtual bool invalidate_dirty_object(const DoutPrefixProvider* dpp, const std::string& key) = 0;
     virtual void cleaning(const DoutPrefixProvider* dpp) = 0;
-    virtual void set_read_flag(const DoutPrefixProvider* dpp, std::string key, int value) = 0;
-    virtual int get_read_flag(const DoutPrefixProvider* dpp, std::string key) = 0;
 };
 
 class LFUDAPolicy : public CachePolicy {
@@ -125,8 +123,9 @@ class LFUDAPolicy : public CachePolicy {
       using handle_type = boost::heap::fibonacci_heap<LFUDAEntry*, boost::heap::compare<EntryComparator<LFUDAEntry>>>::handle_type;
       handle_type handle;
 
-      LFUDAEntry(const std::string& key, uint64_t offset, uint64_t len, const std::string& version, bool dirty, uint64_t refcount, rgw_user user, int localWeight) : Entry(key, offset, len, 
-                                                                                                                                version, dirty, refcount, user), localWeight(localWeight) {}
+      LFUDAEntry(const std::string& key, uint64_t offset, uint64_t len, const std::string& version, bool dirty, uint64_t refcount, rgw_user user, int localWeight, std::string bucketName) : 
+																																Entry(key, offset, len, version, dirty, refcount, user, bucketName), 
+																																localWeight(localWeight) {}
       
       void set_handle(handle_type handle_) { handle = handle_; }
     };
@@ -166,7 +165,7 @@ class LFUDAPolicy : public CachePolicy {
     rgw::sal::Driver* driver;
     std::thread tc;
 
-    CacheBlock* get_victim_block(const DoutPrefixProvider* dpp, optional_yield y);
+    int get_victim_block(const DoutPrefixProvider* dpp, CacheBlock* victim, optional_yield y);
     int age_sync(const DoutPrefixProvider* dpp, optional_yield y); 
     int local_weight_sync(const DoutPrefixProvider* dpp, optional_yield y); 
     asio::awaitable<void> redis_sync(const DoutPrefixProvider* dpp, optional_yield y);
@@ -207,11 +206,10 @@ class LFUDAPolicy : public CachePolicy {
 
     virtual int init(CephContext *cct, const DoutPrefixProvider* dpp, asio::io_context& io_context, rgw::sal::Driver *_driver);
     virtual int exist_key(const std::string& key) override;
-    int sendRemote(const DoutPrefixProvider* dpp, CacheBlock* victim, std::string remoteCacheAddress, std::string key, bufferlist* out_bl, optional_yield y);
     int getMinAvgWeight(const DoutPrefixProvider* dpp, int* minAvgWeight, std::string* cache_address, optional_yield y);
     virtual int eviction(const DoutPrefixProvider* dpp, uint64_t size, optional_yield y) override;
     virtual bool update_refcount_if_key_exists(const DoutPrefixProvider* dpp, const std::string& key, uint8_t op, optional_yield y) override;
-    virtual void update(const DoutPrefixProvider* dpp, const std::string& key, uint64_t offset, uint64_t len, const std::string& version, std::optional<bool> dirty, const rgw_user user, uint8_t op, optional_yield y, std::string& restore_val=empty) override;
+    virtual void update(const DoutPrefixProvider* dpp, const std::string& key, uint64_t offset, uint64_t len, const std::string& version, std::optional<bool> dirty, const rgw_user user, const std::string& bucketName, uint8_t op, optional_yield y, std::string& restore_val=empty) override;
     virtual bool erase(const DoutPrefixProvider* dpp, const std::string& key, optional_yield y) override;
     virtual bool _erase(const DoutPrefixProvider* dpp, const std::string& key, optional_yield y);
     virtual void update_dirty_object(const DoutPrefixProvider* dpp, const std::string& key, const std::string& version, bool deleteMarker, uint64_t size, 
@@ -220,8 +218,6 @@ class LFUDAPolicy : public CachePolicy {
     virtual bool erase_dirty_object(const DoutPrefixProvider* dpp, const std::string& key, optional_yield y) override;
     virtual bool invalidate_dirty_object(const DoutPrefixProvider* dpp, const std::string& key) override;
     virtual void cleaning(const DoutPrefixProvider* dpp) override;
-    virtual void set_read_flag(const DoutPrefixProvider* dpp, std::string key, int value) override;
-    virtual int get_read_flag(const DoutPrefixProvider* dpp, std::string key) override;
     LFUDAObjEntry* find_obj_entry(const std::string& key) {
       auto it = o_entries_map.find(key);
       if (it == o_entries_map.end()) {
@@ -251,7 +247,7 @@ class LRUPolicy : public CachePolicy {
     virtual int exist_key(const std::string& key) override;
     virtual int eviction(const DoutPrefixProvider* dpp, uint64_t size, optional_yield y) override;
     virtual bool update_refcount_if_key_exists(const DoutPrefixProvider* dpp, const std::string& key, uint8_t op, optional_yield y) override { return false; }
-    virtual void update(const DoutPrefixProvider* dpp, const std::string& key, uint64_t offset, uint64_t len, const std::string& version, std::optional<bool> dirty, const rgw_user user, uint8_t op, optional_yield y, std::string& restore_val=empty) override;
+    virtual void update(const DoutPrefixProvider* dpp, const std::string& key, uint64_t offset, uint64_t len, const std::string& version, std::optional<bool> dirty, const rgw_user user, const std::string& bucketName, uint8_t op, optional_yield y, std::string& restore_val=empty) override;
     virtual void update_dirty_object(const DoutPrefixProvider* dpp, const std::string& key, const std::string& version, bool deleteMarker, uint64_t size, 
 			    double creationTime, const rgw_user& user, const std::string& etag, const std::string& bucket_name, const std::string& bucket_id,
     			    const rgw_obj_key& obj_key, uint8_t op, optional_yield y, std::string& restore_val=empty) override;
@@ -259,8 +255,6 @@ class LRUPolicy : public CachePolicy {
     virtual bool erase_dirty_object(const DoutPrefixProvider* dpp, const std::string& key, optional_yield y) override;
     virtual bool invalidate_dirty_object(const DoutPrefixProvider* dpp, const std::string& key) override { return false; }
     virtual void cleaning(const DoutPrefixProvider* dpp) override {}
-    virtual void set_read_flag(const DoutPrefixProvider* dpp, std::string key, int value) override {}
-    virtual int get_read_flag(const DoutPrefixProvider* dpp, std::string key) override { return 0; }
 };
 
 class PolicyDriver {

--- a/src/rgw/driver/d4n/d4n_remote_cache_manager.cc
+++ b/src/rgw/driver/d4n/d4n_remote_cache_manager.cc
@@ -5,6 +5,121 @@
 
 namespace rgw { namespace d4n {
 
+int RemoteCacheGetOp::send_request(const DoutPrefixProvider* dpp, optional_yield& y, bufferlist* bl)
+{
+  in_bl.clear();
+  cb = std::make_unique<RemoteGetCB>(&in_bl);
+  RGWAccessKey accessKey;
+  std::string findKey;
+
+  std::unique_ptr<rgw::sal::User> c_user = driver->get_user(op.bucket_owner);
+  int ret = c_user->load_user(dpp, y);
+  if (ret < 0) {
+    return -EPERM;
+  }
+
+  if (c_user->get_info().access_keys.empty()) {
+    return -EINVAL;
+  }
+
+  accessKey.id = c_user->get_info().access_keys.begin()->second.id;
+  accessKey.key = c_user->get_info().access_keys.begin()->second.key;
+
+  HostStyle host_style = PathStyle;
+  std::map<std::string, std::string> extra_headers;
+  uint64_t end_offset = op.offset + op.len - 1;
+  std::string range_val = "bytes=" + std::to_string(op.offset) + "-" + std::to_string(end_offset);
+  extra_headers["RANGE"] = std::move(range_val);
+
+  auto resource = get_resource(op.bucket_name, op.oid);
+  sender = std::make_unique<RGWRESTStreamRWRequest>(dpp->get_cct(), "GET", op.remote_addr, cb.get(), nullptr, nullptr, "", host_style);
+
+  ret = sender->send_request(dpp, &accessKey, extra_headers, resource, nullptr, bl);
+  if (ret < 0) {
+    return ret;
+  }
+
+  return 0;
+}
+
+rgw::AioResultList RemoteCacheGetOp::send_request(const DoutPrefixProvider* dpp, rgw::Aio* aio, uint64_t cost, uint64_t id, optional_yield& y)
+{
+  in_bl.clear();
+  cb = std::make_unique<RemoteGetCB>(&in_bl);
+  this->aio = aio;
+
+  auto op_func = [this, dpp, y](Aio* aio, AioResult& r) mutable {
+    this->r = &r;
+    RGWAccessKey accessKey;
+    std::string findKey;
+
+    std::unique_ptr<rgw::sal::User> c_user = driver->get_user(op.bucket_owner);
+    int ret = c_user->load_user(dpp, y);
+    if (ret < 0) {
+      r.result = -EPERM;
+      aio->put(r);
+      this->r = nullptr;
+    }
+
+    if (c_user->get_info().access_keys.empty()) {
+      r.result = -EINVAL;
+      aio->put(r);
+      this->r = nullptr;
+    }
+
+    accessKey.id = c_user->get_info().access_keys.begin()->second.id;
+    accessKey.key = c_user->get_info().access_keys.begin()->second.key;
+
+    HostStyle host_style = PathStyle;
+    std::map<std::string, std::string> extra_headers;
+    uint64_t end_offset = op.offset + op.len - 1;
+    std::string range_val = "bytes=" + std::to_string(op.offset) + "-" + std::to_string(end_offset);
+    extra_headers["RANGE"] = std::move(range_val);
+
+    auto resource = get_resource(op.bucket_name, op.oid);
+    sender = std::make_unique<RGWRESTStreamRWRequest>(dpp->get_cct(), "GET", op.remote_addr, cb.get(), nullptr, nullptr, "", host_style);
+
+    ret = sender->send_request(dpp, &accessKey, extra_headers, resource, nullptr, nullptr);
+    if (ret < 0) {
+      r.result = ret;
+      aio->put(r);
+      this->r = nullptr;
+    }
+  };
+
+  return this->aio->get(rgw_raw_obj{}, std::move(op_func), cost, id);
+}
+
+int RemoteCacheGetOp::complete_request(const DoutPrefixProvider* dpp, optional_yield& y)
+{
+  if (!sender) {
+    return -EINVAL;
+  }
+
+  int ret = sender->complete_request(dpp, y);
+  sender.reset();
+
+  if (this->aio) {
+    r->result = ret;
+    ldpp_dout(dpp, 20) << "RemoteCacheGetOp:: " << __func__ <<  " length of buffer received: " << in_bl.length() << dendl;
+    r->data = std::move(in_bl);
+    this->aio->put(*r);
+  }
+  return ret;
+}
+
+rgw::AioResultList RemoteCacheGetOp::send_and_complete_request(const DoutPrefixProvider* dpp, rgw::Aio* aio, uint64_t cost, uint64_t id, optional_yield& y)
+{
+  rgw::AioResultList results = send_request(dpp, aio, cost, id, y);
+  auto ret = complete_request(dpp, y);
+  if (ret < 0) {
+    ldpp_dout(dpp, 20) << "RemoteCacheGetOp:: " << __func__ <<  " complete_request failed with ret: " << ret << dendl;
+  }
+
+  return results;
+}
+
+//placeholder for any initialization that is needed
 int RemoteCacheOp::init(CephContext* cct, const DoutPrefixProvider* dpp)
 {
   return 0;
@@ -21,7 +136,24 @@ int RemoteCacheOp::complete_request(const DoutPrefixProvider* dpp, optional_yiel
   return ret;
 }
 
-int RemoteCacheDeleteOp::send_request(const DoutPrefixProvider* dpp, bufferlist& bl, optional_yield& y)
+int RemoteCacheOp::send_and_complete_request(const DoutPrefixProvider* dpp, optional_yield& y, bufferlist* bl)
+{
+  auto ret = send_request(dpp, y, bl);
+  if (ret < 0) {
+    ldpp_dout(dpp, 20) << "RemoteCachePutOp:: " << __func__ <<  "(): send_request failed with ret: " << ret << dendl;
+    return ret;
+  }
+
+  ret = complete_request(dpp, y);
+  if (ret < 0) {
+    ldpp_dout(dpp, 20) << "RemoteCachePutOp:: " << __func__ << "(): complete_request failed with ret: " << ret << dendl;
+    return ret;
+  }
+
+  return 0;
+}
+
+int RemoteCacheDeleteOp::send_request(const DoutPrefixProvider* dpp, optional_yield& y, bufferlist* bl)
 {
   in_bl.clear();
   cb = std::make_unique<RemoteGetCB>(&in_bl);
@@ -53,7 +185,7 @@ int RemoteCacheDeleteOp::send_request(const DoutPrefixProvider* dpp, bufferlist&
   auto resource = get_resource(op.bucket_name, op.oid);
   sender = std::make_unique<RGWRESTStreamRWRequest>(dpp->get_cct(), "DELETE", op.remote_addr, cb.get(), nullptr, nullptr, "", host_style);
 
-  ret = sender->send_request(dpp, &accessKey, extra_headers, resource, nullptr, &bl);
+  ret = sender->send_request(dpp, &accessKey, extra_headers, resource, nullptr, bl);
   if (ret < 0) {
     return ret;
   }
@@ -61,24 +193,7 @@ int RemoteCacheDeleteOp::send_request(const DoutPrefixProvider* dpp, bufferlist&
   return 0;
 }
 
-int RemoteCacheDeleteOp::send_and_complete_request(const DoutPrefixProvider* dpp, bufferlist& bl, optional_yield& y)
-{
-  auto ret = send_request(dpp, bl, y);
-  if (ret < 0) {
-    ldpp_dout(dpp, 20) << "RemoteCacheDeleteOp:: " << __func__ << "(): send_request failed with ret: " << ret << dendl;
-    return ret;
-  }
-
-  ret = complete_request(dpp, y);
-  if (ret < 0) {
-    ldpp_dout(dpp, 20) << "RemoteCacheDeleteOp:: " << __func__ << "(): complete_request failed with ret: " << ret << dendl;
-    return ret;
-  }
-
-  return 0;
-}
-
-int RemoteCachePutOp::send_request(const DoutPrefixProvider* dpp, bufferlist& bl, optional_yield& y)
+int RemoteCachePutOp::send_request(const DoutPrefixProvider* dpp, optional_yield& y, bufferlist* bl)
 {
   in_bl.clear();
   cb = std::make_unique<RemoteGetCB>(&in_bl);
@@ -110,24 +225,7 @@ int RemoteCachePutOp::send_request(const DoutPrefixProvider* dpp, bufferlist& bl
   auto resource = get_resource(op.bucket_name, op.oid);
   sender = std::make_unique<RGWRESTStreamRWRequest>(dpp->get_cct(), "PUT", op.remote_addr, cb.get(), nullptr, nullptr, "", host_style);
 
-  return sender->send_request(dpp, &accessKey, extra_headers, resource, nullptr, &bl);
-}
-
-int RemoteCachePutOp::send_and_complete_request(const DoutPrefixProvider* dpp, bufferlist& bl, optional_yield& y)
-{
-  auto ret = send_request(dpp, bl, y);
-  if (ret < 0) {
-    ldpp_dout(dpp, 20) << "RemoteCachePutOp:: " << __func__ <<  "(): send_request failed with ret: " << ret << dendl;
-    return ret;
-  }
-
-  ret = complete_request(dpp, y);
-  if (ret < 0) {
-    ldpp_dout(dpp, 20) << "RemoteCachePutOp:: " << __func__ << "(): complete_request failed with ret: " << ret << dendl;
-    return ret;
-  }
-
-  return 0;
+  return sender->send_request(dpp, &accessKey, extra_headers, resource, nullptr, bl);
 }
 
 int RemoteCachePutBatch::send(const DoutPrefixProvider* dpp,
@@ -152,7 +250,7 @@ int RemoteCachePutBatch::send(const DoutPrefixProvider* dpp,
   }
 
   // Send the request
-  ret = put_op->send_request(dpp, bl, y);
+  ret = put_op->send_request(dpp, y, &bl);
   if (ret < 0) {
     ldpp_dout(dpp, 0) << "Failed to send RemoteCachePutOp for oid=" << op.oid << " ret=" << ret << dendl;
     return ret;

--- a/src/rgw/driver/d4n/d4n_remote_cache_manager.cc
+++ b/src/rgw/driver/d4n/d4n_remote_cache_manager.cc
@@ -5,13 +5,80 @@
 
 namespace rgw { namespace d4n {
 
-//placeholder for any initialization that is needed
-int RemoteCachePut::init(CephContext* cct, const DoutPrefixProvider* dpp)
+int RemoteCacheOp::init(CephContext* cct, const DoutPrefixProvider* dpp)
 {
   return 0;
 }
 
-int RemoteCachePut::send_request(const DoutPrefixProvider* dpp, bufferlist& bl, optional_yield& y)
+int RemoteCacheOp::complete_request(const DoutPrefixProvider* dpp, optional_yield& y)
+{
+  if (!sender) {
+    return -EINVAL;
+  }
+
+  int ret = sender->complete_request(dpp, y);
+  sender.reset();
+  return ret;
+}
+
+int RemoteCacheDeleteOp::send_request(const DoutPrefixProvider* dpp, bufferlist& bl, optional_yield& y)
+{
+  in_bl.clear();
+  cb = std::make_unique<RemoteGetCB>(&in_bl);
+
+  RGWAccessKey accessKey;
+  std::string findKey;
+
+  std::unique_ptr<rgw::sal::User> c_user = driver->get_user(op.bucket_owner);
+  int ret = c_user->load_user(dpp, y);
+  if (ret < 0) {
+    return -EPERM;
+  }
+
+  if (c_user->get_info().access_keys.empty()) {
+    return -EINVAL;
+  }
+
+  accessKey.id = c_user->get_info().access_keys.begin()->second.id;
+  accessKey.key = c_user->get_info().access_keys.begin()->second.key;
+
+  HostStyle host_style = PathStyle;
+  std::map<std::string, std::string> extra_headers;
+  extra_headers["x-rgw-remote-cache-request"] = "true";
+  extra_headers["x-rgw-cache-object-version"] = op.version;
+  extra_headers["x-rgw-cache-blk-offset"] = std::to_string(op.offset);
+  extra_headers["x-rgw-cache-blk-len"] = std::to_string(op.len);
+  extra_headers["x-rgw-cache-obj-size"] = std::to_string(op.obj_size);
+
+  auto resource = get_resource(op.bucket_name, op.oid);
+  sender = std::make_unique<RGWRESTStreamRWRequest>(dpp->get_cct(), "DELETE", op.remote_addr, cb.get(), nullptr, nullptr, "", host_style);
+
+  ret = sender->send_request(dpp, &accessKey, extra_headers, resource, nullptr, &bl);
+  if (ret < 0) {
+    return ret;
+  }
+
+  return 0;
+}
+
+int RemoteCacheDeleteOp::send_and_complete_request(const DoutPrefixProvider* dpp, bufferlist& bl, optional_yield& y)
+{
+  auto ret = send_request(dpp, bl, y);
+  if (ret < 0) {
+    ldpp_dout(dpp, 20) << "RemoteCacheDeleteOp:: " << __func__ << "(): send_request failed with ret: " << ret << dendl;
+    return ret;
+  }
+
+  ret = complete_request(dpp, y);
+  if (ret < 0) {
+    ldpp_dout(dpp, 20) << "RemoteCacheDeleteOp:: " << __func__ << "(): complete_request failed with ret: " << ret << dendl;
+    return ret;
+  }
+
+  return 0;
+}
+
+int RemoteCachePutOp::send_request(const DoutPrefixProvider* dpp, bufferlist& bl, optional_yield& y)
 {
   in_bl.clear();
   cb = std::make_unique<RemoteGetCB>(&in_bl);
@@ -46,27 +113,17 @@ int RemoteCachePut::send_request(const DoutPrefixProvider* dpp, bufferlist& bl, 
   return sender->send_request(dpp, &accessKey, extra_headers, resource, nullptr, &bl);
 }
 
-int RemoteCachePut::complete_request(const DoutPrefixProvider* dpp, optional_yield& y)
-{
-  if (!sender) {
-    return -EINVAL;
-  }
-
-  int ret = sender->complete_request(dpp, y);
-  return ret;
-}
-
-int RemoteCachePut::send_and_complete_request(const DoutPrefixProvider* dpp, bufferlist& bl, optional_yield& y)
+int RemoteCachePutOp::send_and_complete_request(const DoutPrefixProvider* dpp, bufferlist& bl, optional_yield& y)
 {
   auto ret = send_request(dpp, bl, y);
   if (ret < 0) {
-    ldpp_dout(dpp, 20) << "RemoteCachePut:: " << __func__ <<  " send_request failed with ret: " << ret << dendl;
+    ldpp_dout(dpp, 20) << "RemoteCachePutOp:: " << __func__ <<  "(): send_request failed with ret: " << ret << dendl;
     return ret;
   }
 
   ret = complete_request(dpp, y);
   if (ret < 0) {
-    ldpp_dout(dpp, 20) << "RemoteCachePut:: " << __func__ <<  " complete_request failed with ret: " << ret << dendl;
+    ldpp_dout(dpp, 20) << "RemoteCachePutOp:: " << __func__ << "(): complete_request failed with ret: " << ret << dendl;
     return ret;
   }
 
@@ -75,29 +132,29 @@ int RemoteCachePut::send_and_complete_request(const DoutPrefixProvider* dpp, buf
 
 int RemoteCachePutBatch::send(const DoutPrefixProvider* dpp,
                               optional_yield y,
-                              RemoteCachePut::RemoteCachePutOp& op,
+                              RemoteCachePutOp::RemoteCachePutOpData& op,
                               bufferlist& bl)
 {
   // Drain one if at capacity
   while (in_flight.size() >= max_in_flight) {
     int ret = complete_next(dpp, y);
     if (ret < 0) {
-      ldpp_dout(dpp, 5) << "RemoteCachePut request failed for oid=" << op.oid << " ret=" << ret << dendl;
+      ldpp_dout(dpp, 5) << "RemoteCachePutOp request failed for oid=" << op.oid << " ret=" << ret << dendl;
     }
   }
 
   // Create and initialize the put operation
-  auto put_op = std::make_unique<RemoteCachePut>(driver, op);
+  auto put_op = std::make_unique<RemoteCachePutOp>(driver, op);
   int ret = put_op->init(cct, dpp);
   if (ret < 0) {
-    ldpp_dout(dpp, 0) << "Failed to init RemoteCachePut for oid=" << op.oid << " ret=" << ret << dendl;
+    ldpp_dout(dpp, 0) << "Failed to init RemoteCachePutOp for oid=" << op.oid << " ret=" << ret << dendl;
     return ret;
   }
 
   // Send the request
   ret = put_op->send_request(dpp, bl, y);
   if (ret < 0) {
-    ldpp_dout(dpp, 0) << "Failed to send RemoteCachePut for oid=" << op.oid << " ret=" << ret << dendl;
+    ldpp_dout(dpp, 0) << "Failed to send RemoteCachePutOp for oid=" << op.oid << " ret=" << ret << dendl;
     return ret;
   }
 
@@ -109,7 +166,7 @@ int RemoteCachePutBatch::send(const DoutPrefixProvider* dpp,
   };
   in_flight.push_back(std::move(result));
 
-  ldpp_dout(dpp, 20) << "RemoteCachePut queued: oid=" << op.oid << " offset=" << op.offset << " len=" << op.len << dendl;
+  ldpp_dout(dpp, 20) << "RemoteCachePutOp queued: oid=" << op.oid << " offset=" << op.offset << " len=" << op.len << dendl;
 
   return 0;
 }

--- a/src/rgw/driver/d4n/d4n_remote_cache_manager.cc
+++ b/src/rgw/driver/d4n/d4n_remote_cache_manager.cc
@@ -1,0 +1,163 @@
+#include "d4n_remote_cache_manager.h"
+
+#include "../../../common/async/yield_context.h"
+#include "common/async/blocked_completion.h"
+
+namespace rgw { namespace d4n {
+
+//placeholder for any initialization that is needed
+int RemoteCachePut::init(CephContext* cct, const DoutPrefixProvider* dpp)
+{
+  return 0;
+}
+
+int RemoteCachePut::send_request(const DoutPrefixProvider* dpp, bufferlist& bl, optional_yield& y)
+{
+  in_bl.clear();
+  cb = std::make_unique<RemoteGetCB>(&in_bl);
+
+  RGWAccessKey accessKey;
+  std::string findKey;
+
+  std::unique_ptr<rgw::sal::User> c_user = driver->get_user(op.bucket_owner);
+  int ret = c_user->load_user(dpp, y);
+  if (ret < 0) {
+    return -EPERM;
+  }
+
+  if (c_user->get_info().access_keys.empty()) {
+    return -EINVAL;
+  }
+
+  accessKey.id = c_user->get_info().access_keys.begin()->second.id;
+  accessKey.key = c_user->get_info().access_keys.begin()->second.key;
+
+  HostStyle host_style = PathStyle;
+  std::map<std::string, std::string> extra_headers;
+  extra_headers["x-rgw-remote-cache-request"] = "true";
+  extra_headers["x-rgw-cache-object-version"] = op.version;
+  extra_headers["x-rgw-cache-blk-offset"] = std::to_string(op.offset);
+  extra_headers["x-rgw-cache-blk-len"] = std::to_string(op.len);
+  extra_headers["x-rgw-cache-obj-size"] = std::to_string(op.obj_size);
+
+  auto resource = get_resource(op.bucket_name, op.oid);
+  sender = std::make_unique<RGWRESTStreamRWRequest>(dpp->get_cct(), "PUT", op.remote_addr, cb.get(), nullptr, nullptr, "", host_style);
+
+  return sender->send_request(dpp, &accessKey, extra_headers, resource, nullptr, &bl);
+}
+
+int RemoteCachePut::complete_request(const DoutPrefixProvider* dpp, optional_yield& y)
+{
+  if (!sender) {
+    return -EINVAL;
+  }
+
+  int ret = sender->complete_request(dpp, y);
+  return ret;
+}
+
+int RemoteCachePut::send_and_complete_request(const DoutPrefixProvider* dpp, bufferlist& bl, optional_yield& y)
+{
+  auto ret = send_request(dpp, bl, y);
+  if (ret < 0) {
+    ldpp_dout(dpp, 20) << "RemoteCachePut:: " << __func__ <<  " send_request failed with ret: " << ret << dendl;
+    return ret;
+  }
+
+  ret = complete_request(dpp, y);
+  if (ret < 0) {
+    ldpp_dout(dpp, 20) << "RemoteCachePut:: " << __func__ <<  " complete_request failed with ret: " << ret << dendl;
+    return ret;
+  }
+
+  return 0;
+}
+
+int RemoteCachePutBatch::send(const DoutPrefixProvider* dpp,
+                              optional_yield y,
+                              RemoteCachePut::RemoteCachePutOp& op,
+                              bufferlist& bl)
+{
+  // Drain one if at capacity
+  while (in_flight.size() >= max_in_flight) {
+    int ret = complete_next(dpp, y);
+    if (ret < 0) {
+      ldpp_dout(dpp, 5) << "RemoteCachePut request failed for oid=" << op.oid << " ret=" << ret << dendl;
+    }
+  }
+
+  // Create and initialize the put operation
+  auto put_op = std::make_unique<RemoteCachePut>(driver, op);
+  int ret = put_op->init(cct, dpp);
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "Failed to init RemoteCachePut for oid=" << op.oid << " ret=" << ret << dendl;
+    return ret;
+  }
+
+  // Send the request
+  ret = put_op->send_request(dpp, bl, y);
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "Failed to send RemoteCachePut for oid=" << op.oid << " ret=" << ret << dendl;
+    return ret;
+  }
+
+  // Track it
+  PutResult result {
+    .put_op = std::move(put_op),
+    .key = op.oid,
+    .op_info = op
+  };
+  in_flight.push_back(std::move(result));
+
+  ldpp_dout(dpp, 20) << "RemoteCachePut queued: oid=" << op.oid << " offset=" << op.offset << " len=" << op.len << dendl;
+
+  return 0;
+}
+
+int RemoteCachePutBatch::complete_next(const DoutPrefixProvider* dpp, optional_yield y)
+{
+  if (in_flight.empty()) {
+    return 0;
+  }
+
+  auto result = std::move(in_flight.front());
+  in_flight.pop_front();
+
+  // Complete the request
+  result.status = result.put_op->complete_request(dpp, y);
+
+  if (result.status < 0) {
+    ldpp_dout(dpp, 5) << "RemoteCachePut completed with error: oid=" << result.key << " ret=" << result.status << dendl;
+  } else {
+    ldpp_dout(dpp, 20) << "RemoteCachePut completed successfully: oid=" << result.key << dendl;
+  }
+
+  result.put_op.reset();
+
+  completed.push_back(std::move(result));
+  return result.status;
+}
+
+int RemoteCachePutBatch::finish_all(const DoutPrefixProvider* dpp, optional_yield y)
+{
+  int first_error = 0;
+  int error_count = 0;
+
+  while (!in_flight.empty()) {
+    int ret = complete_next(dpp, y);
+    if (ret < 0) {
+      error_count++;
+      if (first_error == 0) {
+        first_error = ret;
+      }
+    }
+  }
+
+  if (error_count > 0) {
+    ldpp_dout(dpp, 5) << "RemoteCachePutBatch finished with " << error_count << " errors" << dendl;
+  }
+
+  return first_error;
+}
+
+} } // namespace rgw::d4n

--- a/src/rgw/driver/d4n/d4n_remote_cache_manager.cc
+++ b/src/rgw/driver/d4n/d4n_remote_cache_manager.cc
@@ -222,6 +222,10 @@ int RemoteCachePutOp::send_request(const DoutPrefixProvider* dpp, optional_yield
   extra_headers["x-rgw-cache-blk-len"] = std::to_string(op.len);
   extra_headers["x-rgw-cache-obj-size"] = std::to_string(op.obj_size);
 
+  if (block_only) {
+    extra_headers["x-rgw-cache-block-only"] = "true";
+  }
+
   auto resource = get_resource(op.bucket_name, op.oid);
   sender = std::make_unique<RGWRESTStreamRWRequest>(dpp->get_cct(), "PUT", op.remote_addr, cb.get(), nullptr, nullptr, "", host_style);
 

--- a/src/rgw/driver/d4n/d4n_remote_cache_manager.h
+++ b/src/rgw/driver/d4n/d4n_remote_cache_manager.h
@@ -1,0 +1,114 @@
+#pragma once
+
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/use_awaitable.hpp>
+#include <boost/asio/co_spawn.hpp>
+#include <boost/heap/fibonacci_heap.hpp>
+#include <boost/system/detail/errc.hpp>
+
+#include <aio.h>
+#include "rgw_common.h"
+#include "rgw_sal_d4n.h"
+
+namespace rgw { namespace d4n {
+
+namespace asio = boost::asio;
+namespace sys = boost::system;
+
+inline std::string get_resource(std::string& bucket_name, std::string& oid) {
+  return fmt::format("{}{}{}", bucket_name, "/", oid);
+}
+
+struct RemoteGetCB : RGWHTTPStreamRWRequest::ReceiveCB {
+public:
+  bufferlist *in_bl;
+  RemoteGetCB(bufferlist* _bl): in_bl(_bl) {}
+  int handle_data(bufferlist& bl, bool *pause) override {
+    in_bl->append(bl);
+    return 0;
+  }
+};
+
+class RemoteCachePut {
+  public:
+    struct RemoteCachePutOp {
+      std::string bucket_name;
+      std::string oid;
+      uint64_t offset = 0;
+      uint64_t len = 0;
+      std::string version;
+      rgw_user bucket_owner;
+      std::string remote_addr;
+      uint64_t obj_size = 0;
+    };
+    RemoteCachePut(rgw::sal::Driver* driver, RemoteCachePutOp& op) : driver(driver), op(op) {}
+    virtual ~RemoteCachePut() = default; 
+
+    int init(CephContext* cct, const DoutPrefixProvider* dpp);
+    int send_request(const DoutPrefixProvider* dpp, bufferlist& bl, optional_yield& y);
+    int complete_request(const DoutPrefixProvider* dpp, optional_yield& y);
+    int send_and_complete_request(const DoutPrefixProvider* dpp, bufferlist& bl, optional_yield& y);
+
+  private:
+    rgw::sal::Driver* driver;
+    RemoteCachePutOp op;
+    std::unique_ptr<RGWRESTStreamRWRequest> sender;
+    bufferlist in_bl;
+    std::unique_ptr<RemoteGetCB> cb;
+};
+
+class RemoteCachePutBatch {
+private:
+  size_t max_in_flight;
+  rgw::sal::Driver* driver;
+  CephContext* cct;
+
+  struct PutResult {
+    std::unique_ptr<RemoteCachePut> put_op;
+    std::string key;
+    int status = -EINPROGRESS;
+    RemoteCachePut::RemoteCachePutOp op_info;
+  };
+
+  std::deque<PutResult> in_flight;
+  std::vector<PutResult> completed;
+
+public:
+  RemoteCachePutBatch(rgw::sal::Driver* driver, CephContext* cct, size_t max)
+    : max_in_flight(max), driver(driver), cct(cct) {}
+
+  int send(const DoutPrefixProvider* dpp,
+          optional_yield y,
+          RemoteCachePut::RemoteCachePutOp& op,
+          bufferlist& bl);
+  int complete_next(const DoutPrefixProvider* dpp, optional_yield y);
+  int finish_all(const DoutPrefixProvider* dpp, optional_yield y);
+
+  const std::vector<PutResult>& get_results() const {
+    return completed;
+  }
+
+  void clear_results() {
+    completed.clear();
+  }
+
+  std::vector<RemoteCachePut::RemoteCachePutOp> get_failed_ops() const {
+    std::vector<RemoteCachePut::RemoteCachePutOp> failed;
+    for (const auto& r : completed) {
+      if (r.status < 0) {
+        failed.push_back(r.op_info);
+      }
+    }
+    return failed;
+  }
+
+  bool has_errors() const {
+    return std::any_of(completed.begin(), completed.end(),
+                      [](const PutResult& r) { return r.status < 0; });
+  }
+
+  size_t get_in_flight_count() const { return in_flight.size(); }
+  size_t get_completed_count() const { return completed.size(); }
+};
+
+} } // namespace rgw::d4n

--- a/src/rgw/driver/d4n/d4n_remote_cache_manager.h
+++ b/src/rgw/driver/d4n/d4n_remote_cache_manager.h
@@ -29,29 +29,68 @@ public:
   }
 };
 
-class RemoteCachePut {
+class RemoteCacheOp {
   public:
-    struct RemoteCachePutOp {
+    struct RemoteCacheOpData {
       std::string bucket_name;
       std::string oid;
       uint64_t offset = 0;
       uint64_t len = 0;
       std::string version;
+	  bool dirty;
       rgw_user bucket_owner;
       std::string remote_addr;
       uint64_t obj_size = 0;
     };
-    RemoteCachePut(rgw::sal::Driver* driver, RemoteCachePutOp& op) : driver(driver), op(op) {}
-    virtual ~RemoteCachePut() = default; 
+    RemoteCacheOp(rgw::sal::Driver* driver, RemoteCacheOpData& op) : driver(driver), op(op) {}
+    virtual ~RemoteCacheOp() = default; 
 
-    int init(CephContext* cct, const DoutPrefixProvider* dpp);
-    int send_request(const DoutPrefixProvider* dpp, bufferlist& bl, optional_yield& y);
-    int complete_request(const DoutPrefixProvider* dpp, optional_yield& y);
-    int send_and_complete_request(const DoutPrefixProvider* dpp, bufferlist& bl, optional_yield& y);
+    virtual int init(CephContext* cct, const DoutPrefixProvider* dpp);
+    virtual int send_request(const DoutPrefixProvider* dpp, bufferlist& bl, optional_yield& y) = 0;
+    virtual int complete_request(const DoutPrefixProvider* dpp, optional_yield& y);
+    virtual int send_and_complete_request(const DoutPrefixProvider* dpp, bufferlist& bl, optional_yield& y) = 0;
 
   private:
     rgw::sal::Driver* driver;
-    RemoteCachePutOp op;
+    RemoteCacheOpData op;
+    std::unique_ptr<RGWRESTStreamRWRequest> sender;
+    bufferlist in_bl;
+    std::unique_ptr<RemoteGetCB> cb;
+};
+
+
+
+class RemoteCacheDeleteOp : public RemoteCacheOp {
+  public:
+    struct RemoteCacheDeleteOpData : RemoteCacheOpData {};
+
+    RemoteCacheDeleteOp(rgw::sal::Driver* driver, RemoteCacheDeleteOpData& op) : RemoteCacheOp(driver, op) {}
+    virtual ~RemoteCacheDeleteOp() = default; 
+    
+	virtual int send_request(const DoutPrefixProvider* dpp, bufferlist& bl, optional_yield& y) override;
+    virtual int send_and_complete_request(const DoutPrefixProvider* dpp, bufferlist& bl, optional_yield& y) override;
+
+  private:
+    rgw::sal::Driver* driver;
+    RemoteCacheDeleteOpData op;
+    std::unique_ptr<RGWRESTStreamRWRequest> sender;
+    bufferlist in_bl;
+    std::unique_ptr<RemoteGetCB> cb;
+};
+
+class RemoteCachePutOp : public RemoteCacheOp {
+  public:
+    struct RemoteCachePutOpData : RemoteCacheOpData {};
+
+    RemoteCachePutOp(rgw::sal::Driver* driver, RemoteCachePutOpData& op) : RemoteCacheOp(driver, op) {}
+    virtual ~RemoteCachePutOp() = default;
+ 
+	virtual int send_request(const DoutPrefixProvider* dpp, bufferlist& bl, optional_yield& y) override;
+    virtual int send_and_complete_request(const DoutPrefixProvider* dpp, bufferlist& bl, optional_yield& y) override;
+
+  private:
+    rgw::sal::Driver* driver;
+    RemoteCachePutOpData op;
     std::unique_ptr<RGWRESTStreamRWRequest> sender;
     bufferlist in_bl;
     std::unique_ptr<RemoteGetCB> cb;
@@ -64,10 +103,10 @@ private:
   CephContext* cct;
 
   struct PutResult {
-    std::unique_ptr<RemoteCachePut> put_op;
+    std::unique_ptr<RemoteCachePutOp> put_op;
     std::string key;
     int status = -EINPROGRESS;
-    RemoteCachePut::RemoteCachePutOp op_info;
+    RemoteCachePutOp::RemoteCachePutOpData op_info;
   };
 
   std::deque<PutResult> in_flight;
@@ -79,7 +118,7 @@ public:
 
   int send(const DoutPrefixProvider* dpp,
           optional_yield y,
-          RemoteCachePut::RemoteCachePutOp& op,
+          RemoteCachePutOp::RemoteCachePutOpData& op,
           bufferlist& bl);
   int complete_next(const DoutPrefixProvider* dpp, optional_yield y);
   int finish_all(const DoutPrefixProvider* dpp, optional_yield y);
@@ -92,8 +131,8 @@ public:
     completed.clear();
   }
 
-  std::vector<RemoteCachePut::RemoteCachePutOp> get_failed_ops() const {
-    std::vector<RemoteCachePut::RemoteCachePutOp> failed;
+  std::vector<RemoteCachePutOp::RemoteCachePutOpData> get_failed_ops() const {
+    std::vector<RemoteCachePutOp::RemoteCachePutOpData> failed;
     for (const auto& r : completed) {
       if (r.status < 0) {
         failed.push_back(r.op_info);

--- a/src/rgw/driver/d4n/d4n_remote_cache_manager.h
+++ b/src/rgw/driver/d4n/d4n_remote_cache_manager.h
@@ -46,11 +46,11 @@ class RemoteCacheOp {
     virtual ~RemoteCacheOp() = default; 
 
     virtual int init(CephContext* cct, const DoutPrefixProvider* dpp);
-    virtual int send_request(const DoutPrefixProvider* dpp, bufferlist& bl, optional_yield& y) = 0;
+    virtual int send_request(const DoutPrefixProvider* dpp, optional_yield& y, bufferlist* bl = nullptr) = 0;
     virtual int complete_request(const DoutPrefixProvider* dpp, optional_yield& y);
-    virtual int send_and_complete_request(const DoutPrefixProvider* dpp, bufferlist& bl, optional_yield& y) = 0;
+    virtual int send_and_complete_request(const DoutPrefixProvider* dpp, optional_yield& y, bufferlist* bl = nullptr);
 
-  private:
+  protected:
     rgw::sal::Driver* driver;
     RemoteCacheOpData op;
     std::unique_ptr<RGWRESTStreamRWRequest> sender;
@@ -58,7 +58,24 @@ class RemoteCacheOp {
     std::unique_ptr<RemoteGetCB> cb;
 };
 
+class RemoteCacheGetOp : public RemoteCacheOp {
+  public:
+    struct RemoteCacheGetOpData : RemoteCacheOpData {};
 
+    RemoteCacheGetOp(rgw::sal::Driver* driver, RemoteCacheGetOpData& op) : RemoteCacheOp(driver, op) {}
+    virtual ~RemoteCacheGetOp() = default;
+
+    using RemoteCacheOp::send_and_complete_request;
+    rgw::AioResultList send_request(const DoutPrefixProvider* dpp, rgw::Aio* aio, uint64_t cost, uint64_t id, optional_yield& y);
+    virtual int send_request(const DoutPrefixProvider* dpp, optional_yield& y, bufferlist* bl = nullptr) override;
+    virtual int complete_request(const DoutPrefixProvider* dpp, optional_yield& y) override;
+    rgw::AioResultList send_and_complete_request(const DoutPrefixProvider* dpp, rgw::Aio* aio, uint64_t cost, uint64_t id, optional_yield& y);
+    ceph::bufferlist&& get_buffer() { return std::move(in_bl); }
+
+  private:
+    rgw::Aio* aio{nullptr};
+    rgw::AioResult* r{nullptr};
+};
 
 class RemoteCacheDeleteOp : public RemoteCacheOp {
   public:
@@ -67,15 +84,7 @@ class RemoteCacheDeleteOp : public RemoteCacheOp {
     RemoteCacheDeleteOp(rgw::sal::Driver* driver, RemoteCacheDeleteOpData& op) : RemoteCacheOp(driver, op) {}
     virtual ~RemoteCacheDeleteOp() = default; 
     
-	virtual int send_request(const DoutPrefixProvider* dpp, bufferlist& bl, optional_yield& y) override;
-    virtual int send_and_complete_request(const DoutPrefixProvider* dpp, bufferlist& bl, optional_yield& y) override;
-
-  private:
-    rgw::sal::Driver* driver;
-    RemoteCacheDeleteOpData op;
-    std::unique_ptr<RGWRESTStreamRWRequest> sender;
-    bufferlist in_bl;
-    std::unique_ptr<RemoteGetCB> cb;
+	virtual int send_request(const DoutPrefixProvider* dpp, optional_yield& y, bufferlist* bl = nullptr) override;
 };
 
 class RemoteCachePutOp : public RemoteCacheOp {
@@ -85,15 +94,7 @@ class RemoteCachePutOp : public RemoteCacheOp {
     RemoteCachePutOp(rgw::sal::Driver* driver, RemoteCachePutOpData& op) : RemoteCacheOp(driver, op) {}
     virtual ~RemoteCachePutOp() = default;
  
-	virtual int send_request(const DoutPrefixProvider* dpp, bufferlist& bl, optional_yield& y) override;
-    virtual int send_and_complete_request(const DoutPrefixProvider* dpp, bufferlist& bl, optional_yield& y) override;
-
-  private:
-    rgw::sal::Driver* driver;
-    RemoteCachePutOpData op;
-    std::unique_ptr<RGWRESTStreamRWRequest> sender;
-    bufferlist in_bl;
-    std::unique_ptr<RemoteGetCB> cb;
+	virtual int send_request(const DoutPrefixProvider* dpp, optional_yield& y, bufferlist* bl = nullptr) override;
 };
 
 class RemoteCachePutBatch {

--- a/src/rgw/driver/d4n/d4n_remote_cache_manager.h
+++ b/src/rgw/driver/d4n/d4n_remote_cache_manager.h
@@ -88,10 +88,12 @@ class RemoteCacheDeleteOp : public RemoteCacheOp {
 };
 
 class RemoteCachePutOp : public RemoteCacheOp {
+  bool block_only = false; // bypasses head object upload
+
   public:
     struct RemoteCachePutOpData : RemoteCacheOpData {};
 
-    RemoteCachePutOp(rgw::sal::Driver* driver, RemoteCachePutOpData& op) : RemoteCacheOp(driver, op) {}
+    RemoteCachePutOp(rgw::sal::Driver* driver, RemoteCachePutOpData& op, bool block_only = false) : RemoteCacheOp(driver, op), block_only(block_only) {}
     virtual ~RemoteCachePutOp() = default;
  
 	virtual int send_request(const DoutPrefixProvider* dpp, optional_yield& y, bufferlist* bl = nullptr) override;

--- a/src/rgw/driver/d4n/rgw_sal_d4n.cc
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.cc
@@ -96,6 +96,12 @@ int D4NFilterDriver::initialize(CephContext *cct, const DoutPrefixProvider *dpp)
   blockDir->set_redis_pool(redis_pool);
   bucketDir->set_redis_pool(redis_pool);
   
+  if (dpp->get_cct()->_conf->rgw_d4n_async_remote_put) {
+    int thread_pool_size = dpp->get_cct()->_conf->rgw_d4n_thread_pool_size;
+    d4n_thread_pool = std::make_unique<boost::asio::thread_pool>(thread_pool_size);
+    auto executor = get_d4n_executor();
+    initialize_pool(dpp, executor, (thread_pool_size));
+  }
   return 0;
 }
 
@@ -1000,7 +1006,7 @@ int D4NFilterObject::copy_object(const ACLOwner& owner,
       bufferlist bl;
       driver->get_policy_driver()->get_cache_policy()->update(dpp, key, 0, bl.length(), dest_version, dirty, rgw::d4n::RefCount::NOOP, y);
       d4n_dest_object->set_object_version(dest_version);
-      ret = d4n_dest_object->set_head_obj_dir_entry(dpp, nullptr, y, true, dirty);
+      ret = d4n_dest_object->set_head_obj_dir_entry(dpp, y, true, dirty);
       if (ret < 0) {
         ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object with ret: " << ret << dendl;
         return ret;
@@ -1313,8 +1319,7 @@ int D4NFilterObject::create_delete_marker(const DoutPrefixProvider* dpp, optiona
     if (ret == 0) {
       ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << "(): version stored in update method is: " << version << dendl;
       driver->get_policy_driver()->get_cache_policy()->update(dpp, key, 0, bl.length(), version, true, rgw::d4n::RefCount::NOOP, y);
-      std::vector<std::string> exec_responses;
-      ret = this->set_head_obj_dir_entry(dpp, &exec_responses , y, true, true);
+      ret = this->set_head_obj_dir_entry(dpp, y, true, true);
       if (ret < 0) {
         ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object, ret=" << ret << dendl;
         return ret;
@@ -1343,7 +1348,7 @@ for "null" versions, when bucket is non-versioned.
 4. A versioned hash entry for every version for a version enabled bucket - this helps in get/delete requests with version-id specified
 5. Redis ordered set to maintain the order of dirty objects added for a version enabled bucket. Even when the bucket is non-versioned, this set maintains a "null" entry
 6. Another ordered set to maintain a lexicographically sorted order of objects for a bucket - used for bucket listing */
-int D4NFilterObject::set_head_obj_dir_entry(const DoutPrefixProvider* dpp, std::vector<std::string>* exec_responses, optional_yield y, bool is_latest_version, bool dirty)
+int D4NFilterObject::set_head_obj_dir_entry(const DoutPrefixProvider* dpp, optional_yield y, bool is_latest_version, bool dirty)
 {
   ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): object name: " << this->get_name() << " bucket name: " << this->get_bucket()->get_name() << dendl;
   rgw::d4n::CacheBlock block; 
@@ -1552,45 +1557,189 @@ int D4NFilterObject::set_head_obj_dir_entry(const DoutPrefixProvider* dpp, std::
   return 0;
 }
 
+int D4NFilterObject::update_head_block_hostslist(const DoutPrefixProvider* dpp, optional_yield y)
+{
+  rgw::d4n::BlockDirectory* blockDir = driver->get_block_dir();
+  auto redis_conn = this->driver->get_conn();
+  auto redis_pool = this->driver->get_redis_pool();
+
+  std::string objName = this->get_name();
+  // special handling for name starting with '_'
+  if (objName[0] == '_') {
+    objName = "_" + this->get_name();
+  }
+  ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): objName after special Handling: " << objName << dendl;
+
+  rgw::d4n::CacheObj object;
+  object.objName = objName;
+  object.bucketName = this->get_bucket()->get_bucket_id();
+
+  rgw::d4n::CacheBlock block;
+  block.cacheObj = object;
+  block.blockID = 0;
+  block.size = 0;
+
+  //get block that contains latest version
+  auto ret = blockDir->get(dpp, &block, y);
+  if (ret == 0) {
+    //if found, check if version matches with block's existing version
+    if(this->version == block.version) {
+      //only then update hostsList to contain local cache address
+      block.cacheObj.hostsList.insert(dpp->get_cct()->_conf->rgw_d4n_remote_cache_address);
+      if (!(this->get_bucket()->versioned())) {
+        //for non-versioned bucket, update latest version block and null version block
+        rgw::d4n::Pipeline p = rgw::d4n::Pipeline(redis_conn, redis_pool);
+        p.start();
+        ret = blockDir->set(dpp, &block, y, &p);
+        if (ret < 0) {
+          ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object with ret: " << ret << dendl;
+          return ret;
+        }
+        //bucket is non versioned, set a null instance
+        block.cacheObj.objName = "_:null_" + this->get_name();
+        ret = blockDir->set(dpp, &block, y, &p);
+        if (ret < 0) {
+          ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for null head object with ret: " << ret << dendl;
+          return ret;
+        }
+        p.execute(dpp, y);
+      }
+    }
+  } else if (ret < 0) {
+    ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory get method failed for head block with ret: " << ret << dendl;
+    if (ret != -ENOENT) {
+      return ret;
+    }
+  }
+
+  //save latest block get result to be used later in a pipeline if needed
+  auto latest_block_ret = ret;
+  //check if bucket is versioned
+  if (this->get_bucket()->versioned()) {
+    std::string objName = this->get_oid();
+    if (this->get_instance() == "null" || !this->get_bucket()->versioning_enabled()) {
+      objName = "_:null_" + this->get_name();
+    }
+    rgw::d4n::CacheObj versioned_object;
+    versioned_object.objName = objName;
+    versioned_object.bucketName = this->get_bucket()->get_bucket_id();
+
+    rgw::d4n::CacheBlock versioned_block;
+    versioned_block.cacheObj = versioned_object;
+    versioned_block.blockID = 0;
+    versioned_block.size = 0;
+    //get versioned block
+    ret = blockDir->get(dpp, &versioned_block, y);
+    if (ret == 0) {
+      //verify versions match for the versioned block
+      if(this->version == versioned_block.version) {
+        versioned_block.cacheObj.hostsList.insert(dpp->get_cct()->_conf->rgw_d4n_remote_cache_address);
+        //verify versions match for the latest block
+        if (latest_block_ret == 0 && block.version == version) {
+          block.cacheObj.hostsList.insert(dpp->get_cct()->_conf->rgw_d4n_remote_cache_address);
+          rgw::d4n::Pipeline p = rgw::d4n::Pipeline(redis_conn, redis_pool);
+          p.start();
+          ret = blockDir->set(dpp, &versioned_block, y, &p);
+          if (ret < 0) {
+            ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head block with ret: " << ret << dendl;
+            return ret;
+          }
+          ret = blockDir->set(dpp, &block, y, &p);
+          if (ret < 0) {
+            ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for null head block with ret: " << ret << dendl;
+            return ret;
+          }
+          p.execute(dpp, y);
+        } else {
+          //case when latest block version does not match with existing version, update only version block
+          ret = blockDir->set(dpp, &versioned_block, y);
+          if (ret < 0) {
+            ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head block with ret: " << ret << dendl;
+            return ret;
+          }
+        }
+      } else {
+        //case when only latest block version matches existing version
+        if (latest_block_ret == 0 && block.version == version) {
+          block.cacheObj.hostsList.insert(dpp->get_cct()->_conf->rgw_d4n_remote_cache_address);
+          ret = blockDir->set(dpp, &block, y);
+          if (ret < 0) {
+            ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head block with ret: " << ret << dendl;
+            return ret;
+          }
+        }
+      }
+    } else if (ret < 0) {//ret ==0 for versioned block
+      ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object with ret: " << ret << dendl;
+      return ret;
+    }
+  }
+  return 0;
+}
+
+/*
+ This method updates the hostslist, version and dirty flag for data block directory entries
+*/
 int D4NFilterObject::set_data_block_dir_entries(const DoutPrefixProvider* dpp, optional_yield y, std::string& version, bool dirty)
 {
   rgw::d4n::BlockDirectory* blockDir = driver->get_block_dir();
 
-  //update data block entries in directory
-  off_t lst = this->get_size();
-  ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Object size =" << lst << dendl;
-  off_t fst = 0;
-  std::vector<rgw::d4n::CacheBlock> blocks;
-  do {
-    rgw::d4n::CacheBlock block;
-    if (fst >= lst){
-      break;
+  if (!is_remote_head_block_request()) {
+    //update data block entries in directory
+    off_t lst;
+    off_t fst;
+    if (!is_remote_cache_request()) {
+      lst = this->get_size();
+      fst = 0;
+    } else {
+      lst = this->get_remote_block_len();
+      fst = this->get_remote_block_offset();
     }
-    off_t cur_size = std::min<off_t>(fst + dpp->get_cct()->_conf->rgw_max_chunk_size, lst);
-    off_t cur_len = cur_size - fst;
-    block.cacheObj.bucketName = this->get_bucket()->get_bucket_id();
-    block.cacheObj.objName = this->get_key().get_oid();
-    block.size = cur_len;
-    block.blockID = fst;
+    ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): Object/Block size =" << lst << dendl;
+    ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): offset =" << fst << dendl;
 
-    fst += cur_len;
-    blocks.emplace_back(block);
-  } while(fst < lst);
+    std::vector<rgw::d4n::CacheBlock> blocks;
+    do {
+      rgw::d4n::CacheBlock block;
+      if (fst >= lst){
+        break;
+      }
+      off_t cur_size = std::min<off_t>(fst + dpp->get_cct()->_conf->rgw_max_chunk_size, lst);
+      off_t cur_len = cur_size - fst;
+      block.cacheObj.bucketName = this->get_bucket()->get_bucket_id();
+      block.cacheObj.objName = this->get_key().get_oid();
+      block.size = cur_len;
+      block.blockID = fst;
 
-  auto ret = blockDir->get(dpp, blocks, y);
-  if (ret < 0) {
-    ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): BlockDirectory pipelined get() method failed, ret=" << ret << dendl;
-    return ret;
-  }
+      fst += cur_len;
+      blocks.emplace_back(block);
+    } while(fst < lst);
 
-  for (auto& block : blocks) {
-    block.cacheObj.dirty = dirty;
-    block.cacheObj.hostsList.insert(dpp->get_cct()->_conf->rgw_d4n_local_rgw_address);
-    block.version = version;
-  }
-  if ((ret = blockDir->set(dpp, blocks, y)) < 0) {
-    ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): BlockDirectory pipelined set() method failed, ret=" << ret << dendl;
-    return ret;
+    auto ret = blockDir->get(dpp, blocks, y);
+    if (ret < 0) {
+      ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): BlockDirectory pipelined get() method failed, ret=" << ret << dendl;
+      return ret;
+    }
+
+    //in case of a remote request, the blocks are not dirty, hence don't change the flag in the directory
+    bool update_dirty_flag = true;
+    if (remote_cache_request) {
+      update_dirty_flag = false;
+    }
+    for (auto& block : blocks) {
+      if (block.cacheObj.objName.empty()) {
+        continue;
+      }
+      if (update_dirty_flag) {
+        block.cacheObj.dirty = dirty;
+      }
+      block.cacheObj.hostsList.insert(dpp->get_cct()->_conf->rgw_d4n_local_rgw_address);
+      block.version = version;
+    }
+    if ((ret = blockDir->set(dpp, blocks, y)) < 0) {
+      ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): BlockDirectory pipelined set() method failed, ret=" << ret << dendl;
+      return ret;
+    }
   }
 
   return 0;
@@ -1755,7 +1904,7 @@ int D4NFilterObject::get_obj_attrs(optional_yield y, const DoutPrefixProvider* d
     if (ret == 0) {
       ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " version stored in update method is: " << this->get_object_version() << dendl;
       this->driver->get_policy_driver()->get_cache_policy()->update(dpp, head_oid_in_cache, 0, 0, version, false, rgw::d4n::RefCount::DECR, y);
-      ret = set_head_obj_dir_entry(dpp, nullptr, y, is_latest_version);
+      ret = set_head_obj_dir_entry(dpp, y, is_latest_version);
       if (ret < 0) {
         ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object, ret=" << ret << dendl;
       }
@@ -1876,6 +2025,10 @@ std::unique_ptr<Writer> D4NFilterDriver::get_atomic_writer(const DoutPrefixProvi
 
 void D4NFilterDriver::shutdown()
 {
+  if (d4n_thread_pool) {
+    d4n_coroutine_pool->stop();
+    d4n_thread_pool->stop();
+  }
   // call cancel() on the connection's executor
   boost::asio::dispatch(conn->get_executor(), [c = conn] { c->cancel(); });
 
@@ -1949,7 +2102,7 @@ int D4NFilterObject::D4NFilterReadOp::prepare(optional_yield y, const DoutPrefix
       if (ret == 0) {
         ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " version stored in update method is: " << this->source->get_object_version() << dendl;
         source->driver->get_policy_driver()->get_cache_policy()->update(dpp, head_oid_in_cache, 0, bl.length(), version, false, rgw::d4n::RefCount::NOOP, y);
-        ret = source->set_head_obj_dir_entry(dpp, nullptr, y, is_latest_version);
+        ret = source->set_head_obj_dir_entry(dpp, y, is_latest_version);
         if (ret < 0) {
           ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object, ret=" << ret << dendl;
         }
@@ -2931,19 +3084,26 @@ int D4NFilterWriter::prepare(optional_yield y)
   }
 
   std::string version;
+  bool remote_cache_request = object->is_remote_cache_request();
+  if (remote_cache_request) {
+    version = object->get_object_version();
+  }
   if (!object->have_instance()) {
     if (object->get_bucket()->versioned() && !object->get_bucket()->versioning_enabled()) { //if versioning is suspended
       object->set_instance("null");
     }
-    char buf[OBJ_INSTANCE_LEN + 1];
-    gen_rand_alphanumeric_no_underscore(dpp->get_cct(), buf, OBJ_INSTANCE_LEN);
-    version = buf; // using gen_rand_alphanumeric_no_underscore for the time being
-    ldpp_dout(dpp, 20) << "D4NFilterWriter::" << __func__ << "(): generating version: " << version << dendl;
+    if (version.empty()) {
+      char buf[OBJ_INSTANCE_LEN + 1];
+      gen_rand_alphanumeric_no_underscore(dpp->get_cct(), buf, OBJ_INSTANCE_LEN);
+      version = buf; // using gen_rand_alphanumeric_no_underscore for the time being
+      ldpp_dout(dpp, 20) << "D4NFilterWriter::" << __func__ << "(): generating version: " << version << dendl;
+      object->set_object_version(version);
+    }
   } else {
     ldpp_dout(dpp, 20) << "D4NFilterWriter::" << __func__ << "(): version is: " << object->get_instance() << dendl;
     version = object->get_instance();
+    object->set_object_version(version);
   }
-  object->set_object_version(version);
   this->version = version;
 
   return 0;
@@ -2954,16 +3114,21 @@ int D4NFilterWriter::process(bufferlist&& data, uint64_t offset)
     bufferlist bl = data;
     off_t bl_len = bl.length();
     off_t ofs = offset;
+    bool dirty = true;
     bool cache_request = object->is_cache_request();
-    bool dirty;
-
+    bool remote_cache_request = object->is_remote_cache_request();
+    if (remote_cache_request || cache_request) {
+      dirty = false;
+    }
+    if (remote_cache_request) {
+      ofs = object->get_remote_block_offset();
+      ldpp_dout(dpp, 10) << "D4NFilterWriter::" << __func__ << "(): ofs is: " << ofs << dendl;
+    }
     std::string version = object->get_object_version();
     std::string prefix = get_cache_block_prefix(obj, version);
 
-    int ret = 0;
-
     if (!d4n_writecache) {
-      if (cache_request) {
+      if (cache_request || remote_cache_request) {
 		return -EINVAL;
       }
       ldpp_dout(dpp, 10) << "D4NFilterWriter::" << __func__ << "(): calling next process" << dendl;
@@ -2972,36 +3137,48 @@ int D4NFilterWriter::process(bufferlist&& data, uint64_t offset)
       rgw::sal::Attrs attrs;
       std::string oid = prefix + CACHE_DELIM + std::to_string(ofs);
       std::string oid_in_cache = oid + CACHE_DELIM + std::to_string(bl_len);
-      if (!cache_request) {
-	dirty = true;
-      }
-      ret = driver->get_policy_driver()->get_cache_policy()->eviction(dpp, bl.length(), y);
-      if (ret == 0) {
-        if (bl.length() > 0) {
-          rgw::d4n::CacheObj object;
-          rgw::d4n::CacheBlock block;
-          object.bucketName = obj->get_bucket()->get_name();
-          object.objName = obj->get_key().get_oid();
-          object.size = bl.length();
-          object.dirty = true;
-          bufferlist out_bl;
-          object.hostsList.insert(dpp->get_cct()->_conf->rgw_d4n_l1_datacache_address);
-          ret = sendRemote(dpp, &object, dpp->get_cct()->_conf->rgw_d4n_remote_cache_address, oid, &out_bl, y);
-          if (ret == 0) {
-	    if (!cache_request) {
-	      dirty = true;
-	    }
-	    if (!cache_request) {
-              ret = driver->get_cache_driver()->set_attr(dpp, oid_in_cache, RGW_CACHE_ATTR_DIRTY, "1", y);
-	      if (ret == 0) {
-		driver->get_policy_driver()->get_cache_policy()->update(dpp, oid_in_cache, ofs, bl.length(), version, dirty, rgw::d4n::RefCount::NOOP, y);
-	      }
-            } else {
-	      driver->get_policy_driver()->get_cache_policy()->update(dpp, oid_in_cache, ofs, bl.length(), version, dirty, rgw::d4n::RefCount::NOOP, y);
-            }
-          } //sendRemote ret = 0
+      if (bl.length() > 0) {
+        ldpp_dout(dpp, 10) << "D4NFilterWriter::" << __func__ << "(): oid_in_cache is: " << oid_in_cache << dendl;
+        auto local_cache_ret = driver->get_policy_driver()->get_cache_policy()->eviction(dpp, bl.length(), y);
+        if (local_cache_ret == 0) {
+          if (dirty) {
+            bufferlist bl_val;
+            bl_val.append("1");
+            attrs[RGW_CACHE_ATTR_DIRTY] = std::move(bl_val);
+          }
+          local_cache_ret = driver->get_cache_driver()->put(dpp, oid_in_cache, bl, bl.length(), attrs, y);
+          if (local_cache_ret == 0) {
+            driver->get_policy_driver()->get_cache_policy()->update(dpp, oid_in_cache, ofs, bl.length(), version, dirty, rgw::d4n::RefCount::NOOP, y);
+          }
         }
-      }
+        if (local_cache_ret < 0) {
+          ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): adding block to local cache failed with ret= " << local_cache_ret << dendl;
+        }
+        //send it to remote only if it is not a remote request from another rgw
+        if (!remote_cache_request && dpp->get_cct()->_conf->rgw_d4n_remote_put && !dpp->get_cct()->_conf->rgw_d4n_async_remote_put) {
+          auto user = obj->get_bucket()->get_owner();
+          std::string remote_addr = dpp->get_cct()->_conf->rgw_d4n_remote_cache_address;
+          ldpp_dout(dpp, 20) << "D4NFilterWriter::" << __func__ << "(): remoteaddr =" << remote_addr << dendl;
+          uint64_t offset = ofs;
+          rgw::d4n::RemoteCachePut::RemoteCachePutOp op {
+              obj->get_bucket()->get_name(),
+              obj->get_key().get_oid(),
+              offset,
+              bl.length(),
+              version,
+              std::get<rgw_user>(user),
+              remote_addr
+          };
+          std::unique_ptr<rgw::d4n::RemoteCachePut> remote_put = std::make_unique<rgw::d4n::RemoteCachePut>(driver, op);
+          auto ret = remote_put->send_and_complete_request(dpp, bl, y);
+          if (ret < 0) {
+            ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): send_and_complete_request failed for remote cache: " << remote_addr <<  "ret= " << ret << dendl;
+          }
+        } //end - if (!remote_cache_request)
+        if (local_cache_ret < 0) {
+          return local_cache_ret;
+        }
+      } //end - if (bl.lenght() > 0)
     } 
     return 0;
 }
@@ -3025,6 +3202,7 @@ int D4NFilterWriter::complete(size_t accounted_size, const std::string& etag,
   if (object->have_instance()) {
     instance = object->get_instance();
   }
+  bool remote_cache_request = object->is_remote_cache_request();
   int ret;
   
   /* for cache coherence, we are going to cache the head even in case when read-only cache is enabled, just that
@@ -3087,8 +3265,9 @@ int D4NFilterWriter::complete(size_t accounted_size, const std::string& etag,
       return ret;
     }
 
-    if (!object->is_cache_request()) {
-      dirty = true;
+    dirty = true;
+    if (remote_cache_request || object->is_cache_request()) {
+      dirty = false;
     }
     ceph::real_time m_time;
     if (mtime) {
@@ -3100,7 +3279,12 @@ int D4NFilterWriter::complete(size_t accounted_size, const std::string& etag,
       m_time = real_clock::now();
     }
     object->set_mtime(m_time);
-    object->set_accounted_size(accounted_size);
+    if (object->is_remote_head_block_request()) {
+      object->set_accounted_size(object->get_remote_obj_size());
+      object->set_obj_size(object->get_remote_obj_size());
+    } else {
+      object->set_accounted_size(accounted_size);
+    }
     ldpp_dout(dpp, 20) << "D4NFilterWriter::" << __func__ << " size is: " << object->get_size() << dendl;
     object->set_attr_crypt_parts(dpp, y, attrs);
     object->set_attrs(attrs);
@@ -3131,49 +3315,200 @@ int D4NFilterWriter::complete(size_t accounted_size, const std::string& etag,
     }
   }
 
-  std::string version = object->get_object_version();
-  std::string key = get_cache_block_prefix(obj, version);
+  if (object->is_remote_head_block_request() || !object->is_remote_cache_request()) {
+    std::string version = object->get_object_version();
+    std::string key = get_cache_block_prefix(obj, version);
 
-  bufferlist bl;
-  //same as key, as there is no len or offset attached to head oid in cache
-  ldpp_dout(dpp, 20) << "D4NFilterWriter::" << __func__ << "(): key is: " << key << dendl;
-  ret = driver->get_policy_driver()->get_cache_policy()->eviction(dpp, attrs.size(), y);
-  if (ret == 0) {
-    ret = driver->get_cache_driver()->put(dpp, key, bl, 0, attrs, y);
-    attrs.erase(RGW_CACHE_ATTR_MTIME);
-    attrs.erase(RGW_CACHE_ATTR_OBJECT_SIZE);
-    attrs.erase(RGW_CACHE_ATTR_ACCOUNTED_SIZE);
-    attrs.erase(RGW_CACHE_ATTR_EPOCH);
-    attrs.erase(RGW_CACHE_ATTR_MULTIPART);
-    attrs.erase(RGW_CACHE_ATTR_OBJECT_NS);
-    attrs.erase(RGW_CACHE_ATTR_BUCKET_NAME);
-    object->set_object_version(version);
+    bufferlist bl;
+    //same as key, as there is no len or offset attached to head oid in cache
+    ldpp_dout(dpp, 20) << "D4NFilterWriter::" << __func__ << "(): key is: " << key << dendl;
+    ret = driver->get_policy_driver()->get_cache_policy()->eviction(dpp, attrs.size(), y);
     if (ret == 0) {
-      ldpp_dout(dpp, 20) << "D4NFilterWriter::" << __func__ << "(): version stored in update method is: " << version << dendl;
-      driver->get_policy_driver()->get_cache_policy()->update(dpp, key, 0, bl.length(), version, dirty, rgw::d4n::RefCount::NOOP, y);
-      ret = object->set_head_obj_dir_entry(dpp, nullptr, y, true, dirty);
-      if (ret < 0) {
-        ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): BlockDirectory set method failed for head object, ret=" << ret << dendl;
+      ret = driver->get_cache_driver()->put(dpp, key, bl, 0, attrs, y);
+      attrs.erase(RGW_CACHE_ATTR_MTIME);
+      attrs.erase(RGW_CACHE_ATTR_OBJECT_SIZE);
+      attrs.erase(RGW_CACHE_ATTR_ACCOUNTED_SIZE);
+      attrs.erase(RGW_CACHE_ATTR_EPOCH);
+      attrs.erase(RGW_CACHE_ATTR_MULTIPART);
+      attrs.erase(RGW_CACHE_ATTR_OBJECT_NS);
+      attrs.erase(RGW_CACHE_ATTR_BUCKET_NAME);
+      object->set_object_version(version);
+      if (ret == 0) {
+        ldpp_dout(dpp, 20) << "D4NFilterWriter::" << __func__ << "(): version stored in update method is: " << version << dendl;
+        driver->get_policy_driver()->get_cache_policy()->update(dpp, key, 0, bl.length(), version, dirty, rgw::d4n::RefCount::NOOP, y);
+        if (remote_cache_request) {
+          //update only hostslist since it is a remote cache request
+          ret = object->update_head_block_hostslist(dpp, y);
+        } else {
+          ret = object->set_head_obj_dir_entry(dpp, y, true, dirty);
+        }
+        if (ret < 0) {
+          ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): BlockDirectory set method failed for head object, ret=" << ret << dendl;
+          return ret;
+        }
+        if (dirty) {
+          auto creationTime = ceph::real_clock::to_double(object->get_mtime());
+          ldpp_dout(dpp, 20) << "D4NFilterWriter::" << __func__ << "(): key=" << key << dendl;
+          ldpp_dout(dpp, 20) << "D4NFilterWriter::" << __func__ << "(): obj->get_key()=" << obj->get_key() << dendl;
+          driver->get_policy_driver()->get_cache_policy()->update_dirty_object(dpp, key, version, false, accounted_size, creationTime, std::get<rgw_user>(obj->get_bucket()->get_owner()), objEtag, obj->get_bucket()->get_name(), obj->get_bucket()->get_bucket_id(), obj->get_key(), rgw::d4n::RefCount::NOOP, y);
+          if (!prev_oid_in_cache.empty()) {
+            driver->get_policy_driver()->get_cache_policy()->invalidate_dirty_object(dpp, prev_oid_in_cache);
+          }
+          if (dpp->get_cct()->_conf->rgw_d4n_remote_put && !object->is_remote_cache_request()) {
+            auto user = obj->get_bucket()->get_owner();
+            std::string remote_addr = dpp->get_cct()->_conf->rgw_d4n_remote_cache_address;
+            if (!dpp->get_cct()->_conf->rgw_d4n_async_remote_put) {
+              ldpp_dout(dpp, 20) << "D4NFilterWriter::" << __func__ << "(): remoteaddr =" << remote_addr << dendl;
+              rgw::d4n::RemoteCachePut::RemoteCachePutOp op {
+                  obj->get_bucket()->get_name(),
+                  obj->get_key().get_oid(),
+                  0,
+                  0,
+                  version,
+                  std::get<rgw_user>(user),
+                  remote_addr,
+                  obj->get_size()
+              };
+              bufferlist bl;
+              std::unique_ptr<rgw::d4n::RemoteCachePut> remote_put = std::make_unique<rgw::d4n::RemoteCachePut>(driver, op);
+              ret = remote_put->send_and_complete_request(dpp, bl, y);
+              if (ret < 0) {
+                ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): send_and_complete_request failed for remote cache: " << remote_addr <<  "ret= " << ret << dendl;
+              }
+            } else {
+              CephContext* cct = dpp->get_cct();
+              auto pool = driver->get_pool();
+              if (pool) {
+                pool->submit(
+                  [cct,
+                  prefix = key,
+                  size = obj->get_size(),
+                  usr = std::get<rgw_user>(user),
+                  remote_addr,
+                  bucket_name = obj->get_bucket()->get_name(),
+                  oid = obj->get_key().get_oid(),
+                  version,
+                  driver = this->driver]
+                  (boost::asio::yield_context yield) {
+
+                  auto dpp_local = std::make_shared<D4NFilterDPP>(cct);
+                  try {
+                    D4NFilterWriter::write_to_remote_cache(
+                        dpp_local.get(),
+                        prefix,
+                        size,
+                        usr,
+                        remote_addr,
+                        bucket_name,
+                        oid,
+                        version,
+                        driver,
+                        yield
+                    );
+
+                    ldpp_dout(dpp_local.get(), 10)
+                        << "Successfully completed remote cache write for "
+                        << oid << dendl;
+
+                  } catch (const std::exception& e) {
+                      ldpp_dout(dpp_local.get(), 0)
+                          << "Error in remote cache write: "
+                          << e.what() << dendl;
+                  }
+                });
+              }
+            }
+          }
+        }
+      } else { //if get_cache_driver()->put()
+        ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): put failed for head_oid_in_cache, ret=" << ret << dendl;
         return ret;
       }
-      if (dirty) {
-        auto creationTime = ceph::real_clock::to_double(object->get_mtime());
-        ldpp_dout(dpp, 20) << "D4NFilterWriter::" << __func__ << "(): key=" << key << dendl;
-        ldpp_dout(dpp, 20) << "D4NFilterWriter::" << __func__ << "(): obj->get_key()=" << obj->get_key() << dendl;
-        driver->get_policy_driver()->get_cache_policy()->update_dirty_object(dpp, key, version, false, accounted_size, creationTime, std::get<rgw_user>(obj->get_bucket()->get_owner()), objEtag, obj->get_bucket()->get_name(), obj->get_bucket()->get_bucket_id(), obj->get_key(), rgw::d4n::RefCount::NOOP, y);
-        if (!prev_oid_in_cache.empty()) {
-          driver->get_policy_driver()->get_cache_policy()->invalidate_dirty_object(dpp, prev_oid_in_cache);
-        }
-      }
-    } else { //if get_cache_driver()->put()
-      ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): put failed for head_oid_in_cache, ret=" << ret << dendl;
+    } else {
+      ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): eviction failed for head_oid_in_cache, ret=" << ret << dendl;
       return ret;
     }
-  } else {
-    ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): eviction failed for head_oid_in_cache, ret=" << ret << dendl;
-    return ret;
   }
   return 0;
+}
+
+void D4NFilterWriter::write_to_remote_cache(const DoutPrefixProvider* dpp_o, const std::string& prefix, uint64_t size, const rgw_user& user, const std::string& remote_addr, const std::string& bucket_name, const std::string& oid, const std::string& version, D4NFilterDriver* driver, optional_yield y)
+{
+  //Read data blocks from cache, and send remote requests
+  uint64_t lst = size;
+  uint64_t fst = 0;
+  auto policy = driver->get_policy_driver()->get_cache_policy();
+  auto cache_driver = driver->get_cache_driver();
+  do {
+    ldpp_dout(dpp_o, 20) << "D4NFilterWriter:: " << __func__ <<  " " << __LINE__ << "(): lst=" << lst << " fst: " << fst << dendl;
+    rgw::d4n::CacheBlock block;
+    if (fst >= lst) {
+      break;
+    }
+    uint64_t chunk_size = std::min<off_t>(fst + dpp_o->get_cct()->_conf->rgw_max_chunk_size, lst);
+    uint64_t cur_len = chunk_size - fst;
+    std::string oid_in_cache = get_key_in_cache(prefix, std::to_string(fst), std::to_string(cur_len));
+
+    ldpp_dout(dpp_o, 20) << "D4NFilterWriter:: " << __func__ <<  " " << __LINE__ << "(): READ FROM CACHE: oid=" << oid_in_cache << " length to read is: " << cur_len << 
+    " read_ofs: " << fst << dendl;
+
+    if (policy->update_refcount_if_key_exists(dpp_o, oid_in_cache, rgw::d4n::RefCount::INCR, y)) {
+      // Read From Cache
+      bufferlist bl;
+      rgw::sal::Attrs attrs;
+      auto ret = cache_driver->get(dpp_o, oid_in_cache, 0, cur_len, bl, attrs, y);
+      if (ret < 0) {
+        ldpp_dout(dpp_o, 20) << "D4NFilterWriter:: " << __func__ <<  " get failed with ret: " << ret << dendl;
+        return;
+      }
+
+      rgw::d4n::RemoteCachePut::RemoteCachePutOp op {
+          bucket_name,
+          oid,
+          fst,
+          cur_len,
+          version,
+          user,
+          remote_addr,
+          size
+      };
+      std::unique_ptr<rgw::d4n::RemoteCachePut> remote_put = std::make_unique<rgw::d4n::RemoteCachePut>(driver, op);
+      ret = remote_put->send_and_complete_request(dpp_o, bl, y);
+      if (ret < 0) {
+        ldpp_dout(dpp_o, 0) << "D4NFilterWriter::" << __func__ << "(): send_and_complete_request failed for remote cache: " << remote_addr <<  "ret= " << ret << dendl;
+        return;
+      }
+      fst += cur_len;
+    }
+  } while(fst < lst);
+  rgw::d4n::RemoteCachePut::RemoteCachePutOp op {
+              bucket_name,
+              oid,
+              0,
+              0,
+              version,
+              user,
+              remote_addr,
+              size
+            };
+  bufferlist bl;
+
+  std::unique_ptr<rgw::d4n::RemoteCachePut> remote_put = std::make_unique<rgw::d4n::RemoteCachePut>(driver, op);
+  auto ret = remote_put->send_and_complete_request(dpp_o, bl, y);
+  if (ret < 0) {
+    ldpp_dout(dpp_o, 0) << "D4NFilterWriter::" << __func__ << "(): send_and_complete_request failed for remote cache: " << remote_addr <<  "ret= " << ret << dendl;
+  }
+
+  if (driver->get_pool()) {
+    auto stats = driver->get_pool()->get_stats();
+    ldpp_dout(dpp_o, 20) << "D4NFilterWriter::" << __func__
+                          << " Pool stats:"
+                          << " Queue: " << stats.queue_size
+                          << " Active: " << stats.active_workers
+                          << " Idle: " << stats.idle_workers
+                          << " Total submitted: " << stats.queued_tasks
+                          << dendl;
+  }
 }
 
 int D4NFilterMultipartUpload::complete(const DoutPrefixProvider *dpp,
@@ -3225,7 +3560,7 @@ int D4NFilterMultipartUpload::complete(const DoutPrefixProvider *dpp,
     if (ret == 0) {
       ldpp_dout(dpp, 20) << "D4NFilterMultipartUpload::" << __func__ << " version stored in update method is: " << d4n_target_obj->get_object_version() << dendl;
       driver->get_policy_driver()->get_cache_policy()->update(dpp, head_oid_in_cache, 0, bl.length(), version, false, rgw::d4n::RefCount::NOOP, y);
-      ret = d4n_target_obj->set_head_obj_dir_entry(dpp, nullptr, y, true);
+      ret = d4n_target_obj->set_head_obj_dir_entry(dpp, y, true);
       if (ret < 0) {
         ldpp_dout(dpp, 0) << "D4NFilterMultipartUpload::" << __func__ << "(): BlockDirectory set method failed for head object, ret=" << ret << dendl;
       }
@@ -3238,51 +3573,6 @@ int D4NFilterMultipartUpload::complete(const DoutPrefixProvider *dpp,
     return ret;
   }
 
-  return 0;
-}
-
-int D4NFilterWriter::sendRemote(const DoutPrefixProvider* dpp, rgw::d4n::CacheObj *object, std::string remoteCacheAddress, std::string key, bufferlist*
- out_bl, optional_yield y)
-{
-  bufferlist in_bl;
-  RGWRemoteD4NGetCB cb(&in_bl);
-  std::string bucketName = object->bucketName;
-
-  RGWAccessKey accessKey;
-  std::string findKey;
-
-  auto user = obj->get_bucket()->get_owner();
-  if (std::holds_alternative<rgw_user>(user)) {
-    std::unique_ptr<rgw::sal::User> c_user = driver->get_user(std::get<rgw_user>(user));
-    int ret = c_user->load_user(dpp, y);
-    if (ret < 0) {
-      return -EPERM;
-    }
-
-    if (c_user->get_info().access_keys.empty()) {
-      return -EINVAL;
-    }
-
-    accessKey.id = c_user->get_info().access_keys.begin()->second.id;
-    accessKey.key = c_user->get_info().access_keys.begin()->second.key;
-
-    HostStyle host_style = PathStyle;
-    std::map<std::string, std::string> extra_headers;
-
-    auto sender = new RGWRESTStreamRWRequest(dpp->get_cct(), "PUT", remoteCacheAddress, &cb, NULL, NULL, "", host_style);
-
-    ret = sender->send_request(dpp, accessKey, extra_headers, obj->get_obj(), nullptr);
-    if (ret < 0) {
-      delete sender;
-      return ret;
-    }
-
-    ret = sender->complete_request(dpp, y);
-    if (ret < 0) {
-      delete sender;
-      return ret;
-    }
-  }
   return 0;
 }
 
@@ -3307,7 +3597,7 @@ int D4NFilterObject::D4NFilterReadOp::getRemote(const DoutPrefixProvider* dpp, l
 
     bufferlist out_bl;
     HostStyle host_style = PathStyle;
-    std::map<std::string, std::string> extra_headers;                                                            
+    std::map<std::string, std::string> extra_headers;
     Attrs object_attrs;
     D4NGetObjectCB cb(bl);
 
@@ -3379,7 +3669,7 @@ int D4NFilterObject::D4NFilterReadOp::remoteFlush(const DoutPrefixProvider* dpp,
     if (ret == 0) {
       std::string objEtag = "";
       source->driver->get_policy_driver()->get_cache_policy()->update(dpp, oid_in_cache, ofs, len, version, false, rgw::d4n::RefCount::NOOP, y);
-      if (blockDir->update_field(dpp, &block, "blockHosts", dpp->get_cct()->_conf->rgw_d4n_l1_datacache_address, y) < 0)
+      if (blockDir->update_field(dpp, &block, "blockHosts", dpp->get_cct()->_conf->rgw_d4n_remote_cache_address, y) < 0)
         ldpp_dout(dpp, 10) << "D4NFilterObject::D4NFilterReadOp::D4NFilterGetCB::" << __func__ << "(): BlockDirectory update_field method failed for hostsList." << dendl;
       if (ofs + len >= source->get_size()){ //last block
         ldpp_dout(dpp, 20) << __func__ << "(): " <<  __LINE__ << " THIS IS the last block for object " << block.cacheObj.objName << dendl;
@@ -3389,7 +3679,7 @@ int D4NFilterObject::D4NFilterReadOp::remoteFlush(const DoutPrefixProvider* dpp,
         object.objName = source->get_key().get_oid();
         object.bucketName = source->get_bucket()->get_name();
 
-        if (objectDir->update_field(dpp, &object, "objHosts", dpp->get_cct()->_conf->rgw_d4n_l1_datacache_address, y) < 0)
+        if (objectDir->update_field(dpp, &object, "objHosts", dpp->get_cct()->_conf->rgw_d4n_remote_cache_address, y) < 0)
           ldpp_dout(dpp, 10) << "D4NFilterObject::D4NFilterReadOp::D4NFilterGetCB::" << __func__ << "(): objectDirectory update_field method failed for hostsList." << dendl;
       }
     }

--- a/src/rgw/driver/d4n/rgw_sal_d4n.cc
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.cc
@@ -95,12 +95,12 @@ int D4NFilterDriver::initialize(CephContext *cct, const DoutPrefixProvider *dpp)
   objDir->set_redis_pool(redis_pool);
   blockDir->set_redis_pool(redis_pool);
   bucketDir->set_redis_pool(redis_pool);
-  
+
   if (dpp->get_cct()->_conf->rgw_d4n_async_remote_put) {
     int thread_pool_size = dpp->get_cct()->_conf->rgw_d4n_thread_pool_size;
     d4n_thread_pool = std::make_unique<boost::asio::thread_pool>(thread_pool_size);
     auto executor = get_d4n_executor();
-    initialize_pool(dpp, executor, (thread_pool_size));
+    initialize_pool(dpp, executor, thread_pool_size);
   }
   return 0;
 }
@@ -1354,7 +1354,7 @@ int D4NFilterObject::set_head_obj_dir_entry(const DoutPrefixProvider* dpp, optio
   rgw::d4n::CacheBlock block; 
   rgw::d4n::BlockDirectory* blockDir = this->driver->get_block_dir();
   auto attrs = this->get_attrs();
-  bufferlist bl_etag, bl_acl;
+  bufferlist bl_etag;
   auto etag_it = attrs.find(RGW_ATTR_ETAG);
   if (etag_it != attrs.end()) {
     bl_etag = etag_it->second;
@@ -1362,25 +1362,19 @@ int D4NFilterObject::set_head_obj_dir_entry(const DoutPrefixProvider* dpp, optio
   auto etag = bl_etag.to_str();
   ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): etag: " << etag << dendl;
 
-  auto acl_it = attrs.find(RGW_ATTR_ACL);
-  RGWAccessControlPolicy policy;
+  RGWAccessControlPolicy policy = this->get_acl();
   std::string user_id, display_name;
+  ACLOwner owner = policy.get_owner();
+  rgw_user user = std::get<rgw_user>(owner.id);
+  ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << "(): INFO: user_d: " << user.to_str() << dendl;
+  ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << "(): INFO: display_name: " << owner.display_name << dendl;
+  user_id = user.to_str();
+  display_name = owner.display_name;
+  bufferlist bl_acl;
+  auto acl_it = attrs.find(RGW_ATTR_ACL);
   if (acl_it != attrs.end()) {
-    auto bliter = acl_it->second.cbegin();
-    try {
-      policy.decode(bliter);
-    } catch (buffer::error& err) {
-      ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): ERROR: could not decode policy, caught buffer::error" << dendl;
-      return -EIO;
-    }
-    ACLOwner owner = policy.get_owner();
-    rgw_user user = std::get<rgw_user>(owner.id);
-    ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << "(): INFO: user_d: " << user.to_str() << dendl;
-    ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << "(): INFO: display_name: " << owner.display_name << dendl;
-    user_id = user.to_str();
-    display_name = owner.display_name;
+    bl_acl = acl_it->second;
   }
-
   if (is_latest_version) {
     std::string objName = this->get_name();
     // special handling for name starting with '_'
@@ -1398,6 +1392,7 @@ int D4NFilterObject::set_head_obj_dir_entry(const DoutPrefixProvider* dpp, optio
       .size = this->get_accounted_size(),
       .user_id = user_id,
       .display_name = display_name,
+      .acl = bl_acl.to_str()
       };
 
     block.cacheObj = object;
@@ -1585,7 +1580,7 @@ int D4NFilterObject::update_head_block_hostslist(const DoutPrefixProvider* dpp, 
     //if found, check if version matches with block's existing version
     if(this->version == block.version) {
       //only then update hostsList to contain local cache address
-      block.cacheObj.hostsList.insert(dpp->get_cct()->_conf->rgw_d4n_remote_cache_address);
+      block.cacheObj.hostsList.insert(dpp->get_cct()->_conf->rgw_d4n_local_rgw_address);
       if (!(this->get_bucket()->versioned())) {
         //for non-versioned bucket, update latest version block and null version block
         rgw::d4n::Pipeline p = rgw::d4n::Pipeline(redis_conn, redis_pool);
@@ -1633,10 +1628,10 @@ int D4NFilterObject::update_head_block_hostslist(const DoutPrefixProvider* dpp, 
     if (ret == 0) {
       //verify versions match for the versioned block
       if(this->version == versioned_block.version) {
-        versioned_block.cacheObj.hostsList.insert(dpp->get_cct()->_conf->rgw_d4n_remote_cache_address);
+        versioned_block.cacheObj.hostsList.insert(dpp->get_cct()->_conf->rgw_d4n_local_rgw_address);
         //verify versions match for the latest block
         if (latest_block_ret == 0 && block.version == version) {
-          block.cacheObj.hostsList.insert(dpp->get_cct()->_conf->rgw_d4n_remote_cache_address);
+          block.cacheObj.hostsList.insert(dpp->get_cct()->_conf->rgw_d4n_local_rgw_address);
           rgw::d4n::Pipeline p = rgw::d4n::Pipeline(redis_conn, redis_pool);
           p.start();
           ret = blockDir->set(dpp, &versioned_block, y, &p);
@@ -1661,7 +1656,7 @@ int D4NFilterObject::update_head_block_hostslist(const DoutPrefixProvider* dpp, 
       } else {
         //case when only latest block version matches existing version
         if (latest_block_ret == 0 && block.version == version) {
-          block.cacheObj.hostsList.insert(dpp->get_cct()->_conf->rgw_d4n_remote_cache_address);
+          block.cacheObj.hostsList.insert(dpp->get_cct()->_conf->rgw_d4n_local_rgw_address);
           ret = blockDir->set(dpp, &block, y);
           if (ret < 0) {
             ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head block with ret: " << ret << dendl;
@@ -1832,7 +1827,49 @@ bool D4NFilterObject::check_head_exists_in_cache_get_oid(const DoutPrefixProvide
       this->driver->get_policy_driver()->get_cache_policy()->update(dpp, key, 0, 0, version, block.cacheObj.dirty, rgw::d4n::RefCount::DECR, y);
       this->exists_in_cache = true;
     } else {
-      found_in_cache = false;
+      bufferlist bl_val;
+      ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): acl: " << block.cacheObj.acl << dendl;
+      bl_val.append(block.cacheObj.acl);
+      attrs[RGW_ATTR_ACL] = std::move(bl_val);
+
+      ceph::encode(block.cacheObj.etag, bl_val);
+      attrs[RGW_ATTR_ETAG] = std::move(bl_val);
+
+      bl_val.append(std::to_string(block.cacheObj.size));
+      attrs[RGW_CACHE_ATTR_OBJECT_SIZE] = std::move(bl_val);
+
+      bl_val.append(block.cacheObj.creationTime);
+      attrs[RGW_CACHE_ATTR_MTIME] = std::move(bl_val);
+
+      bl_val.append(std::to_string(block.cacheObj.size));
+      attrs[RGW_CACHE_ATTR_ACCOUNTED_SIZE] = std::move(bl_val);
+
+      bl_val.append(block.cacheObj.bucketName);
+      attrs[RGW_CACHE_ATTR_BUCKET_NAME] = std::move(bl_val);
+
+      if (block.cacheObj.dirty) {
+        bl_val.append("1"); // only set xattr if dirty
+        attrs[RGW_CACHE_ATTR_DIRTY] = std::move(bl_val);
+      }
+      found_in_cache = true;
+      bufferlist bl;
+      std::string head_oid_in_cache = get_cache_block_prefix(this, version);
+      ret = this->driver->get_policy_driver()->get_cache_policy()->eviction(dpp, attrs.size(), y);
+      if (ret == 0) {
+        ret = this->driver->get_cache_driver()->put(dpp, head_oid_in_cache, bl, 0, attrs, y);
+        if (ret == 0) {
+          ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " version stored in update method is: " << this->get_object_version() << dendl;
+          this->driver->get_policy_driver()->get_cache_policy()->update(dpp, head_oid_in_cache, 0, bl.length(), version, false, rgw::d4n::RefCount::NOOP, y);
+          ret = this->update_head_block_hostslist(dpp, y);
+          if (ret < 0) {
+            ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): BlockDirectory update_head_block_hostslist method failed for head object, ret=" << ret << dendl;
+          }
+        } else {
+          ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): put for head object failed, ret=" << ret << dendl;
+        }
+      } else {
+        ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): failed to cache head object during eviction, ret=" << ret << dendl;
+      }
     }
   } else if (ret == -ENOENT) { //if blockDir->get
     found_in_cache = false;
@@ -2026,8 +2063,15 @@ std::unique_ptr<Writer> D4NFilterDriver::get_atomic_writer(const DoutPrefixProvi
 void D4NFilterDriver::shutdown()
 {
   if (d4n_thread_pool) {
-    d4n_coroutine_pool->stop();
-    d4n_thread_pool->stop();
+    if(d4n_coroutine_pool) {
+      d4n_coroutine_pool->stop();
+    }
+    if(d4n_coroutine_get_pool) {
+      d4n_coroutine_get_pool->stop();
+    }
+    if(d4n_thread_pool) {
+      d4n_thread_pool->stop();
+    }
   }
   // call cancel() on the connection's executor
   boost::asio::dispatch(conn->get_executor(), [c = conn] { c->cancel(); });
@@ -2198,11 +2242,11 @@ int D4NFilterObject::D4NFilterReadOp::drain(const DoutPrefixProvider* dpp, optio
   std::string version = source->get_object_version();
   std::string prefix = source->get_prefix();
   for (auto it : blocks_info) {
-    std::pair<uint64_t, uint64_t> ofs_len_pair = it.second;
-    uint64_t ofs = ofs_len_pair.first;
-    uint64_t len = ofs_len_pair.second;
-    std::string oid_in_cache = prefix + CACHE_DELIM + std::to_string(ofs) + CACHE_DELIM + std::to_string(len);
-    source->driver->get_policy_driver()->get_cache_policy()->update_refcount_if_key_exists(dpp, oid_in_cache, rgw::d4n::RefCount::DECR, y);
+    auto [id, ofs, len, read_ofs, read_len, is_remote] = it.second;
+    if(!is_remote) {
+      std::string oid_in_cache = get_key_in_cache(prefix, std::to_string(ofs), std::to_string(len));
+      source->driver->get_policy_driver()->get_cache_policy()->update_refcount_if_key_exists(dpp, oid_in_cache, rgw::d4n::RefCount::DECR, y);
+    }
   }
   if (r < 0) {
     cancel();
@@ -2218,74 +2262,115 @@ int D4NFilterObject::D4NFilterReadOp::flush(const DoutPrefixProvider* dpp, rgw::
     return r;
   }
 
-  std::list<bufferlist> bl_list;
-
-  auto cmp = [](const auto& lhs, const auto& rhs) { return lhs.id < rhs.id; };
-  results.sort(cmp); // merge() requires results to be sorted first
-  completed.merge(results, cmp); // merge results in sorted order
+  while (!results.empty()) {
+    rgw::AioResultEntry* entry_ptr = &results.front();
+    results.pop_front();
+    std::unique_ptr<rgw::AioResultEntry> entry(entry_ptr);
+    uint64_t id = entry->id;
+    completed_map.try_emplace(id, std::move(entry));
+  }
 
   ldpp_dout(dpp, 20) << "D4NFilterObject::In flush:: " << dendl;
 
-  while (!completed.empty() && completed.front().id == offset) {
-    auto bl = std::move(completed.front().data);
-
-    ldpp_dout(dpp, 20) << "D4NFilterObject::flush:: calling handle_data for offset: " << offset << " bufferlist length: " << bl.length() << dendl;
-
-    bl_list.push_back(bl);
+  while (true) {
+    bufferlist bl;
+    uint64_t cur_ofs;
+    auto map_it = completed_map.find(offset);
+    if (map_it == completed_map.end() || map_it->first != offset) {
+      break;
+    }
+    ldpp_dout(dpp, 20) << "D4NFilterObject::In flush:: map_it->first:" << map_it->first << dendl;
+    bl = std::move(map_it->second->data);
+    completed_map.erase(map_it);
+    cur_ofs = offset;
+    offset += bl.length();
+    std::optional<BlockMeta> block_meta;
+    auto it = blocks_info.find(cur_ofs);
+    if (it != blocks_info.end()) {
+      block_meta = it->second;
+      blocks_info.erase(it);
+    }
+    ldpp_dout(dpp, 20) << "D4NFilterObject::flush:: calling handle_data for offset: " << cur_ofs << " bufferlist length: " << bl.length() << dendl;
     if (client_cb) {
-      int r = client_cb->handle_data(bl, 0, bl.length());
-      if (r < 0) {
-        return r;
+      int r;
+      //We read an entire block from the remote and then send the data needed for a range request
+      //and then cache the entire block locally (instead of just the range)
+      if (block_meta && block_meta->is_remote) {
+        r = client_cb->handle_data(bl, block_meta->read_offset, block_meta->read_len);
+        if (r < 0) {
+          return r;
+        }
+      } else {
+        r = client_cb->handle_data(bl, 0, bl.length());
       }
     }
-    auto it = blocks_info.find(offset);
-    if (it != blocks_info.end()) {
+    if (block_meta) {
       std::string version = source->get_object_version();
       std::string prefix = source->get_prefix();
-      std::pair<uint64_t, uint64_t> ofs_len_pair = it->second;
-      uint64_t ofs = ofs_len_pair.first;
-      uint64_t len = ofs_len_pair.second;
-
+      uint64_t ofs = block_meta->offset;
+      uint64_t len = block_meta->len;
+      bool is_remote = block_meta->is_remote;
       std::string oid_in_cache = get_key_in_cache(prefix, std::to_string(ofs), std::to_string(len));
 
-      ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " calling update for offset: " << offset << " adjusted offset: " << ofs  << " length: " << len << " oid_in_cache: " << oid_in_cache << dendl;
-      ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " version stored in update method is: " << version << " " << source->get_object_version() << dendl;
-      source->driver->get_policy_driver()->get_cache_policy()->update(dpp, oid_in_cache, ofs, len, version, std::nullopt, rgw::d4n::RefCount::DECR, y);
-      blocks_info.erase(it);
-      if (source->dest_object && source->dest_bucket) {
-        D4NFilterObject* d4n_dest_object = dynamic_cast<D4NFilterObject*>(source->dest_object);
-        std::string dest_version = d4n_dest_object->get_object_version();
+      if(!is_remote) {
+        ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " calling update for offset: " << cur_ofs << " adjusted offset: " << ofs  << " length: " << len << " oid_in_cache: " << oid_in_cache << dendl;
+        ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " version stored in update method is: " << version << " " << source->get_object_version() << dendl;
+        source->driver->get_policy_driver()->get_cache_policy()->update(dpp, oid_in_cache, ofs, len, version, std::nullopt, rgw::d4n::RefCount::DECR, y);
+      }
+      if ((source->dest_object && source->dest_bucket) || is_remote) {
+        std::string dest_version;
         rgw::d4n::CacheBlock dest_block;
-        dest_block.cacheObj.objName = source->dest_object->get_oid();
-        dest_block.cacheObj.bucketName = source->dest_bucket->get_bucket_id();
         dest_block.blockID = ofs;
         dest_block.size = len;
-        dest_block.cacheObj.hostsList.insert(dpp->get_cct()->_conf->rgw_d4n_local_rgw_address);
         dest_block.version = dest_version;
-        dest_block.cacheObj.dirty = true; //writing to cache
-        std::string key =  get_key_in_cache(get_cache_block_prefix(source->dest_object, dest_version), std::to_string(ofs), std::to_string(len));
-        auto ret = source->driver->get_policy_driver()->get_cache_policy()->eviction(dpp, dest_block.size, y);
-        if (ret == 0) {
-          rgw::sal::Attrs attrs;
-          ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " destination object version in update method is: " << dest_version << dendl;
-          // destination key is the same as key
-          ret = source->driver->get_cache_driver()->put(dpp, key, bl, bl.length(), attrs, y);
+        std::string key;
+        bool write_to_local_cache{true};
+        if (is_remote) {
+          dest_version = source->get_object_version();
+          dest_block.cacheObj.objName = source->get_oid();
+          dest_block.cacheObj.bucketName = source->get_bucket()->get_bucket_id();
+          key = get_key_in_cache(get_cache_block_prefix(source, dest_version), std::to_string(ofs), std::to_string(len));
+          if (auto ret = source->driver->get_block_dir()->get(dpp, &dest_block, y); ret < 0) {
+            ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " BlockDirectory get failed with ret: " << ret << dendl;
+            //should we return from here?
+          }
+          //if a new version has been written, then do not cache old data locally
+          if (dest_version == dest_block.version) {
+            dest_block.cacheObj.hostsList.insert(dpp->get_cct()->_conf->rgw_d4n_local_rgw_address);
+          } else {
+            write_to_local_cache = false;
+          }
+        } else { // for copy object
+          D4NFilterObject* d4n_dest_object = dynamic_cast<D4NFilterObject*>(source->dest_object);
+          dest_version = d4n_dest_object->get_object_version();
+          dest_block.cacheObj.objName = source->dest_object->get_oid();
+          dest_block.cacheObj.bucketName = source->dest_bucket->get_bucket_id();
+          dest_block.cacheObj.dirty = true;
+          key = get_key_in_cache(get_cache_block_prefix(source->dest_object, dest_version), std::to_string(ofs), std::to_string(len));
+          dest_block.cacheObj.hostsList.insert(dpp->get_cct()->_conf->rgw_d4n_local_rgw_address);
+        }
+
+        if (write_to_local_cache) {
+          auto ret = source->driver->get_policy_driver()->get_cache_policy()->eviction(dpp, dest_block.size, y);
           if (ret == 0) {
-            source->driver->get_policy_driver()->get_cache_policy()->update(dpp, key, ofs, bl.length(), dest_version, true, rgw::d4n::RefCount::NOOP, y);
+            rgw::sal::Attrs attrs;
+            ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " object version in update method is: " << dest_version << dendl;
+            // destination key is the same as key
+            ret = source->driver->get_cache_driver()->put(dpp, key, bl, bl.length(), attrs, y);
+            if (ret == 0) {
+              source->driver->get_policy_driver()->get_cache_policy()->update(dpp, key, ofs, bl.length(), dest_version, true, rgw::d4n::RefCount::NOOP, y);
+            }
+            if (ret = source->driver->get_block_dir()->set(dpp, &dest_block, y); ret < 0){
+              ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " BlockDirectory set failed with ret: " << ret << dendl;
+            }
+          } else {
+            ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " eviction returned ret: " << ret << dendl;
           }
-          if (ret = source->driver->get_block_dir()->set(dpp, &dest_block, y); ret < 0){
-            ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " BlockDirectory set failed with ret: " << ret << dendl;
-          }
-        } else {
-          ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " eviction returned ret: " << ret << dendl;
         }
       }
     } else {
-      ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << " offset not found: " << offset << dendl;
+      ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << " offset not found: " << cur_ofs << dendl;
     }
-  
-    offset += bl.length();
-    completed.pop_front_and_dispose(std::default_delete<rgw::AioResultEntry>{});
     if(perfcounter) {
       perfcounter->inc(l_rgw_d4n_cache_hits);
     }
@@ -2293,6 +2378,39 @@ int D4NFilterObject::D4NFilterReadOp::flush(const DoutPrefixProvider* dpp, rgw::
 
   ldpp_dout(dpp, 20) << "D4NFilterObject::returning from flush:: " << dendl;
   return 0;
+}
+
+int D4NFilterObject::D4NFilterReadOp::process_remote_results(const DoutPrefixProvider* dpp, std::shared_ptr<TaskGroup> group, optional_yield y)
+{
+  if (remote_task_results.empty()) {
+    return 0;
+  }
+
+  try {
+    group->wait(dpp, y.get_yield_context());
+    for (auto& task_result : remote_task_results) {
+      while (!task_result->result_list.empty()) {
+        auto& entry = task_result->result_list.front();
+        auto id = entry.id;
+        task_result->result_list.pop_front();
+        completed_map.emplace(id, std::unique_ptr<rgw::AioResultEntry>(&entry));
+      }
+      for (auto& meta : task_result->blocks) {
+        blocks_info.emplace(
+          meta.id,
+          BlockMeta(meta.id, meta.offset, meta.len, meta.read_offset, meta.read_len, meta.is_remote)
+        );
+      }
+    }
+    remote_task_results.clear();
+    return 0;
+  } catch (const std::exception& e) {
+    ldpp_dout(dpp, 0) << "D4NFilterObject::iterate:: " << __func__
+                      << "(): Error processing remote task results: "
+                      << e.what() << dendl;
+    remote_task_results.clear();
+    return -EIO;
+  }
 }
 
 int D4NFilterObject::D4NFilterReadOp::iterate(const DoutPrefixProvider* dpp, int64_t ofs, int64_t end,
@@ -2333,6 +2451,7 @@ int D4NFilterObject::D4NFilterReadOp::iterate(const DoutPrefixProvider* dpp, int
   ldpp_dout(dpp, 20) << "D4NFilterObject::iterate:: " << " adjusted_len: " << adjusted_len << dendl;
   ldpp_dout(dpp, 20) << "D4NFilterObject::iterate:: " << " len: " << len << dendl;
 
+  auto group = std::make_shared<TaskGroup>(y.get_yield_context().get_executor());
   if ((params.part_num && !source->is_multipart()) || !params.part_num) {
     aio = rgw::make_throttle(window_size, y);
 
@@ -2374,24 +2493,27 @@ int D4NFilterObject::D4NFilterReadOp::iterate(const DoutPrefixProvider* dpp, int
       auto policy = source->driver->get_policy_driver()->get_cache_policy();
       auto cache_driver = source->driver->get_cache_driver();
       auto block_dir = source->driver->get_block_dir();
-      if (policy->update_refcount_if_key_exists(dpp, oid_in_cache, rgw::d4n::RefCount::INCR, y) > 0) {
+      if (policy->update_refcount_if_key_exists(dpp, oid_in_cache, rgw::d4n::RefCount::INCR, y)) {
         ldpp_dout(dpp, 20) << "D4NFilterObject::iterate:: " << __func__ << "(): " << __LINE__ << ": READ FROM CACHE: oid_in_cache=" << oid_in_cache << dendl;
         // Read From Cache
         auto completed = cache_driver->get_async(dpp, y, aio.get(), oid_in_cache, read_ofs, len_to_read, cost, id);
-        this->blocks_info.insert(std::make_pair(id, std::make_pair(adjusted_start_ofs, part_len)));
+        this->blocks_info.insert(std::make_pair(id, BlockMeta{id, adjusted_start_ofs, part_len, read_ofs, len_to_read, false}));
         ldpp_dout(dpp, 20) << "D4NFilterObject::iterate:: " << __func__ << "(): Info: flushing data for oid: " << oid_in_cache << dendl;
         auto r = flush(dpp, std::move(completed), y);
         if (r < 0) {
+          process_remote_results(dpp, group, y);
           drain(dpp, y);
           ldpp_dout(dpp, 0) << "D4NFilterObject::iterate:: " << __func__ << "(): Error: failed to flush, ret=" << r << dendl;
           return r;
         }
       } else { // else - if update_refcount_if_key_exists
         int r = -1;
+        ldpp_dout(dpp, 20) << "D4NFilterObject::iterate:: " << __func__ << "(): Info: Fetching from remote cache! " << dendl;
         if ((ret = block_dir->get(dpp, &block, y)) == 0) {
           if (block.version != version) {
             // TODO: If data has already been returned for any older versioned block, then return ‘retry’ error
             ldpp_dout(dpp, 20) << "D4NFilterObject::iterate:: " << __func__ << "(): Info: Version mismatch, draining data for oid: " << oid_in_cache << dendl;
+            process_remote_results(dpp, group, y);
             auto r = drain(dpp, y);
             if (r < 0) {
               ldpp_dout(dpp, 0) << "D4NFilterObject::iterate:: " << __func__ << "(): Error: failed to drain, ret=" << r << dendl;
@@ -2407,13 +2529,110 @@ int D4NFilterObject::D4NFilterReadOp::iterate(const DoutPrefixProvider* dpp, int
               hostsListSize = hostsListSize - 1;
             }
           }
+          ldpp_dout(dpp, 20) << "D4NFilterObject::iterate:: " << __func__ << "(): hostsListSize=" << hostsListSize << dendl;
           if (hostsListSize > 0) { /* Remote copy */
             ldpp_dout(dpp, 20) << "D4NFilterObject::iterate:: " << __func__ << "(): Block with oid=" << oid_in_cache << " found in remote cache." << dendl;
-            // TODO: Retrieve remotely
-            // Policy decision: should we cache remote blocks locally?
+            auto user = source->get_bucket()->get_owner();
+            std::string remote_addr = *(block.cacheObj.hostsList.begin());
+            if (!dpp->get_cct()->_conf->rgw_d4n_remote_async_get) {
+              ldpp_dout(dpp, 20) << "D4NFilterObject::iterate:: " << __func__ << "(): Info: remote_addr: " << remote_addr << dendl;
+              rgw::d4n::RemoteCacheGetOp::RemoteCacheGetOpData op {
+                  source->get_bucket()->get_name(),
+                  source->get_key().get_oid(),
+                  adjusted_start_ofs,
+                  part_len,
+                  version,
+                  block.cacheObj.dirty,
+                  std::get<rgw_user>(user),
+                  remote_addr
+                };
+              std::unique_ptr<rgw::d4n::RemoteCacheGetOp> remote_get = std::make_unique<rgw::d4n::RemoteCacheGetOp>(source->driver, op);
+              auto completed = remote_get->send_and_complete_request(dpp, aio.get(), cost, id, y);
+              this->blocks_info.insert(std::make_pair(id, BlockMeta{id, adjusted_start_ofs, part_len, read_ofs, len_to_read, true}));
+              ldpp_dout(dpp, 20) << "D4NFilterObject::iterate:: " << __func__ << "(): Info: flushing data for oid: " << oid_in_cache << dendl;
+              auto r = flush(dpp, std::move(completed), y);
+              if (r < 0) {
+                process_remote_results(dpp, group, y);
+                drain(dpp, y);
+                ldpp_dout(dpp, 0) << "D4NFilterObject::iterate:: " << __func__ << "(): Error: failed to flush, ret=" << r << dendl;
+                return r;
+              }
+            } else {
+              CephContext* cct = dpp->get_cct();
+              group->in_flight++;
+              auto task_result = std::make_shared<RemoteTaskResult>();
+              remote_task_results.push_back(task_result);
+              auto executor = y.get_yield_context().get_executor();
+              boost::asio::spawn(executor,
+                [cct,
+                task_result,
+                group,
+                bucket_name = source->get_bucket()->get_name(),
+                oid = source->get_key().get_oid(),
+                offset = adjusted_start_ofs,
+                len = part_len,
+                read_offset = read_ofs,
+                read_len = len_to_read,
+                cost,
+                id,
+                start_part_num,
+                num_parts,
+                remote_addr,
+                version,
+                usr = std::get<rgw_user>(user),
+                driver = source->driver,
+                aio_shared = aio,
+                dirty = block.cacheObj.dirty,
+                this]
+                (boost::asio::yield_context yield) mutable {
+                optional_yield y(yield);
+                std::string prefix = "async_read_from_remote_cache: ";
+                auto dpp_local = std::make_shared<D4NFilterDPP>(cct, prefix);
+                try {
+                  auto guard = make_scope_guard([group, dpp_local]() {
+                    int old_value = group->in_flight.fetch_sub(1, std::memory_order_release);
+                    ldpp_dout(dpp_local.get(), 0) << "DEBUG: Task complete, in_flight was=" << old_value 
+                                                    << ", now=" << (old_value - 1) << dendl;
+                    if (old_value == 1 && group->timer_set.load(std::memory_order_acquire)) {
+                      ldpp_dout(dpp_local.get(), 0) << "DEBUG: Last task, cancelling timer" << dendl;
+                      group->signal_timer.cancel();
+                    }
+                  });
+                  ldpp_dout(dpp_local.get(), 20) << "D4NFilterObject::iterate:: " << __func__ << "(): Info: remote_addr: " << remote_addr << dendl;
+                  rgw::d4n::RemoteCacheGetOp::RemoteCacheGetOpData op {
+                      bucket_name,
+                      oid,
+                      offset,
+                      len,
+                      version,
+                      dirty,
+                      usr,
+                      remote_addr
+                    };
+                  std::unique_ptr<rgw::d4n::RemoteCacheGetOp> remote_get = std::make_unique<rgw::d4n::RemoteCacheGetOp>(driver, op);
+                  task_result->result_list = remote_get->send_and_complete_request(dpp_local.get(), aio_shared.get(), cost, id, y);
+                  ldpp_dout(dpp_local.get(), 20) << "D4NFilterObject::iterate:: " << __func__ << "(): After send_and complete: " << dendl;
+                  task_result->blocks.push_back({ id, offset, len, read_offset, read_len, true });
+                  ldpp_dout(dpp_local.get(), 10)
+                      << "Successfully completed remote cache get for "
+                      << oid << dendl;
+                  return 0;
+                } catch (const std::exception& e) {
+                  ldpp_dout(dpp_local.get(), 0)
+                      << "Error in remote cache get: "
+                      << e.what() << dendl;
+                  return -EIO;
+                }
+              },
+              boost::asio::detached);
+            }
           } else {
             ldpp_dout(dpp, 20) << "D4NFilterObject::iterate:: " << __func__ << "(): Info: draining data for oid: " << oid_in_cache << dendl;
-            auto r = drain(dpp, y);
+            auto r = process_remote_results(dpp, group, y);
+            if (r < 0) {
+              return r;
+            }
+            r = drain(dpp, y);
             if (r < 0) {
               ldpp_dout(dpp, 0) << "D4NFilterObject::iterate:: " << __func__ << "(): Error: failed to drain, ret=" << r << dendl;
               return r;
@@ -2423,7 +2642,11 @@ int D4NFilterObject::D4NFilterReadOp::iterate(const DoutPrefixProvider* dpp, int
         } else { // else - if source->driver->get_block_dir()->get
           ldpp_dout(dpp, 5) << "Failed to fetch block for: " << block.cacheObj.objName << " blockID: " << block.blockID << " block size: " << block.size << ", ret=" << ret << dendl;
           ldpp_dout(dpp, 20) << "D4NFilterObject::iterate:: " << __func__ << "(): Info: draining data for oid: " << oid_in_cache << dendl;
-          auto r = drain(dpp, y);
+          auto r = process_remote_results(dpp, group, y);
+          if (r < 0) {
+            return r;
+          }
+          r = drain(dpp, y);
           if (r < 0) {
             ldpp_dout(dpp, 10) << "D4NFilterObject::iterate:: " << __func__ << "(): Error: failed to drain, ret=" << r << dendl;
             return r;
@@ -2433,6 +2656,10 @@ int D4NFilterObject::D4NFilterReadOp::iterate(const DoutPrefixProvider* dpp, int
       } //end - else
       if (start_part_num == (num_parts - 1)) {
         ldpp_dout(dpp, 20) << "D4NFilterObject::iterate:: " << __func__ << "(): Info: draining data for oid: " << oid_in_cache << dendl;
+        auto r = process_remote_results(dpp, group, y);
+        if (r < 0) {
+          return r;
+        }
         return drain(dpp, y);
       } else {
         adjusted_start_ofs += max_chunk_size;
@@ -2784,9 +3011,8 @@ int D4NFilterObject::D4NFilterDeleteOp::delete_obj(const DoutPrefixProvider* dpp
               remote_addr,
 			  source->get_size()
           };
-          bufferlist bl;
           std::unique_ptr<rgw::d4n::RemoteCacheDeleteOp> remote_delete = std::make_unique<rgw::d4n::RemoteCacheDeleteOp>(source->driver, op);
-          auto ret = remote_delete->send_and_complete_request(dpp, bl, y);
+          auto ret = remote_delete->send_and_complete_request(dpp, y);
           if (ret < 0) {
             ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): send_and_complete_request failed for remote cache: " << remote_addr <<  "ret= " << ret << dendl;
     	}
@@ -3237,7 +3463,7 @@ int D4NFilterWriter::process(bufferlist&& data, uint64_t offset)
               remote_addr
           };
           std::unique_ptr<rgw::d4n::RemoteCachePutOp> remote_put = std::make_unique<rgw::d4n::RemoteCachePutOp>(driver, op);
-          auto ret = remote_put->send_and_complete_request(dpp, bl, y);
+          auto ret = remote_put->send_and_complete_request(dpp, y, &bl);
           if (ret < 0) {
             ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): send_and_complete_request failed for remote cache: " << remote_addr <<  "ret= " << ret << dendl;
           }
@@ -3439,7 +3665,7 @@ int D4NFilterWriter::complete(size_t accounted_size, const std::string& etag,
               };
               bufferlist bl;
               std::unique_ptr<rgw::d4n::RemoteCachePutOp> remote_put = std::make_unique<rgw::d4n::RemoteCachePutOp>(driver, op);
-              ret = remote_put->send_and_complete_request(dpp, bl, y);
+              ret = remote_put->send_and_complete_request(dpp, y, &bl);
               if (ret < 0) {
                 ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): send_and_complete_request failed for remote cache: " << remote_addr <<  "ret= " << ret << dendl;
               }
@@ -3460,7 +3686,8 @@ int D4NFilterWriter::complete(size_t accounted_size, const std::string& etag,
                   driver = this->driver]
                   (boost::asio::yield_context yield) {
 
-                  auto dpp_local = std::make_shared<D4NFilterDPP>(cct);
+                  std::string dpp_prefix = "async_write_to_remote_cache: ";
+                  auto dpp_local = std::make_shared<D4NFilterDPP>(cct, dpp_prefix);
                   try {
                     D4NFilterWriter::write_to_remote_cache(
                         dpp_local.get(),
@@ -3544,7 +3771,7 @@ void D4NFilterWriter::write_to_remote_cache(const DoutPrefixProvider* dpp_o, con
           size
       };
       std::unique_ptr<rgw::d4n::RemoteCachePutOp> remote_put = std::make_unique<rgw::d4n::RemoteCachePutOp>(driver, op);
-      ret = remote_put->send_and_complete_request(dpp_o, bl, y);
+      ret = remote_put->send_and_complete_request(dpp_o, y, &bl);
       if (ret < 0) {
         ldpp_dout(dpp_o, 0) << "D4NFilterWriter::" << __func__ << "(): send_and_complete_request failed for remote cache: " << remote_addr <<  "ret= " << ret << dendl;
         return;
@@ -3566,7 +3793,7 @@ void D4NFilterWriter::write_to_remote_cache(const DoutPrefixProvider* dpp_o, con
   bufferlist bl;
 
   std::unique_ptr<rgw::d4n::RemoteCachePutOp> remote_put = std::make_unique<rgw::d4n::RemoteCachePutOp>(driver, op);
-  auto ret = remote_put->send_and_complete_request(dpp_o, bl, y);
+  auto ret = remote_put->send_and_complete_request(dpp_o, y, &bl);
   if (ret < 0) {
     ldpp_dout(dpp_o, 0) << "D4NFilterWriter::" << __func__ << "(): send_and_complete_request failed for remote cache: " << remote_addr <<  "ret= " << ret << dendl;
   }
@@ -3643,121 +3870,6 @@ int D4NFilterMultipartUpload::complete(const DoutPrefixProvider *dpp,
   } else {
     ldpp_dout(dpp, 0) << "D4NFilterMultipartUpload::" << __func__ << "(): failed to cache head object during eviction, ret=" << ret << dendl;
     return ret;
-  }
-
-  return 0;
-}
-
-int D4NFilterObject::D4NFilterReadOp::getRemote(const DoutPrefixProvider* dpp, long long start, long long end, std::string key, std::string remoteCacheAddress,
-  bufferlist *bl, optional_yield y)
-{
-  RGWAccessKey accessKey;
-  auto user = source->get_bucket()->get_owner();
-  if (std::holds_alternative<rgw_user>(user)) {
-    std::unique_ptr<rgw::sal::User> c_user = source->driver->get_user(std::get<rgw_user>(user));
-    int ret = c_user->load_user(dpp, y);
-    if (ret < 0) {
-      return -EPERM;
-    }
-    if (c_user->get_info().access_keys.empty()) {
-      return -EINVAL;
-    }
-    accessKey.id = c_user->get_info().access_keys.begin()->second.id;
-    accessKey.key = c_user->get_info().access_keys.begin()->second.key;
-
-    std::string bucketName = source->get_bucket()->get_name();
-
-    bufferlist out_bl;
-    HostStyle host_style = PathStyle;
-    std::map<std::string, std::string> extra_headers;
-    Attrs object_attrs;
-    D4NGetObjectCB cb(bl);
-
-    auto sender = new RGWRESTStreamRWRequest(dpp->get_cct(), "GET", remoteCacheAddress, &cb, NULL, NULL, "", host_style);
-    char buf[64];
-    snprintf(buf, sizeof(buf), "bytes=%lld-%lld", start, end);
-    extra_headers.insert(std::make_pair("RANGE", buf));
-
-    ret = sender->send_request(dpp, accessKey, extra_headers, source->get_obj(), nullptr);
-    if (ret < 0) {
-      delete sender;
-      return ret;
-    }
-
-    ret = sender->complete_request(dpp, y); //request is done
-    if (ret < 0){
-      delete sender;
-      return ret;
-    }
-    std::tuple<off_t, bool, bufferlist> len_remote_data_tuple = std::make_tuple(end, true, *bl);
-    this->read_data.insert(std::make_pair(start, len_remote_data_tuple));
-
-    if (static_cast<uint64_t>(start) == last_adjusted_ofs)
-      this->last_part_done = true;
-  }
-  return 0;
-}
-
-int D4NFilterObject::D4NFilterReadOp::remoteFlush(const DoutPrefixProvider* dpp, bufferlist bl, uint64_t ofs, uint64_t len, uint64_t read_ofs, std::string creationTime, optional_yield y)
-{
-  if (this->first_block == true){
-    int r = client_cb->handle_data(bl, read_ofs, bl.length()-read_ofs);
-    set_first_block(false);
-    offset += bl.length();
-    if (r < 0) {
-      return r;
-    }
-  }
-  else{
-    int r = client_cb->handle_data(bl, 0, bl.length());
-    offset += bl.length();
-    if (r < 0) {
-      return r;
-    }
-  }
-
-  if (ofs == last_adjusted_ofs)
-    this->last_part_done = true;
-
-  std::string version = source->get_object_version();
-  std::string prefix = source->get_prefix();
-  Attrs attrs = source->get_object_attrs();
-  bool dirty = false; //TODO: we should pass dirty flag correctly.
-
-  std::string oid_in_cache = prefix + "_" + std::to_string(ofs) + "_" + std::to_string(len); // we read from adjusted_ofs = offset
-  ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " calling update for offset: " << ofs  << " length: " << len << " oid_in_cache: " << oid_in_cache << dendl;
-
-  rgw::d4n::BlockDirectory* blockDir = source->driver->get_block_dir();
-  rgw::d4n::CacheBlock block;
-  block.cacheObj.objName = source->get_key().get_oid();
-  block.cacheObj.bucketName = source->get_bucket()->get_name();
-  block.blockID = ofs;
-  block.size = len;
-
-  auto ret = source->driver->get_policy_driver()->get_cache_policy()->eviction(dpp, block.size, y);
-  if (ret == 0) {
-    ret = source->driver->get_cache_driver()->put(dpp, oid_in_cache, bl, bl.length(), attrs, y);
-    std::this_thread::sleep_for(std::chrono::milliseconds(700));
-    if (ret == 0) {
-      std::string objEtag = "";
-      source->driver->get_policy_driver()->get_cache_policy()->update(dpp, oid_in_cache, ofs, len, version, false, rgw::d4n::RefCount::NOOP, y);
-      if (blockDir->update_field(dpp, &block, "blockHosts", dpp->get_cct()->_conf->rgw_d4n_remote_cache_address, y) < 0)
-        ldpp_dout(dpp, 10) << "D4NFilterObject::D4NFilterReadOp::D4NFilterGetCB::" << __func__ << "(): BlockDirectory update_field method failed for hostsList." << dendl;
-      if (ofs + len >= source->get_size()){ //last block
-        ldpp_dout(dpp, 20) << __func__ << "(): " <<  __LINE__ << " THIS IS the last block for object " << block.cacheObj.objName << dendl;
-        source->driver->get_policy_driver()->get_cache_policy()->update_dirty_object(dpp, prefix, version, dirty, source->get_size(), std::stol(creationTime), std::get<rgw_user>(source->get_bucket()->get_owner()), objEtag, source->get_bucket()->get_name(), source->get_bucket()->get_bucket_id(), source->get_key(), rgw::d4n::RefCount::NOOP, y);
-        rgw::d4n::ObjectDirectory* objectDir = source->driver->get_obj_dir();
-        rgw::d4n::CacheObj object;
-        object.objName = source->get_key().get_oid();
-        object.bucketName = source->get_bucket()->get_name();
-
-        if (objectDir->update_field(dpp, &object, "objHosts", dpp->get_cct()->_conf->rgw_d4n_remote_cache_address, y) < 0)
-          ldpp_dout(dpp, 10) << "D4NFilterObject::D4NFilterReadOp::D4NFilterGetCB::" << __func__ << "(): objectDirectory update_field method failed for hostsList." << dendl;
-      }
-    }
-    else {
-      ldpp_dout(dpp, 0) << "D4NFilterObject::D4NFilterReadOp::D4NFilterGetCB::" << __func__ << "(): put() to cache backend failed with error: " << ret << dendl;
-    }
   }
 
   return 0;

--- a/src/rgw/driver/d4n/rgw_sal_d4n.cc
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.cc
@@ -2954,6 +2954,7 @@ int D4NFilterWriter::process(bufferlist&& data, uint64_t offset)
     bufferlist bl = data;
     off_t bl_len = bl.length();
     off_t ofs = offset;
+    bool cache_request = object->is_cache_request();
     bool dirty;
 
     std::string version = object->get_object_version();
@@ -2962,7 +2963,7 @@ int D4NFilterWriter::process(bufferlist&& data, uint64_t offset)
     int ret = 0;
 
     if (!d4n_writecache) {
-      if (object->is_cache_request()) {
+      if (cache_request) {
 		return -EINVAL;
       }
       ldpp_dout(dpp, 10) << "D4NFilterWriter::" << __func__ << "(): calling next process" << dendl;
@@ -2971,19 +2972,26 @@ int D4NFilterWriter::process(bufferlist&& data, uint64_t offset)
       rgw::sal::Attrs attrs;
       std::string oid = prefix + CACHE_DELIM + std::to_string(ofs);
       std::string oid_in_cache = oid + CACHE_DELIM + std::to_string(bl_len);
-      if (!object->is_cache_request()) {
+      if (!cache_request) {
 	dirty = true;
       }
       ret = driver->get_policy_driver()->get_cache_policy()->eviction(dpp, bl.length(), y);
-      if (ret == 0) {     
-        if (bl.length() > 0) {          
-          ldpp_dout(dpp, 10) << "D4NFilterWriter::" << __func__ << "(): oid_in_cache is: " << oid_in_cache << dendl;
-          ret = driver->get_cache_driver()->put(dpp, oid_in_cache, bl, bl.length(), attrs, y);
+      if (ret == 0) {
+        if (bl.length() > 0) {
+          rgw::d4n::CacheObj object;
+          rgw::d4n::CacheBlock block;
+          object.bucketName = obj->get_bucket()->get_name();
+          object.objName = obj->get_key().get_oid();
+          object.size = bl.length();
+          object.dirty = true;
+          bufferlist out_bl;
+          object.hostsList.insert(dpp->get_cct()->_conf->rgw_d4n_l1_datacache_address);
+          ret = sendRemote(dpp, &object, dpp->get_cct()->_conf->rgw_d4n_remote_cache_address, oid, &out_bl, y);
           if (ret == 0) {
-	    if (!object->is_cache_request()) {
+	    if (!cache_request) {
 	      dirty = true;
 	    }
-	    if (!object->is_cache_request()) {
+	    if (!cache_request) {
               ret = driver->get_cache_driver()->set_attr(dpp, oid_in_cache, RGW_CACHE_ATTR_DIRTY, "1", y);
 	      if (ret == 0) {
 		driver->get_policy_driver()->get_cache_policy()->update(dpp, oid_in_cache, ofs, bl.length(), version, dirty, rgw::d4n::RefCount::NOOP, y);
@@ -2991,10 +2999,7 @@ int D4NFilterWriter::process(bufferlist&& data, uint64_t offset)
             } else {
 	      driver->get_policy_driver()->get_cache_policy()->update(dpp, oid_in_cache, ofs, bl.length(), version, dirty, rgw::d4n::RefCount::NOOP, y);
             }
-          } else {
-            ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): ERROR: writing data to the cache failed, ret=" << ret << dendl;
-            return ret;
-          }
+          } //sendRemote ret = 0
         }
       }
     } 
@@ -3231,6 +3236,166 @@ int D4NFilterMultipartUpload::complete(const DoutPrefixProvider *dpp,
   } else {
     ldpp_dout(dpp, 0) << "D4NFilterMultipartUpload::" << __func__ << "(): failed to cache head object during eviction, ret=" << ret << dendl;
     return ret;
+  }
+
+  return 0;
+}
+
+int D4NFilterWriter::sendRemote(const DoutPrefixProvider* dpp, rgw::d4n::CacheObj *object, std::string remoteCacheAddress, std::string key, bufferlist*
+ out_bl, optional_yield y)
+{
+  bufferlist in_bl;
+  RGWRemoteD4NGetCB cb(&in_bl);
+  std::string bucketName = object->bucketName;
+
+  RGWAccessKey accessKey;
+  std::string findKey;
+
+  auto user = obj->get_bucket()->get_owner();
+  if (std::holds_alternative<rgw_user>(user)) {
+    std::unique_ptr<rgw::sal::User> c_user = driver->get_user(std::get<rgw_user>(user));
+    int ret = c_user->load_user(dpp, y);
+    if (ret < 0) {
+      return -EPERM;
+    }
+
+    if (c_user->get_info().access_keys.empty()) {
+      return -EINVAL;
+    }
+
+    accessKey.id = c_user->get_info().access_keys.begin()->second.id;
+    accessKey.key = c_user->get_info().access_keys.begin()->second.key;
+
+    HostStyle host_style = PathStyle;
+    std::map<std::string, std::string> extra_headers;
+
+    auto sender = new RGWRESTStreamRWRequest(dpp->get_cct(), "PUT", remoteCacheAddress, &cb, NULL, NULL, "", host_style);
+
+    ret = sender->send_request(dpp, accessKey, extra_headers, obj->get_obj(), nullptr);
+    if (ret < 0) {
+      delete sender;
+      return ret;
+    }
+
+    ret = sender->complete_request(dpp, y);
+    if (ret < 0) {
+      delete sender;
+      return ret;
+    }
+  }
+  return 0;
+}
+
+int D4NFilterObject::D4NFilterReadOp::getRemote(const DoutPrefixProvider* dpp, long long start, long long end, std::string key, std::string remoteCacheAddress,
+  bufferlist *bl, optional_yield y)
+{
+  RGWAccessKey accessKey;
+  auto user = source->get_bucket()->get_owner();
+  if (std::holds_alternative<rgw_user>(user)) {
+    std::unique_ptr<rgw::sal::User> c_user = source->driver->get_user(std::get<rgw_user>(user));
+    int ret = c_user->load_user(dpp, y);
+    if (ret < 0) {
+      return -EPERM;
+    }
+    if (c_user->get_info().access_keys.empty()) {
+      return -EINVAL;
+    }
+    accessKey.id = c_user->get_info().access_keys.begin()->second.id;
+    accessKey.key = c_user->get_info().access_keys.begin()->second.key;
+
+    std::string bucketName = source->get_bucket()->get_name();
+
+    bufferlist out_bl;
+    HostStyle host_style = PathStyle;
+    std::map<std::string, std::string> extra_headers;                                                            
+    Attrs object_attrs;
+    D4NGetObjectCB cb(bl);
+
+    auto sender = new RGWRESTStreamRWRequest(dpp->get_cct(), "GET", remoteCacheAddress, &cb, NULL, NULL, "", host_style);
+    char buf[64];
+    snprintf(buf, sizeof(buf), "bytes=%lld-%lld", start, end);
+    extra_headers.insert(std::make_pair("RANGE", buf));
+
+    ret = sender->send_request(dpp, accessKey, extra_headers, source->get_obj(), nullptr);
+    if (ret < 0) {
+      delete sender;
+      return ret;
+    }
+
+    ret = sender->complete_request(dpp, y); //request is done
+    if (ret < 0){
+      delete sender;
+      return ret;
+    }
+    std::tuple<off_t, bool, bufferlist> len_remote_data_tuple = std::make_tuple(end, true, *bl);
+    this->read_data.insert(std::make_pair(start, len_remote_data_tuple));
+
+    if (static_cast<uint64_t>(start) == last_adjusted_ofs)
+      this->last_part_done = true;
+  }
+  return 0;
+}
+
+int D4NFilterObject::D4NFilterReadOp::remoteFlush(const DoutPrefixProvider* dpp, bufferlist bl, uint64_t ofs, uint64_t len, uint64_t read_ofs, std::string creationTime, optional_yield y)
+{
+  if (this->first_block == true){
+    int r = client_cb->handle_data(bl, read_ofs, bl.length()-read_ofs);
+    set_first_block(false);
+    offset += bl.length();
+    if (r < 0) {
+      return r;
+    }
+  }
+  else{
+    int r = client_cb->handle_data(bl, 0, bl.length());
+    offset += bl.length();
+    if (r < 0) {
+      return r;
+    }
+  }
+
+  if (ofs == last_adjusted_ofs)
+    this->last_part_done = true;
+
+  std::string version = source->get_object_version();
+  std::string prefix = source->get_prefix();
+  Attrs attrs = source->get_object_attrs();
+  bool dirty = false; //this is remote, no cleaning
+
+  std::string oid_in_cache = prefix + "_" + std::to_string(ofs) + "_" + std::to_string(len); // we read from adjusted_ofs = offset
+  ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " calling update for offset: " << ofs  << " length: " << len << " oid_in_cache: " << oid_in_cache << dendl;
+
+  rgw::d4n::BlockDirectory* blockDir = source->driver->get_block_dir();
+  rgw::d4n::CacheBlock block;
+  block.cacheObj.objName = source->get_key().get_oid();
+  block.cacheObj.bucketName = source->get_bucket()->get_name();
+  block.blockID = ofs;
+  block.size = len;
+
+  auto ret = source->driver->get_policy_driver()->get_cache_policy()->eviction(dpp, block.size, y);
+  if (ret == 0) {
+    ret = source->driver->get_cache_driver()->put(dpp, oid_in_cache, bl, bl.length(), attrs, y);
+    std::this_thread::sleep_for(std::chrono::milliseconds(700));
+    if (ret == 0) {
+      std::string objEtag = "";
+      source->driver->get_policy_driver()->get_cache_policy()->update(dpp, oid_in_cache, ofs, len, version, false, rgw::d4n::RefCount::NOOP, y);
+      if (blockDir->update_field(dpp, &block, "blockHosts", dpp->get_cct()->_conf->rgw_d4n_l1_datacache_address, y) < 0)
+        ldpp_dout(dpp, 10) << "D4NFilterObject::D4NFilterReadOp::D4NFilterGetCB::" << __func__ << "(): BlockDirectory update_field method failed for hostsList." << dendl;
+      if (ofs + len >= source->get_size()){ //last block
+        ldpp_dout(dpp, 20) << __func__ << "(): " <<  __LINE__ << " THIS IS the last block for object " << block.cacheObj.objName << dendl;
+        source->driver->get_policy_driver()->get_cache_policy()->update_dirty_object(dpp, prefix, version, dirty, source->get_size(), std::stol(creationTime), std::get<rgw_user>(source->get_bucket()->get_owner()), objEtag, source->get_bucket()->get_name(), source->get_bucket()->get_bucket_id(), source->get_key(), rgw::d4n::RefCount::NOOP, y);
+        rgw::d4n::ObjectDirectory* objectDir = source->driver->get_obj_dir();
+        rgw::d4n::CacheObj object;
+        object.objName = source->get_key().get_oid();
+        object.bucketName = source->get_bucket()->get_name();
+
+        if (objectDir->update_field(dpp, &object, "objHosts", dpp->get_cct()->_conf->rgw_d4n_l1_datacache_address, y) < 0)
+          ldpp_dout(dpp, 10) << "D4NFilterObject::D4NFilterReadOp::D4NFilterGetCB::" << __func__ << "(): objectDirectory update_field method failed for hostsList." << dendl;
+      }
+    }
+    else {
+      ldpp_dout(dpp, 0) << "D4NFilterObject::D4NFilterReadOp::D4NFilterGetCB::" << __func__ << "(): put() to cache backend failed with error: " << ret << dendl;
+    }
   }
 
   return 0;

--- a/src/rgw/driver/d4n/rgw_sal_d4n.cc
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.cc
@@ -1721,7 +1721,7 @@ int D4NFilterObject::set_data_block_dir_entries(const DoutPrefixProvider* dpp, o
       return ret;
     }
 
-    //in case of a remote request, the blocks are not dirty, hence don't change the flag in the directory
+    //in case of a remote request, the flag in the directory should updated only by the local cache and/or the cleaning cache.
     bool update_dirty_flag = true;
     if (remote_cache_request) {
       update_dirty_flag = false;
@@ -2258,12 +2258,11 @@ int D4NFilterObject::D4NFilterReadOp::flush(const DoutPrefixProvider* dpp, rgw::
         rgw::d4n::CacheBlock dest_block;
         dest_block.cacheObj.objName = source->dest_object->get_oid();
         dest_block.cacheObj.bucketName = source->dest_bucket->get_bucket_id();
-        dest_block.cacheObj.dirty = true; //writing to cache
         dest_block.blockID = ofs;
         dest_block.size = len;
         dest_block.cacheObj.hostsList.insert(dpp->get_cct()->_conf->rgw_d4n_local_rgw_address);
         dest_block.version = dest_version;
-        dest_block.cacheObj.dirty = true;
+        dest_block.cacheObj.dirty = true; //writing to cache
         std::string key =  get_key_in_cache(get_cache_block_prefix(source->dest_object, dest_version), std::to_string(ofs), std::to_string(len));
         auto ret = source->driver->get_policy_driver()->get_cache_policy()->eviction(dpp, dest_block.size, y);
         if (ret == 0) {
@@ -2726,7 +2725,6 @@ int D4NFilterObject::D4NFilterReadOp::D4NFilterGetCB::handle_data(bufferlist& bl
 int D4NFilterObject::D4NFilterDeleteOp::delete_obj(const DoutPrefixProvider* dpp,
                                                    optional_yield y, uint32_t flags)
 {
-  // TODO: Send delete request to cache nodes with remote copies
 
   rgw::sal::Attrs attrs;
   std::string head_oid_in_cache;
@@ -2754,6 +2752,47 @@ int D4NFilterObject::D4NFilterDeleteOp::delete_obj(const DoutPrefixProvider* dpp
     auto bucketDir = source->driver->get_bucket_dir();
     std::string version = source->get_object_version();
     std::string objName = source->get_name();
+    bool remote_cache_request = source->is_remote_cache_request();
+
+	if (dpp->get_cct()->_conf->rgw_d4n_remote_delete_enabled) {
+	  if (remote_cache_request) {
+		objDirty = source->get_remote_dirty_flag();
+	    if (objDirty){
+	  	  ret = source->driver->get_policy_driver()->get_cache_policy()->invalidate_dirty_object(dpp, head_oid_in_cache);
+	  	  if (ret < 0)
+			return ret;
+		  objDirty = false;
+	    }
+	    //check if the cache has enough space, if yes, we will wait for cleaning.
+	    if (source->driver->get_cache_driver()->get_free_space(dpp, y) > dpp->get_cct()->_conf->rgw_d4n_l1_datacache_free_threshold)
+		  return 0;
+	  }
+      //send it to remote only if it is not a remote request from another rgw
+	  // TODO: for better efficiency, it is better to check if the data is copied to the remote before sending the request
+	  else{
+          auto user = source->get_bucket()->get_owner();
+          std::string remote_addr = dpp->get_cct()->_conf->rgw_d4n_remote_cache_address;
+          ldpp_dout(dpp, 20) << "D4NFilterWriter::" << __func__ << "(): remoteaddr =" << remote_addr << dendl;
+          rgw::d4n::RemoteCacheDeleteOp::RemoteCacheDeleteOpData op {
+              source->get_bucket()->get_name(),
+              objName,
+			  0, 
+			  0,
+              version,
+			  objDirty,
+              std::get<rgw_user>(user),
+              remote_addr,
+			  source->get_size()
+          };
+          bufferlist bl;
+          std::unique_ptr<rgw::d4n::RemoteCacheDeleteOp> remote_delete = std::make_unique<rgw::d4n::RemoteCacheDeleteOp>(source->driver, op);
+          auto ret = remote_delete->send_and_complete_request(dpp, bl, y);
+          if (ret < 0) {
+            ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): send_and_complete_request failed for remote cache: " << remote_addr <<  "ret= " << ret << dendl;
+    	}
+      } //end - if else (remote_cache_request)
+	} //if (dpp->get_cct()->_conf->rgw_d4n_remote_delete_enabled)
+
     // special handling for name starting with '_'
     if (objName[0] == '_') {
       objName = "_" + source->get_name();
@@ -3033,6 +3072,20 @@ int D4NFilterObject::D4NFilterDeleteOp::delete_obj(const DoutPrefixProvider* dpp
             ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Failed to delete directory entry for: " << source->get_name() << " blockid: " << fst << " block size: " << cur_len << ", ret=" << ret << dendl;
             return ret;
           }
+	  	  /* check if we have enough space, if not, call eviction with deleted object size. We don't delete the requested object since 
+	  	  // it is possible for policy to choose a better candidate. The requested object to be deleted will be cleaned eventually. */
+	 	  if (source->driver->get_cache_driver()->get_free_space(dpp, y) <= dpp->get_cct()->_conf->rgw_d4n_l1_datacache_free_threshold){
+		    std::string key =  get_key_in_cache(get_cache_block_prefix(source, version), std::to_string(fst), std::to_string(cur_len));
+    		if ((ret = source->driver->get_cache_driver()->delete_data(dpp, key, y)) == 0) {
+	       	  if (!(ret = source->driver->get_policy_driver()->get_cache_policy()->erase(dpp, key, y))) {
+    	      	ldpp_dout(dpp, 0) << "Failed to delete policy entry for: " << key << ", ret=" << ret << dendl;
+        	  	return ret;
+	          }
+    		} else {
+      		  ldpp_dout(dpp, 0) << "Failed to delete cache entry for: " << key << ", ret=" << ret << dendl;
+        	  return ret;
+	  	    }
+		  }
 
 	    std::string req_oid_in_cache = get_key_in_cache(get_cache_block_prefix(source, version), std::to_string(block.blockID), std::to_string(block.size));
 		if (cache_request) {
@@ -3042,6 +3095,19 @@ int D4NFilterObject::D4NFilterDeleteOp::delete_obj(const DoutPrefixProvider* dpp
 		}
         fst += cur_len;
       } while (fst < lst);
+	  // we delete the head block at the end if needed
+	  if (source->driver->get_cache_driver()->get_free_space(dpp, y) <= dpp->get_cct()->_conf->rgw_d4n_l1_datacache_free_threshold){
+	    std::string key =  get_key_in_cache(get_cache_block_prefix(source, version), std::to_string(0), std::to_string(0));
+    	if ((ret = source->driver->get_cache_driver()->delete_data(dpp, key, y)) == 0) {
+	   	  if (!(ret = source->driver->get_policy_driver()->get_cache_policy()->erase(dpp, key, y))) {
+         	ldpp_dout(dpp, 0) << "Failed to delete policy entry for: " << key << ", ret=" << ret << dendl;
+       	  	return ret;
+	      }
+    	} else {
+    	  ldpp_dout(dpp, 0) << "Failed to delete cache entry for: " << key << ", ret=" << ret << dendl;
+          return ret;
+	    }
+	  }	
     }
 
     if (!objDirty) {
@@ -3160,16 +3226,17 @@ int D4NFilterWriter::process(bufferlist&& data, uint64_t offset)
           std::string remote_addr = dpp->get_cct()->_conf->rgw_d4n_remote_cache_address;
           ldpp_dout(dpp, 20) << "D4NFilterWriter::" << __func__ << "(): remoteaddr =" << remote_addr << dendl;
           uint64_t offset = ofs;
-          rgw::d4n::RemoteCachePut::RemoteCachePutOp op {
+          rgw::d4n::RemoteCachePutOp::RemoteCachePutOpData op {
               obj->get_bucket()->get_name(),
               obj->get_key().get_oid(),
               offset,
               bl.length(),
               version,
+			  dirty,
               std::get<rgw_user>(user),
               remote_addr
           };
-          std::unique_ptr<rgw::d4n::RemoteCachePut> remote_put = std::make_unique<rgw::d4n::RemoteCachePut>(driver, op);
+          std::unique_ptr<rgw::d4n::RemoteCachePutOp> remote_put = std::make_unique<rgw::d4n::RemoteCachePutOp>(driver, op);
           auto ret = remote_put->send_and_complete_request(dpp, bl, y);
           if (ret < 0) {
             ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): send_and_complete_request failed for remote cache: " << remote_addr <<  "ret= " << ret << dendl;
@@ -3359,18 +3426,19 @@ int D4NFilterWriter::complete(size_t accounted_size, const std::string& etag,
             std::string remote_addr = dpp->get_cct()->_conf->rgw_d4n_remote_cache_address;
             if (!dpp->get_cct()->_conf->rgw_d4n_async_remote_put) {
               ldpp_dout(dpp, 20) << "D4NFilterWriter::" << __func__ << "(): remoteaddr =" << remote_addr << dendl;
-              rgw::d4n::RemoteCachePut::RemoteCachePutOp op {
+              rgw::d4n::RemoteCachePutOp::RemoteCachePutOpData op {
                   obj->get_bucket()->get_name(),
                   obj->get_key().get_oid(),
                   0,
                   0,
                   version,
+				  dirty,
                   std::get<rgw_user>(user),
                   remote_addr,
                   obj->get_size()
               };
               bufferlist bl;
-              std::unique_ptr<rgw::d4n::RemoteCachePut> remote_put = std::make_unique<rgw::d4n::RemoteCachePut>(driver, op);
+              std::unique_ptr<rgw::d4n::RemoteCachePutOp> remote_put = std::make_unique<rgw::d4n::RemoteCachePutOp>(driver, op);
               ret = remote_put->send_and_complete_request(dpp, bl, y);
               if (ret < 0) {
                 ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): send_and_complete_request failed for remote cache: " << remote_addr <<  "ret= " << ret << dendl;
@@ -3388,6 +3456,7 @@ int D4NFilterWriter::complete(size_t accounted_size, const std::string& etag,
                   bucket_name = obj->get_bucket()->get_name(),
                   oid = obj->get_key().get_oid(),
                   version,
+				  dirty,
                   driver = this->driver]
                   (boost::asio::yield_context yield) {
 
@@ -3402,6 +3471,7 @@ int D4NFilterWriter::complete(size_t accounted_size, const std::string& etag,
                         bucket_name,
                         oid,
                         version,
+						dirty,
                         driver,
                         yield
                     );
@@ -3432,7 +3502,7 @@ int D4NFilterWriter::complete(size_t accounted_size, const std::string& etag,
   return 0;
 }
 
-void D4NFilterWriter::write_to_remote_cache(const DoutPrefixProvider* dpp_o, const std::string& prefix, uint64_t size, const rgw_user& user, const std::string& remote_addr, const std::string& bucket_name, const std::string& oid, const std::string& version, D4NFilterDriver* driver, optional_yield y)
+void D4NFilterWriter::write_to_remote_cache(const DoutPrefixProvider* dpp_o, const std::string& prefix, uint64_t size, const rgw_user& user, const std::string& remote_addr, const std::string& bucket_name, const std::string& oid, const std::string& version, bool dirty, D4NFilterDriver* driver, optional_yield y)
 {
   //Read data blocks from cache, and send remote requests
   uint64_t lst = size;
@@ -3462,17 +3532,18 @@ void D4NFilterWriter::write_to_remote_cache(const DoutPrefixProvider* dpp_o, con
         return;
       }
 
-      rgw::d4n::RemoteCachePut::RemoteCachePutOp op {
+      rgw::d4n::RemoteCachePutOp::RemoteCachePutOpData op {
           bucket_name,
           oid,
           fst,
           cur_len,
           version,
+		  dirty,
           user,
           remote_addr,
           size
       };
-      std::unique_ptr<rgw::d4n::RemoteCachePut> remote_put = std::make_unique<rgw::d4n::RemoteCachePut>(driver, op);
+      std::unique_ptr<rgw::d4n::RemoteCachePutOp> remote_put = std::make_unique<rgw::d4n::RemoteCachePutOp>(driver, op);
       ret = remote_put->send_and_complete_request(dpp_o, bl, y);
       if (ret < 0) {
         ldpp_dout(dpp_o, 0) << "D4NFilterWriter::" << __func__ << "(): send_and_complete_request failed for remote cache: " << remote_addr <<  "ret= " << ret << dendl;
@@ -3481,19 +3552,20 @@ void D4NFilterWriter::write_to_remote_cache(const DoutPrefixProvider* dpp_o, con
       fst += cur_len;
     }
   } while(fst < lst);
-  rgw::d4n::RemoteCachePut::RemoteCachePutOp op {
+  rgw::d4n::RemoteCachePutOp::RemoteCachePutOpData op {
               bucket_name,
               oid,
               0,
               0,
               version,
+			  dirty,
               user,
               remote_addr,
               size
             };
   bufferlist bl;
 
-  std::unique_ptr<rgw::d4n::RemoteCachePut> remote_put = std::make_unique<rgw::d4n::RemoteCachePut>(driver, op);
+  std::unique_ptr<rgw::d4n::RemoteCachePutOp> remote_put = std::make_unique<rgw::d4n::RemoteCachePutOp>(driver, op);
   auto ret = remote_put->send_and_complete_request(dpp_o, bl, y);
   if (ret < 0) {
     ldpp_dout(dpp_o, 0) << "D4NFilterWriter::" << __func__ << "(): send_and_complete_request failed for remote cache: " << remote_addr <<  "ret= " << ret << dendl;
@@ -3650,7 +3722,7 @@ int D4NFilterObject::D4NFilterReadOp::remoteFlush(const DoutPrefixProvider* dpp,
   std::string version = source->get_object_version();
   std::string prefix = source->get_prefix();
   Attrs attrs = source->get_object_attrs();
-  bool dirty = false; //this is remote, no cleaning
+  bool dirty = false; //TODO: we should pass dirty flag correctly.
 
   std::string oid_in_cache = prefix + "_" + std::to_string(ofs) + "_" + std::to_string(len); // we read from adjusted_ofs = offset
   ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " calling update for offset: " << ofs  << " length: " << len << " oid_in_cache: " << oid_in_cache << dendl;

--- a/src/rgw/driver/d4n/rgw_sal_d4n.cc
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.cc
@@ -47,7 +47,7 @@ D4NFilterDriver::D4NFilterDriver(Driver* _next, boost::asio::io_context& io_cont
   partition_info.name = "d4n";
   partition_info.type = "read-cache";
   partition_info.reserve_size = g_conf()->rgw_d4n_l1_datacache_disk_reserve;
-  cacheDriver = std::make_unique<rgw::cache::SSDDriver>(partition_info, admin);
+  cacheDriver = std::make_unique<rgw::cache::SSDDriver>(partition_info, io_context, admin);
 }
 
 D4NFilterDriver::~D4NFilterDriver() = default;
@@ -1257,6 +1257,44 @@ int D4NFilterObject::calculate_version(const DoutPrefixProvider* dpp, optional_y
   return 0;
 }
 
+int D4NFilterObject::write_if_space_available(const DoutPrefixProvider* dpp, const std::string& key, const bufferlist& bl, uint64_t len, const Attrs& attrs, 
+                                               uint64_t ofs, const std::string& version, const bool& dirty, const rgw_user user, const std::string& bucketName, 
+                                               uint8_t op, optional_yield y) {
+  // Fast path: enough space exists, reserve and return
+  auto cacheDriver = driver->get_cache_driver();
+  if (attrs.size()) {
+    len += rgw::cache::XATTR_OVERHEAD_ESTIMATE;
+  }
+
+  auto rollback_reservation = [&]() {
+	cacheDriver->release_reservation(dpp, len, y);
+  };
+
+  int ret = cacheDriver->check_and_reserve_space(dpp, len, y);
+  if (ret == -ENOSPC) {
+    // Not enough space — reserve upfront unconditionally and evict to free space
+	cacheDriver->reserve_space(dpp, len, y);  
+	ret = driver->get_policy_driver()->get_cache_policy()->eviction(dpp, len, y);
+    if (ret < 0) {
+	  ldpp_dout(dpp, 0) << __func__ << "(): ERROR: Eviction call failed, ret=" << ret << dendl;
+	  rollback_reservation();
+      return ret;
+    }
+  } else if (ret < 0) {
+    return ret;
+  }
+
+  ret = driver->get_cache_driver()->put(dpp, key, bl, len, attrs, y);
+  if (ret == 0) {
+	driver->get_policy_driver()->get_cache_policy()->update(dpp, key, ofs, len, version, dirty, user, bucketName, op, y);
+  } else {
+	ldpp_dout(dpp, 0) << __func__ << "(): ERROR: Cache driver put call failed, ret=" << ret << dendl;
+	rollback_reservation();
+	return ret;
+  }
+  return 0;
+}
+
 /* This method creates a delete marker for dirty objects:
 1. creates a head block entry in cache driver - so that data can be restored from this when rgw goes down
 2. calls set_head_block_dir_entry to set block entries for a delete marker */
@@ -1288,27 +1326,21 @@ int D4NFilterObject::create_delete_marker(const DoutPrefixProvider* dpp, optiona
 
   bufferlist bl;
   ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << "(): key is: " << key << dendl;
-  auto ret = driver->get_policy_driver()->get_cache_policy()->eviction(dpp, attrs.size(), y);
+  ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << "(): version stored in update method is: " << version << dendl;
+  auto ret = write_if_space_available(dpp, key, bl, bl.length(), attrs, 0, version, true, std::get<rgw_user>(this->get_bucket()->get_owner()),
+                                       this->get_bucket()->get_name(), rgw::d4n::RefCount::NOOP, y); // bl.length() is equal to 0
   if (ret == 0) {
-    ret = driver->get_cache_driver()->put(dpp, key, bl, 0, attrs, y);
-    if (ret == 0) {
-      ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << "(): version stored in update method is: " << version << dendl;
-      driver->get_policy_driver()->get_cache_policy()->update(dpp, key, 0, bl.length(), version, true, std::get<rgw_user>(this->get_bucket()->get_owner()), rgw::d4n::RefCount::NOOP, y);
-      ret = this->set_head_block_dir_entry(dpp, y, attrs, true, true);
-      if (ret < 0) {
-        ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object, ret=" << ret << dendl;
-        return ret;
-      }
-      auto creationTime = ceph::real_clock::to_double(this->get_mtime());
-      ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): key=" << key << dendl;
-      std::string objEtag = "";
-      driver->get_policy_driver()->get_cache_policy()->update_dirty_object(dpp, key, version, true, this->get_accounted_size(), creationTime, std::get<rgw_user>(this->get_bucket()->get_owner()), objEtag, this->get_bucket()->get_name(), this->get_bucket()->get_bucket_id(), this->get_key(), rgw::d4n::RefCount::NOOP, y);
-    } else { //if get_cache_driver()->put()
-      ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): put failed for key, ret=" << ret << " key: " << key << dendl;
-      return ret;
-    }
+	ret = this->set_head_block_dir_entry(dpp, y, attrs, true, true);
+	if (ret < 0) {
+	  ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object, ret=" << ret << dendl;
+	  return ret;
+	}
+	auto creationTime = ceph::real_clock::to_double(this->get_mtime());
+	ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): key=" << key << dendl;
+	std::string objEtag = "";
+	driver->get_policy_driver()->get_cache_policy()->update_dirty_object(dpp, key, version, true, this->get_accounted_size(), creationTime, std::get<rgw_user>(this->get_bucket()->get_owner()), objEtag, this->get_bucket()->get_name(), this->get_bucket()->get_bucket_id(), this->get_key(), rgw::d4n::RefCount::NOOP, y);
   } else {
-    ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): eviction failed for key, ret=" << ret << dendl;
+    ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Write failed for key, ret=" << ret << dendl;
     return ret;
   }
 
@@ -2185,7 +2217,7 @@ int D4NFilterObject::D4NFilterReadOp::flush(const DoutPrefixProvider* dpp, rgw::
       if(!is_remote) {
         ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " calling update for offset: " << cur_ofs << " adjusted offset: " << ofs  << " length: " << len << " oid_in_cache: " << oid_in_cache << dendl;
         ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " version stored in update method is: " << version << " " << source->get_object_version() << dendl;
-        source->driver->get_policy_driver()->get_cache_policy()->update(dpp, oid_in_cache, ofs, len, version, std::nullopt, std::get<rgw_user>(source->get_bucket()->get_owner()), rgw::d4n::RefCount::DECR, y);
+        source->driver->get_policy_driver()->get_cache_policy()->update(dpp, oid_in_cache, ofs, len, version, std::nullopt, std::get<rgw_user>(source->get_bucket()->get_owner()), source->get_bucket()->get_name(), rgw::d4n::RefCount::DECR, y);
       }
       if ((source->dest_object && source->dest_bucket) || is_remote) {
         std::string dest_version;
@@ -2233,19 +2265,16 @@ int D4NFilterObject::D4NFilterReadOp::flush(const DoutPrefixProvider* dpp, rgw::
         }
 
         if (write_to_local_cache) {
-          auto ret = source->driver->get_policy_driver()->get_cache_policy()->eviction(dpp, dest_block.size, y);
+		  ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " object version in update method is: " << dest_version << dendl;
+		  // destination key is the same as key
+		  auto ret = source->write_if_space_available(dpp, key, bl, bl.length(), attrs, ofs, dest_version, true, std::get<rgw_user>(source->get_bucket()->get_owner()), 
+											           source->get_bucket()->get_name(), rgw::d4n::RefCount::NOOP, y);
           if (ret == 0) {
-            ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " object version in update method is: " << dest_version << dendl;
-            // destination key is the same as key
-            ret = source->driver->get_cache_driver()->put(dpp, key, bl, bl.length(), attrs, y);
-            if (ret == 0) {
-              source->driver->get_policy_driver()->get_cache_policy()->update(dpp, key, ofs, bl.length(), dest_version, true, std::get<rgw_user>(source->get_bucket()->get_owner()), rgw::d4n::RefCount::NOOP, y);
-            }
             if (ret = source->driver->get_block_dir()->set(dpp, &dest_block, y); ret < 0){
               ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " BlockDirectory set failed with ret: " << ret << dendl;
             }
           } else {
-            ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " eviction returned ret: " << ret << dendl;
+			ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Write failed for key, ret=" << ret << dendl;
           }
         }
       }
@@ -2387,8 +2416,6 @@ int D4NFilterObject::D4NFilterReadOp::iterate(const DoutPrefixProvider* dpp, int
           ldpp_dout(dpp, 0) << "D4NFilterObject::iterate:: " << __func__ << "(): Error: failed to flush, ret=" << r << dendl;
           return r;
         }
-        //setting read_flag = 0
-		source->driver->get_policy_driver()->get_cache_policy()->set_read_flag(dpp, oid_in_cache, 0);
       } else { // else - if update_refcount_if_key_exists
         int r = -1;
         ldpp_dout(dpp, 20) << "D4NFilterObject::iterate:: " << __func__ << "(): Info: Fetching from remote cache! " << dendl;
@@ -2668,7 +2695,6 @@ int D4NFilterObject::D4NFilterReadOp::D4NFilterGetCB::handle_data(bufferlist& bl
     rgw::d4n::CacheBlock block, dest_block;
     rgw::d4n::BlockDirectory* blockDir = source->driver->get_block_dir();
     auto policy = filter->get_policy_driver()->get_cache_policy();
-    auto cache_driver = filter->get_cache_driver();
     block.cacheObj.objName = source->get_key().get_oid();
     block.cacheObj.bucketName = source->get_bucket()->get_bucket_id();
     std::stringstream s;
@@ -2695,16 +2721,11 @@ int D4NFilterObject::D4NFilterReadOp::D4NFilterGetCB::handle_data(bufferlist& bl
         block.blockID = adjusted_start_ofs;
         block.size = bl.length();
 
-        auto ret = policy->eviction(dpp, block.size, *y);
-        if (ret == 0) {
-          ret = cache_driver->put(dpp, oid, bl, bl.length(), attrs, *y);
-          if (ret == 0) {
-            std::string objEtag = "";
-            policy->update(dpp, oid, adjusted_start_ofs, bl.length(), version, dirty, std::get<rgw_user>(source->get_bucket()->get_owner()), rgw::d4n::RefCount::NOOP, *y);
-            blocks.emplace_back(block);
-          } else {
-            ldpp_dout(dpp, 10) << "D4NFilterObject::D4NFilterReadOp::D4NFilterGetCB::" << __func__ << "(): put() to cache backend failed, ret=" << ret << dendl;
-          }
+		auto ret = source->write_if_space_available(dpp, oid, bl, bl.length(), attrs, adjusted_start_ofs, version, dirty, std::get<rgw_user>(source->get_bucket()->get_owner()), 
+											           source->get_bucket()->get_name(), rgw::d4n::RefCount::NOOP, *y);
+		if (ret == 0) {
+		  std::string objEtag = "";
+		  blocks.emplace_back(block);
         } //end-if ret == 0
       } //end-if exist_key
       if (source->dest_object && source->dest_bucket) {
@@ -2713,13 +2734,10 @@ int D4NFilterObject::D4NFilterReadOp::D4NFilterGetCB::handle_data(bufferlist& bl
         std::string dest_oid = get_key_in_cache(dest_prefix, std::to_string(adjusted_start_ofs), std::to_string(bl_len));
         dest_block.blockID = adjusted_start_ofs;
         dest_block.size = bl.length();
-        auto ret = policy->eviction(dpp, dest_block.size, *y);
+		auto ret = source->write_if_space_available(dpp, dest_oid, bl, bl.length(), attrs, adjusted_start_ofs, dest_version, dirty, std::get<rgw_user>(source->get_bucket()->get_owner()), 
+													 source->get_bucket()->get_name(), rgw::d4n::RefCount::NOOP, *y);
         if (ret == 0) {
-          ret = cache_driver->put(dpp, dest_oid, bl, bl.length(), attrs, *y);
-          if (ret == 0) {
-            policy->update(dpp, dest_oid, adjusted_start_ofs, bl.length(), dest_version, dirty, std::get<rgw_user>(source->get_bucket()->get_owner()), rgw::d4n::RefCount::NOOP, *y);
-            dest_blocks.emplace_back(dest_block);
-          }
+		  dest_blocks.emplace_back(dest_block);
         }
       }
     } else if (bl.length() == rgw_max_chunk_size && bl_rem.length() == 0) { // if bl is the same size as rgw_max_chunk_size, write it to cache
@@ -2727,15 +2745,10 @@ int D4NFilterObject::D4NFilterReadOp::D4NFilterGetCB::handle_data(bufferlist& bl
       block.blockID = adjusted_start_ofs;
       block.size = bl.length();
       if (!policy->exist_key(oid)) {
-        auto ret = policy->eviction(dpp, block.size, *y);
+		auto ret = source->write_if_space_available(dpp, oid, bl, bl.length(), attrs, adjusted_start_ofs, version, dirty, std::get<rgw_user>(source->get_bucket()->get_owner()), 
+											           source->get_bucket()->get_name(), rgw::d4n::RefCount::NOOP, *y);
         if (ret == 0) {
-          ret = cache_driver->put(dpp, oid, bl, bl.length(), attrs, *y);
-          if (ret == 0) {
-            policy->update(dpp, oid, adjusted_start_ofs, bl.length(), version, dirty, std::get<rgw_user>(source->get_bucket()->get_owner()), rgw::d4n::RefCount::NOOP, *y);
-            blocks.emplace_back(block);
-          } else {
-            ldpp_dout(dpp, 10) << "D4NFilterObject::D4NFilterReadOp::D4NFilterGetCB::" << __func__ << "(): put() to cache backend failed, ret=" << ret << dendl;
-          }
+		  blocks.emplace_back(block);
         }
       }
       if (source->dest_object && source->dest_bucket) {
@@ -2744,13 +2757,10 @@ int D4NFilterObject::D4NFilterReadOp::D4NFilterGetCB::handle_data(bufferlist& bl
         std::string dest_oid = get_key_in_cache(dest_prefix, std::to_string(adjusted_start_ofs), std::to_string(bl_len));
         dest_block.blockID = adjusted_start_ofs;
         dest_block.size = bl.length();
-        auto ret = policy->eviction(dpp, dest_block.size, *y);
+		auto ret = source->write_if_space_available(dpp, dest_oid, bl, bl.length(), attrs, adjusted_start_ofs, dest_version, dirty, std::get<rgw_user>(source->get_bucket()->get_owner()), 
+											           source->get_bucket()->get_name(), rgw::d4n::RefCount::NOOP, *y);
         if (ret == 0) {
-          ret = cache_driver->put(dpp, dest_oid, bl, bl.length(), attrs, *y);
-          if (ret == 0) {
-            policy->update(dpp, dest_oid, adjusted_start_ofs, bl.length(), dest_version, dirty, std::get<rgw_user>(source->get_bucket()->get_owner()), rgw::d4n::RefCount::NOOP, *y);
-            dest_blocks.emplace_back(dest_block);
-          }
+		  dest_blocks.emplace_back(dest_block);
         }
       }
       adjusted_start_ofs += bl_len;
@@ -2768,17 +2778,12 @@ int D4NFilterObject::D4NFilterReadOp::D4NFilterGetCB::handle_data(bufferlist& bl
           block.blockID = adjusted_start_ofs;
           block.size = bl_rem.length();
           
-          auto ret = policy->eviction(dpp, block.size, *y);
+		  auto ret = source->write_if_space_available(dpp, oid, bl_rem, bl_rem.length(), attrs, adjusted_start_ofs, version, dirty, std::get<rgw_user>(source->get_bucket()->get_owner()), 
+											           source->get_bucket()->get_name(), rgw::d4n::RefCount::NOOP, *y);
           if (ret == 0) {
-            ret = cache_driver->put(dpp, oid, bl_rem, bl_rem.length(), attrs, *y);
-            if (ret == 0) {
-              policy->update(dpp, oid, adjusted_start_ofs, bl_rem.length(), version, dirty, std::get<rgw_user>(source->get_bucket()->get_owner()), rgw::d4n::RefCount::NOOP, *y);
               blocks.emplace_back(block);
-            } else {
-              ldpp_dout(dpp, 0) << "D4NFilterObject::D4NFilterReadOp::D4NFilterGetCB::" << __func__ << "(): put() to cache backend failed, ret=" << ret << dendl;
-            }
           } else {
-            ldpp_dout(dpp, 0) << "D4N Filter: " << __func__ << " An error occurred during eviction, ret=" << ret << dendl;
+            ldpp_dout(dpp, 0) << "D4N Filter: " << __func__ << " An error occurred during writing, ret=" << ret << dendl;
           }
         }
 
@@ -2788,13 +2793,10 @@ int D4NFilterObject::D4NFilterReadOp::D4NFilterGetCB::handle_data(bufferlist& bl
           std::string dest_oid = dest_prefix + CACHE_DELIM + std::to_string(adjusted_start_ofs) + CACHE_DELIM + std::to_string(bl_rem.length());
           dest_block.blockID = adjusted_start_ofs;
           dest_block.size = bl_rem.length();
-          auto ret = policy->eviction(dpp, dest_block.size, *y);
+		  auto ret = source->write_if_space_available(dpp, dest_oid, bl_rem, bl_rem.length(), attrs, adjusted_start_ofs, dest_version, dirty, std::get<rgw_user>(source->get_bucket()->get_owner()), 
+											           source->get_bucket()->get_name(), rgw::d4n::RefCount::NOOP, *y);
           if (ret == 0) {
-            ret = cache_driver->put(dpp, dest_oid, bl_rem, bl_rem.length(), attrs, *y);
-            if (ret == 0) {
-              policy->update(dpp, dest_oid, adjusted_start_ofs, bl_rem.length(), dest_version, dirty, std::get<rgw_user>(source->get_bucket()->get_owner()), rgw::d4n::RefCount::NOOP, *y);
               dest_blocks.emplace_back(dest_block);
-            }
           }
         }
         adjusted_start_ofs += bl_rem.length();
@@ -3295,26 +3297,22 @@ int D4NFilterWriter::process(bufferlist&& data, uint64_t offset)
     std::string oid_in_cache = oid + CACHE_DELIM + std::to_string(bl_len);
     if (bl.length() > 0) {
       ldpp_dout(dpp, 10) << "D4NFilterWriter::" << __func__ << "(): oid_in_cache is: " << oid_in_cache << dendl;
-      auto local_cache_ret = driver->get_policy_driver()->get_cache_policy()->eviction(dpp, bl.length(), y);
-      if (local_cache_ret == 0) {
-        if (dirty) {
-          bufferlist bl_val;
-          bl_val.append("1");
-          attrs[RGW_CACHE_ATTR_DIRTY] = std::move(bl_val);
-        }
-        if (object->have_instance()) {
-          bufferlist bl_val;
-          bl_val.append(object->get_instance());
-          attrs[RGW_CACHE_ATTR_VERSION_ID] = std::move(bl_val);
-        }
-        bufferlist bl_val;
-        bl_val.append(object->get_key().ns);
-        attrs[RGW_CACHE_ATTR_OBJECT_NS] = std::move(bl_val);
-        local_cache_ret = driver->get_cache_driver()->put(dpp, oid_in_cache, bl, bl.length(), attrs, y);
-        if (local_cache_ret == 0) {
-          driver->get_policy_driver()->get_cache_policy()->update(dpp, oid_in_cache, ofs, bl.length(), version, dirty, std::get<rgw_user>(object->get_bucket()->get_owner()), rgw::d4n::RefCount::NOOP, y);
-        }
-      }
+	  if (dirty) {
+		bufferlist bl_val;
+		bl_val.append("1");
+		attrs[RGW_CACHE_ATTR_DIRTY] = std::move(bl_val);
+	  }
+	  if (object->have_instance()) {
+		bufferlist bl_val;
+		bl_val.append(object->get_instance());
+		attrs[RGW_CACHE_ATTR_VERSION_ID] = std::move(bl_val);
+	  }
+	  bufferlist bl_val;
+	  bl_val.append(object->get_key().ns);
+	  attrs[RGW_CACHE_ATTR_OBJECT_NS] = std::move(bl_val);
+
+	  auto local_cache_ret = object->write_if_space_available(dpp, oid_in_cache, bl, bl.length(), attrs, ofs, version, dirty, std::get<rgw_user>(object->get_bucket()->get_owner()), 
+												   object->get_bucket()->get_name(), rgw::d4n::RefCount::NOOP, y);
       if (local_cache_ret < 0) {
         ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): adding block to local cache failed with ret= " << local_cache_ret << dendl;
       }
@@ -3370,6 +3368,20 @@ int D4NFilterWriter::complete(size_t accounted_size, const std::string& etag,
   bool remote_cache_request = object->is_remote_cache_request();
   int ret;
   
+  /* Return early if the put request was only for the data block. This occurs when a remote RGW evicts a block and
+   * a different, qualifying RGW is available to keep the block instead. This logic is part of the LFUDA algorithm. */ 
+  if (object->get_remote_block_only()) {
+    ldpp_dout(dpp, 20) << "D4NFilterWriter::" << __func__ << " Skipping head object write." << dendl;
+
+    //update data block entries in directory
+    ret = object->set_data_block_dir_entries(dpp, y, this->version, object->get_remote_dirty_flag());
+    if (ret < 0) {
+      return ret;
+    }
+
+    return 0;
+  }
+
   /* for cache coherence, we are going to cache the head even in case when read-only cache is enabled, just that
      the head will not be marked dirty and the entire object will written to backend store also. In case write-back
      cache is enabled, the head will be cached as dirty. */

--- a/src/rgw/driver/d4n/rgw_sal_d4n.cc
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.cc
@@ -514,6 +514,8 @@ int D4NFilterBucket::list(const DoutPrefixProvider* dpp, ListParams& params, int
         }
         entry.key.instance = entries[start_j].key.instance;
         entry.flags = entries[start_j].flags;
+        ldpp_dout(dpp, 20) << "D4NFilterBucket::" << __func__ << " block.cacheObj.objName: " << block.cacheObj.objName << dendl;
+        ldpp_dout(dpp, 20) << "D4NFilterBucket::" << __func__ << " block.deleteMarker: " << block.deleteMarker << dendl;
         if (block.deleteMarker) {
           entry.flags |= rgw_bucket_dir_entry::FLAG_DELETE_MARKER;
         }
@@ -988,33 +990,23 @@ int D4NFilterObject::copy_object(const ACLOwner& owner,
   bufferlist bl_data;
   dest_version = d4n_dest_object->get_object_version();
 
-  //same as key, as there is no len or offset attached to head oid in cache
   std::string key = get_cache_block_prefix(dest_object, dest_version);
-  auto ret = driver->get_policy_driver()->get_cache_policy()->eviction(dpp, baseAttrs.size(), y);
-  if (ret == 0) {
-    ret = driver->get_cache_driver()->put(dpp, key, bl_data, 0, baseAttrs, y);
-    baseAttrs.erase(RGW_CACHE_ATTR_MTIME);
-    baseAttrs.erase(RGW_CACHE_ATTR_OBJECT_SIZE);
-    baseAttrs.erase(RGW_CACHE_ATTR_ACCOUNTED_SIZE);
-    baseAttrs.erase(RGW_CACHE_ATTR_EPOCH);
-    baseAttrs.erase(RGW_CACHE_ATTR_MULTIPART);
-    baseAttrs.erase(RGW_CACHE_ATTR_OBJECT_NS);
-    baseAttrs.erase(RGW_CACHE_ATTR_BUCKET_NAME);
-    baseAttrs.erase(RGW_CACHE_ATTR_DIRTY);
-    if (ret == 0) {
-      ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " version stored in update method is: " << dest_version << dendl;
-      bufferlist bl;
-      driver->get_policy_driver()->get_cache_policy()->update(dpp, key, 0, bl.length(), dest_version, dirty, rgw::d4n::RefCount::NOOP, y);
-      d4n_dest_object->set_object_version(dest_version);
-      ret = d4n_dest_object->set_head_obj_dir_entry(dpp, y, true, dirty);
-      if (ret < 0) {
-        ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object with ret: " << ret << dendl;
-        return ret;
-      }
-      if (dirty) {
-        driver->get_policy_driver()->get_cache_policy()->update_dirty_object(dpp, key, dest_version, false, this->get_size(), creationTime, std::get<rgw_user>(dest_object->get_bucket()->get_owner()), *etag, dest_object->get_bucket()->get_name(), dest_object->get_bucket()->get_bucket_id(), dest_object->get_key(), rgw::d4n::RefCount::NOOP, y);
-      }
-    }
+  d4n_dest_object->set_object_version(dest_version);
+  auto ret = d4n_dest_object->set_head_block_dir_entry(dpp, y, baseAttrs, true, dirty);
+  baseAttrs.erase(RGW_CACHE_ATTR_MTIME);
+  baseAttrs.erase(RGW_CACHE_ATTR_OBJECT_SIZE);
+  baseAttrs.erase(RGW_CACHE_ATTR_ACCOUNTED_SIZE);
+  baseAttrs.erase(RGW_CACHE_ATTR_EPOCH);
+  baseAttrs.erase(RGW_CACHE_ATTR_MULTIPART);
+  baseAttrs.erase(RGW_CACHE_ATTR_OBJECT_NS);
+  baseAttrs.erase(RGW_CACHE_ATTR_BUCKET_NAME);
+  baseAttrs.erase(RGW_CACHE_ATTR_DIRTY);
+  if (ret < 0) {
+    ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object with ret: " << ret << dendl;
+    return ret;
+  }
+  if (dirty) {
+    driver->get_policy_driver()->get_cache_policy()->update_dirty_object(dpp, key, dest_version, false, this->get_size(), creationTime, std::get<rgw_user>(dest_object->get_bucket()->get_owner()), *etag, dest_object->get_bucket()->get_name(), dest_object->get_bucket()->get_bucket_id(), dest_object->get_key(), rgw::d4n::RefCount::NOOP, y);
   }
 
   return 0;
@@ -1057,9 +1049,7 @@ int D4NFilterObject::set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattr
   rgw::sal::Attrs attrs;
   std::string head_oid_in_cache;
   rgw::d4n::CacheBlock block;
-  bool found_in_cache = false;
   if (check_head_exists_in_cache_get_oid(dpp, head_oid_in_cache, attrs, block, y)) {
-    found_in_cache = true;
     if (setattrs != nullptr) {
       /* Ensure setattrs and delattrs do not overlap */
       if (delattrs != nullptr) {
@@ -1069,16 +1059,8 @@ int D4NFilterObject::set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattr
           }
         }
       }
-      //if set_obj_attrs() can be called to update existing attrs, then update_attrs() need to be called
-      if (this->driver->get_policy_driver()->get_cache_policy()->update_refcount_if_key_exists(dpp, head_oid_in_cache, rgw::d4n::RefCount::INCR, y)) {
-        auto ret = driver->get_cache_driver()->set_attrs(dpp, head_oid_in_cache, *setattrs, y);
-        this->driver->get_policy_driver()->get_cache_policy()->update_refcount_if_key_exists(dpp, head_oid_in_cache, rgw::d4n::RefCount::DECR, y);
-        if (ret < 0) {
-          ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): CacheDriver set_attrs method failed with ret: " << ret << dendl;
-          return ret;
-        }
-      } else {
-        found_in_cache = false;
+      for (const auto& attr : *setattrs) {
+        block.cacheObj.attrs[attr.first] = attr.second;
       }
     } //if setattrs != nullptr
 
@@ -1092,26 +1074,18 @@ int D4NFilterObject::set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattr
           delattrs->erase(std::find(delattrs->begin(), delattrs->end(), attr));
         }
       }
-      if (this->driver->get_policy_driver()->get_cache_policy()->update_refcount_if_key_exists(dpp, head_oid_in_cache, rgw::d4n::RefCount::INCR, y)) {
-        auto ret = driver->get_cache_driver()->delete_attrs(dpp, head_oid_in_cache, *delattrs, y);
-        this->driver->get_policy_driver()->get_cache_policy()->update_refcount_if_key_exists(dpp, head_oid_in_cache, rgw::d4n::RefCount::DECR, y);
-        if (ret < 0) {
-          ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): CacheDriver delete_attrs method failed with ret: " << ret << dendl;
-          return ret;
-        }
-      } else {
-        found_in_cache = false;
+      for (const auto& attr : *delattrs) {
+        block.cacheObj.attrs.erase(attr.first);
       }
     } //if delattrs != nullptr
-  } else {
-    if (block.deleteMarker) {
-      ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): object " << this->get_name() << " does not exist." << dendl;
-      return -ENOENT;
+    auto ret = driver->get_block_dir()->set(dpp, &block, y);
+    if (ret < 0) {
+      ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed with ret: " << ret << dendl;
+      return ret;
     }
-  }
-
-  if (!found_in_cache) {
-    if (cache_request) {
+  } else {
+    if (block.deleteMarker || cache_request) {
+      ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): object " << this->get_name() << " does not exist." << dendl;
       return -ENOENT;
     }
     auto ret = next->set_obj_attrs(dpp, setattrs, delattrs, y, flags);
@@ -1120,6 +1094,7 @@ int D4NFilterObject::set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattr
       return ret;
     }
   }
+
   return 0;
 }
 
@@ -1284,7 +1259,7 @@ int D4NFilterObject::calculate_version(const DoutPrefixProvider* dpp, optional_y
 
 /* This method creates a delete marker for dirty objects:
 1. creates a head block entry in cache driver - so that data can be restored from this when rgw goes down
-2. calls set_head_obj_dir_entry to set block entries for a delete marker */
+2. calls set_head_block_dir_entry to set block entries for a delete marker */
 int D4NFilterObject::create_delete_marker(const DoutPrefixProvider* dpp, optional_yield y)
 {
   this->delete_marker = true;
@@ -1319,7 +1294,7 @@ int D4NFilterObject::create_delete_marker(const DoutPrefixProvider* dpp, optiona
     if (ret == 0) {
       ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << "(): version stored in update method is: " << version << dendl;
       driver->get_policy_driver()->get_cache_policy()->update(dpp, key, 0, bl.length(), version, true, rgw::d4n::RefCount::NOOP, y);
-      ret = this->set_head_obj_dir_entry(dpp, y, true, true);
+      ret = this->set_head_block_dir_entry(dpp, y, attrs, true, true);
       if (ret < 0) {
         ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object, ret=" << ret << dendl;
         return ret;
@@ -1348,12 +1323,11 @@ for "null" versions, when bucket is non-versioned.
 4. A versioned hash entry for every version for a version enabled bucket - this helps in get/delete requests with version-id specified
 5. Redis ordered set to maintain the order of dirty objects added for a version enabled bucket. Even when the bucket is non-versioned, this set maintains a "null" entry
 6. Another ordered set to maintain a lexicographically sorted order of objects for a bucket - used for bucket listing */
-int D4NFilterObject::set_head_obj_dir_entry(const DoutPrefixProvider* dpp, optional_yield y, bool is_latest_version, bool dirty)
+int D4NFilterObject::set_head_block_dir_entry(const DoutPrefixProvider* dpp, optional_yield y, rgw::sal::Attrs& attrs, bool is_latest_version, bool dirty)
 {
   ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): object name: " << this->get_name() << " bucket name: " << this->get_bucket()->get_name() << dendl;
   rgw::d4n::CacheBlock block; 
   rgw::d4n::BlockDirectory* blockDir = this->driver->get_block_dir();
-  auto attrs = this->get_attrs();
   bufferlist bl_etag;
   auto etag_it = attrs.find(RGW_ATTR_ETAG);
   if (etag_it != attrs.end()) {
@@ -1392,7 +1366,8 @@ int D4NFilterObject::set_head_obj_dir_entry(const DoutPrefixProvider* dpp, optio
       .size = this->get_accounted_size(),
       .user_id = user_id,
       .display_name = display_name,
-      .acl = bl_acl.to_str()
+      .acl = bl_acl.to_str(),
+      .attrs = attrs
       };
 
     block.cacheObj = object;
@@ -1530,6 +1505,8 @@ int D4NFilterObject::set_head_obj_dir_entry(const DoutPrefixProvider* dpp, optio
     .size = this->get_accounted_size(),
     .user_id = user_id,
     .display_name = display_name,
+    .acl = bl_acl.to_str(),
+    .attrs = attrs
     };
 
     version_object.hostsList.insert({ dpp->get_cct()->_conf->rgw_d4n_local_rgw_address });
@@ -1590,7 +1567,6 @@ int D4NFilterObject::update_head_block_hostslist(const DoutPrefixProvider* dpp, 
           ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object with ret: " << ret << dendl;
           return ret;
         }
-        //bucket is non versioned, set a null instance
         block.cacheObj.objName = "_:null_" + this->get_name();
         ret = blockDir->set(dpp, &block, y, &p);
         if (ret < 0) {
@@ -1679,62 +1655,60 @@ int D4NFilterObject::set_data_block_dir_entries(const DoutPrefixProvider* dpp, o
 {
   rgw::d4n::BlockDirectory* blockDir = driver->get_block_dir();
 
-  if (!is_remote_head_block_request()) {
-    //update data block entries in directory
-    off_t lst;
-    off_t fst;
-    if (!is_remote_cache_request()) {
-      lst = this->get_size();
-      fst = 0;
-    } else {
-      lst = this->get_remote_block_len();
-      fst = this->get_remote_block_offset();
-    }
-    ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): Object/Block size =" << lst << dendl;
-    ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): offset =" << fst << dendl;
+  //update data block entries in directory
+  off_t lst;
+  off_t fst;
+  if (!is_remote_cache_request()) {
+    lst = this->get_size();
+    fst = 0;
+  } else {
+    lst = this->get_remote_block_len();
+    fst = this->get_remote_block_offset();
+  }
+  ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): Object/Block size =" << lst << dendl;
+  ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): offset =" << fst << dendl;
 
-    std::vector<rgw::d4n::CacheBlock> blocks;
-    do {
-      rgw::d4n::CacheBlock block;
-      if (fst >= lst){
-        break;
-      }
-      off_t cur_size = std::min<off_t>(fst + dpp->get_cct()->_conf->rgw_max_chunk_size, lst);
-      off_t cur_len = cur_size - fst;
-      block.cacheObj.bucketName = this->get_bucket()->get_bucket_id();
-      block.cacheObj.objName = this->get_key().get_oid();
-      block.size = cur_len;
-      block.blockID = fst;
+  std::vector<rgw::d4n::CacheBlock> blocks;
+  do {
+    rgw::d4n::CacheBlock block;
+    if (fst >= lst){
+      break;
+    }
+    off_t cur_size = std::min<off_t>(fst + dpp->get_cct()->_conf->rgw_max_chunk_size, lst);
+    off_t cur_len = cur_size - fst;
+    block.cacheObj.bucketName = this->get_bucket()->get_bucket_id();
+    block.cacheObj.objName = this->get_key().get_oid();
+    block.size = cur_len;
+    block.blockID = fst;
 
-      fst += cur_len;
-      blocks.emplace_back(block);
-    } while(fst < lst);
+    fst += cur_len;
+    blocks.emplace_back(block);
+  } while(fst < lst);
 
-    auto ret = blockDir->get(dpp, blocks, y);
-    if (ret < 0) {
-      ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): BlockDirectory pipelined get() method failed, ret=" << ret << dendl;
-      return ret;
-    }
+  auto ret = blockDir->get(dpp, blocks, y);
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): BlockDirectory pipelined get() method failed, ret=" << ret << dendl;
+    return ret;
+  }
 
-    //in case of a remote request, the flag in the directory should updated only by the local cache and/or the cleaning cache.
-    bool update_dirty_flag = true;
-    if (remote_cache_request) {
-      update_dirty_flag = false;
+  //in case of a remote request, the flag in the directory should updated only by the local cache and/or the cleaning cache.
+  bool update_dirty_flag = true;
+  if (remote_cache_request) {
+    update_dirty_flag = false;
+  }
+  for (auto& block : blocks) {
+    if (block.cacheObj.objName.empty()) {
+      continue;
     }
-    for (auto& block : blocks) {
-      if (block.cacheObj.objName.empty()) {
-        continue;
-      }
-      if (update_dirty_flag) {
-        block.cacheObj.dirty = dirty;
-      }
-      block.cacheObj.hostsList.insert(dpp->get_cct()->_conf->rgw_d4n_local_rgw_address);
-      block.version = version;
+    if (update_dirty_flag) {
+      block.cacheObj.dirty = dirty;
     }
-    if ((ret = blockDir->set(dpp, blocks, y)) < 0) {
-      ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): BlockDirectory pipelined set() method failed, ret=" << ret << dendl;
-      return ret;
-    }
+    block.cacheObj.hostsList.insert(dpp->get_cct()->_conf->rgw_d4n_local_rgw_address);
+    block.version = version;
+  }
+  if ((ret = blockDir->set(dpp, blocks, y)) < 0) {
+    ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): BlockDirectory pipelined set() method failed, ret=" << ret << dendl;
+    return ret;
   }
 
   return 0;
@@ -1809,68 +1783,10 @@ bool D4NFilterObject::check_head_exists_in_cache_get_oid(const DoutPrefixProvide
     version = block.version;
     this->set_object_version(version);
 
-    /* for distributed cache-the blockHostsList can be used to determine if the head block resides on the localhost, then get the block from localhost, whether or not the block is dirty
-       can be determined using the block entry. */
-
-    std::string key = get_cache_block_prefix(this, version);
-    if (this->driver->get_policy_driver()->get_cache_policy()->update_refcount_if_key_exists(dpp, key, rgw::d4n::RefCount::INCR, y)) {
-      ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): Is block dirty: " << block.cacheObj.dirty << dendl;
-      ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): version: " << block.version << dendl;
-      head_oid_in_cache = get_cache_block_prefix(this, version);
-      ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): Fetching attrs from cache for head obj id: " << head_oid_in_cache << dendl;
-      auto ret = this->driver->get_cache_driver()->get_attrs(dpp, head_oid_in_cache, attrs, y);
-      if (ret < 0) {
-        found_in_cache = false;
-        ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): CacheDriver get_attrs method failed." << dendl;
-      }
-      std::string key = head_oid_in_cache;
-      this->driver->get_policy_driver()->get_cache_policy()->update(dpp, key, 0, 0, version, block.cacheObj.dirty, rgw::d4n::RefCount::DECR, y);
-      this->exists_in_cache = true;
-    } else {
-      bufferlist bl_val;
-      ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): acl: " << block.cacheObj.acl << dendl;
-      bl_val.append(block.cacheObj.acl);
-      attrs[RGW_ATTR_ACL] = std::move(bl_val);
-
-      ceph::encode(block.cacheObj.etag, bl_val);
-      attrs[RGW_ATTR_ETAG] = std::move(bl_val);
-
-      bl_val.append(std::to_string(block.cacheObj.size));
-      attrs[RGW_CACHE_ATTR_OBJECT_SIZE] = std::move(bl_val);
-
-      bl_val.append(block.cacheObj.creationTime);
-      attrs[RGW_CACHE_ATTR_MTIME] = std::move(bl_val);
-
-      bl_val.append(std::to_string(block.cacheObj.size));
-      attrs[RGW_CACHE_ATTR_ACCOUNTED_SIZE] = std::move(bl_val);
-
-      bl_val.append(block.cacheObj.bucketName);
-      attrs[RGW_CACHE_ATTR_BUCKET_NAME] = std::move(bl_val);
-
-      if (block.cacheObj.dirty) {
-        bl_val.append("1"); // only set xattr if dirty
-        attrs[RGW_CACHE_ATTR_DIRTY] = std::move(bl_val);
-      }
-      found_in_cache = true;
-      bufferlist bl;
-      std::string head_oid_in_cache = get_cache_block_prefix(this, version);
-      ret = this->driver->get_policy_driver()->get_cache_policy()->eviction(dpp, attrs.size(), y);
-      if (ret == 0) {
-        ret = this->driver->get_cache_driver()->put(dpp, head_oid_in_cache, bl, 0, attrs, y);
-        if (ret == 0) {
-          ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " version stored in update method is: " << this->get_object_version() << dendl;
-          this->driver->get_policy_driver()->get_cache_policy()->update(dpp, head_oid_in_cache, 0, bl.length(), version, false, rgw::d4n::RefCount::NOOP, y);
-          ret = this->update_head_block_hostslist(dpp, y);
-          if (ret < 0) {
-            ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): BlockDirectory update_head_block_hostslist method failed for head object, ret=" << ret << dendl;
-          }
-        } else {
-          ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): put for head object failed, ret=" << ret << dendl;
-        }
-      } else {
-        ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): failed to cache head object during eviction, ret=" << ret << dendl;
-      }
-    }
+    head_oid_in_cache = get_cache_block_prefix(this, version); //check if still needed
+    attrs = block.cacheObj.attrs;
+    this->exists_in_cache = true;
+    found_in_cache = true;
   } else if (ret == -ENOENT) { //if blockDir->get
     found_in_cache = false;
   } else {
@@ -1925,29 +1841,9 @@ int D4NFilterObject::get_obj_attrs(optional_yield y, const DoutPrefixProvider* d
     if (version.empty()) {
       ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): version could not be calculated." << dendl;
     }
-    std::string objName = this->get_name();
-    head_oid_in_cache = get_cache_block_prefix(this, version);
-    if (this->driver->get_policy_driver()->get_cache_policy()->update_refcount_if_key_exists(dpp, head_oid_in_cache, rgw::d4n::RefCount::INCR, y)) {
-      ret = this->driver->get_cache_driver()->set_attrs(dpp, head_oid_in_cache, attrs, y);
-    } else {
-      ret = this->driver->get_policy_driver()->get_cache_policy()->eviction(dpp, attrs.size(), y);
-      if (ret == 0) {
-        bufferlist bl;
-        ret = this->driver->get_cache_driver()->put(dpp, head_oid_in_cache, bl, 0, attrs, y);
-      } else {
-        ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Failed to evict data, ret=" << ret << dendl;
-      }
-    }
-    if (ret == 0) {
-      ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " version stored in update method is: " << this->get_object_version() << dendl;
-      this->driver->get_policy_driver()->get_cache_policy()->update(dpp, head_oid_in_cache, 0, 0, version, false, rgw::d4n::RefCount::DECR, y);
-      ret = set_head_obj_dir_entry(dpp, y, is_latest_version);
-      if (ret < 0) {
-        ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object, ret=" << ret << dendl;
-      }
-    } else {
-      this->driver->get_policy_driver()->get_cache_policy()->update_refcount_if_key_exists(dpp, head_oid_in_cache, rgw::d4n::RefCount::DECR, y);
-      ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): failed to cache head object in cache backend, ret=" << ret << dendl;
+    ret = set_head_block_dir_entry(dpp, y, attrs, is_latest_version);
+    if (ret < 0) {
+      ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object, ret=" << ret << dendl;
     }
   } else {
     if(perfcounter) {
@@ -1967,8 +1863,9 @@ int D4NFilterObject::modify_obj_attrs(const char* attr_name, bufferlist& attr_va
   rgw::sal::Attrs attrs;
   rgw::d4n::CacheBlock block;
   if (check_head_exists_in_cache_get_oid(dpp, head_oid_in_cache, attrs, block, y)) {
-    if (auto ret = driver->get_cache_driver()->update_attrs(dpp, head_oid_in_cache, update, y); ret < 0) {
-      ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): CacheDriver update_attrs method failed with ret: " << ret << dendl;
+    block.cacheObj.attrs[attr_name] = attr_val;
+    if (auto ret = driver->get_block_dir()->set(dpp, &block, y); ret < 0) {
+      ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed with ret: " << ret << dendl;
       return ret;
     }
   } else {
@@ -1998,25 +1895,15 @@ int D4NFilterObject::delete_obj_attrs(const DoutPrefixProvider* dpp, const char*
   rgw::sal::Attrs attrs;
   Attrs delattr;
   rgw::d4n::CacheBlock block;
-  bool found_in_cache = false;
   if (check_head_exists_in_cache_get_oid(dpp, head_oid_in_cache, attrs, block, y)) {
-    found_in_cache = true;
-    delattr.insert({attr_name, bl});
-    Attrs currentattrs = this->get_attrs();
-    rgw::sal::Attrs::iterator attr = delattr.begin();
+    auto it = block.cacheObj.attrs.find(attr_name);
+    if (it != block.cacheObj.attrs.end()) {
+      block.cacheObj.attrs.erase(it);
 
-    /* Ensure delAttr exists */
-    if (std::find_if(currentattrs.begin(), currentattrs.end(),
-        [&](const auto& pair) { return pair.first == attr->first; }) != currentattrs.end()) {
-      if (this->driver->get_policy_driver()->get_cache_policy()->update_refcount_if_key_exists(dpp, head_oid_in_cache, rgw::d4n::RefCount::INCR, y)) {
-        auto ret = driver->get_cache_driver()->delete_attrs(dpp, head_oid_in_cache, delattr, y);
-        this->driver->get_policy_driver()->get_cache_policy()->update_refcount_if_key_exists(dpp, head_oid_in_cache, rgw::d4n::RefCount::DECR, y);
-        if ( ret < 0) {
-          ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): CacheDriver delete_attrs method failed with ret: " << ret << dendl;
-          return ret;
-        }
-      } else {
-        found_in_cache = false;
+      auto ret = driver->get_block_dir()->set(dpp, &block, y);
+      if (ret < 0) {
+        ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed with ret: " << ret << dendl;
+        return ret;
       }
     }
   } else {
@@ -2024,8 +1911,6 @@ int D4NFilterObject::delete_obj_attrs(const DoutPrefixProvider* dpp, const char*
       ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): object " << this->get_name() << " does not exist." << dendl;
       return -ENOENT;
     }
-  }
-  if (!found_in_cache) {
     if (cache_request) {
       return -ENOENT;
     }
@@ -2137,24 +2022,9 @@ int D4NFilterObject::D4NFilterReadOp::prepare(optional_yield y, const DoutPrefix
     }
 
     this->source->set_attr_crypt_parts(dpp, y, attrs);
-
-    bufferlist bl;
-    head_oid_in_cache = get_cache_block_prefix(source, version);
-    ret = source->driver->get_policy_driver()->get_cache_policy()->eviction(dpp, attrs.size(), y);
-    if (ret == 0) {
-      ret = source->driver->get_cache_driver()->put(dpp, head_oid_in_cache, bl, 0, attrs, y);
-      if (ret == 0) {
-        ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " version stored in update method is: " << this->source->get_object_version() << dendl;
-        source->driver->get_policy_driver()->get_cache_policy()->update(dpp, head_oid_in_cache, 0, bl.length(), version, false, rgw::d4n::RefCount::NOOP, y);
-        ret = source->set_head_obj_dir_entry(dpp, y, is_latest_version);
-        if (ret < 0) {
-          ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object, ret=" << ret << dendl;
-        }
-      } else {
-        ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): put for head object failed, ret=" << ret << dendl;
-      }
-    } else {
-      ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): failed to cache head object during eviction, ret=" << ret << dendl;
+    ret = source->set_head_block_dir_entry(dpp, y, attrs, is_latest_version);
+    if (ret < 0) {
+      ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): set_head_block_dir_entry method failed for head object, ret=" << ret << dendl;
     }
   } else {
     /* 
@@ -2325,6 +2195,7 @@ int D4NFilterObject::D4NFilterReadOp::flush(const DoutPrefixProvider* dpp, rgw::
         dest_block.version = dest_version;
         std::string key;
         bool write_to_local_cache{true};
+        rgw::sal::Attrs attrs;
         if (is_remote) {
           dest_version = source->get_object_version();
           dest_block.cacheObj.objName = source->get_oid();
@@ -2342,6 +2213,17 @@ int D4NFilterObject::D4NFilterReadOp::flush(const DoutPrefixProvider* dpp, rgw::
           }
         } else { // for copy object
           D4NFilterObject* d4n_dest_object = dynamic_cast<D4NFilterObject*>(source->dest_object);
+          bufferlist bl_val;
+          bl_val.append("1");
+          attrs[RGW_CACHE_ATTR_DIRTY] = std::move(bl_val);
+          bl_val.clear();
+          if (d4n_dest_object->have_instance()) {
+            bufferlist bl_val;
+            bl_val.append(d4n_dest_object->get_instance());
+            attrs[RGW_CACHE_ATTR_VERSION_ID] = std::move(bl_val);
+          }
+          bl_val.append(d4n_dest_object->get_key().ns);
+          attrs[RGW_CACHE_ATTR_OBJECT_NS] = std::move(bl_val);
           dest_version = d4n_dest_object->get_object_version();
           dest_block.cacheObj.objName = source->dest_object->get_oid();
           dest_block.cacheObj.bucketName = source->dest_bucket->get_bucket_id();
@@ -2353,7 +2235,6 @@ int D4NFilterObject::D4NFilterReadOp::flush(const DoutPrefixProvider* dpp, rgw::
         if (write_to_local_cache) {
           auto ret = source->driver->get_policy_driver()->get_cache_policy()->eviction(dpp, dest_block.size, y);
           if (ret == 0) {
-            rgw::sal::Attrs attrs;
             ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " object version in update method is: " << dest_version << dendl;
             // destination key is the same as key
             ret = source->driver->get_cache_driver()->put(dpp, key, bl, bl.length(), attrs, y);
@@ -2977,6 +2858,7 @@ int D4NFilterObject::D4NFilterDeleteOp::delete_obj(const DoutPrefixProvider* dpp
     auto blockDir = source->driver->get_block_dir();
     auto objDir = source->driver->get_obj_dir();
     auto bucketDir = source->driver->get_bucket_dir();
+    auto cacheDriver = source->driver->get_cache_driver();
     std::string version = source->get_object_version();
     std::string objName = source->get_name();
     bool remote_cache_request = source->is_remote_cache_request();
@@ -3051,7 +2933,7 @@ int D4NFilterObject::D4NFilterDeleteOp::delete_obj(const DoutPrefixProvider* dpp
             }
           }
           /* if versioning is suspended, we might have a latest head entry created from when bucket was non-versioned
-             don't return error as that could already be deleted by set_head_obj_dir_entry */
+             don't return error as that could already be deleted by set_head_block_dir_entry */
           if (!source->get_bucket()->versioning_enabled()) {
             block.cacheObj.objName = objName;
             if ((ret = blockDir->del(dpp, &block, y)) < 0) {
@@ -3259,7 +3141,7 @@ int D4NFilterObject::D4NFilterDeleteOp::delete_obj(const DoutPrefixProvider* dpp
     /* delete data blocks directory entries, when,
        1. object is clean, bucket is versioned and there is an instance in the request
        2. object is clean, bucket is non-versioned
-       3. object is dirty - delete blocks in cache also except for delete markers */
+       3. object is dirty - except for delete markers */
     if ((!objDirty && source->get_bucket()->versioned() && source->have_instance()) ||
         (!objDirty && !source->get_bucket()->versioned()) ||
         (objDirty && !block.deleteMarker)) {
@@ -3267,7 +3149,6 @@ int D4NFilterObject::D4NFilterDeleteOp::delete_obj(const DoutPrefixProvider* dpp
         off_t fst = 0;
 
       do { // loop through the data blocks
-        std::string prefix = get_cache_block_prefix(source, version);
         if (fst >= lst) {
           break;
         }
@@ -3298,42 +3179,23 @@ int D4NFilterObject::D4NFilterDeleteOp::delete_obj(const DoutPrefixProvider* dpp
             ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Failed to delete directory entry for: " << source->get_name() << " blockid: " << fst << " block size: " << cur_len << ", ret=" << ret << dendl;
             return ret;
           }
-	  	  /* check if we have enough space, if not, call eviction with deleted object size. We don't delete the requested object since 
-	  	  // it is possible for policy to choose a better candidate. The requested object to be deleted will be cleaned eventually. */
-	 	  if (source->driver->get_cache_driver()->get_free_space(dpp, y) <= dpp->get_cct()->_conf->rgw_d4n_l1_datacache_free_threshold){
-		    std::string key =  get_key_in_cache(get_cache_block_prefix(source, version), std::to_string(fst), std::to_string(cur_len));
-    		if ((ret = source->driver->get_cache_driver()->delete_data(dpp, key, y)) == 0) {
-	       	  if (!(ret = source->driver->get_policy_driver()->get_cache_policy()->erase(dpp, key, y))) {
-    	      	ldpp_dout(dpp, 0) << "Failed to delete policy entry for: " << key << ", ret=" << ret << dendl;
-        	  	return ret;
-	          }
-    		} else {
-      		  ldpp_dout(dpp, 0) << "Failed to delete cache entry for: " << key << ", ret=" << ret << dendl;
-        	  return ret;
-	  	    }
-		  }
 
 	    std::string req_oid_in_cache = get_key_in_cache(get_cache_block_prefix(source, version), std::to_string(block.blockID), std::to_string(block.size));
-		if (cache_request) {
+		if (cache_request || (source->driver->get_cache_driver()->get_free_space(dpp, y) <= dpp->get_cct()->_conf->rgw_d4n_l1_datacache_free_threshold)) {
 		  if ((ret = source->delete_cache_entry(dpp, req_oid_in_cache, y)) < 0) {
 			return ret;
 		  }
 		}
+          //set invalid flag for dirty data blocks
+          if (objDirty) {
+            std::string key = get_key_in_cache(get_cache_block_prefix(source, version), std::to_string(fst), std::to_string(cur_len));
+            int ret = cacheDriver->set_attr(dpp, key, RGW_CACHE_ATTR_INVALID, "1", y);
+            if (ret < 0) {
+              ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): Failed to set xattr, ret=" << ret << dendl;
+            }
+          }
         fst += cur_len;
       } while (fst < lst);
-	  // we delete the head block at the end if needed
-	  if (source->driver->get_cache_driver()->get_free_space(dpp, y) <= dpp->get_cct()->_conf->rgw_d4n_l1_datacache_free_threshold){
-	    std::string key =  get_key_in_cache(get_cache_block_prefix(source, version), std::to_string(0), std::to_string(0));
-    	if ((ret = source->driver->get_cache_driver()->delete_data(dpp, key, y)) == 0) {
-	   	  if (!(ret = source->driver->get_policy_driver()->get_cache_policy()->erase(dpp, key, y))) {
-         	ldpp_dout(dpp, 0) << "Failed to delete policy entry for: " << key << ", ret=" << ret << dendl;
-       	  	return ret;
-	      }
-    	} else {
-    	  ldpp_dout(dpp, 0) << "Failed to delete cache entry for: " << key << ", ret=" << ret << dendl;
-          return ret;
-	    }
-	  }	
     }
 
     if (!objDirty) {
@@ -3403,77 +3265,85 @@ int D4NFilterWriter::prepare(optional_yield y)
 
 int D4NFilterWriter::process(bufferlist&& data, uint64_t offset)
 {
-    bufferlist bl = data;
-    off_t bl_len = bl.length();
-    off_t ofs = offset;
-    bool dirty = true;
-    bool cache_request = object->is_cache_request();
-    bool remote_cache_request = object->is_remote_cache_request();
-    if (remote_cache_request || cache_request) {
-      dirty = false;
-    }
-    if (remote_cache_request) {
-      ofs = object->get_remote_block_offset();
-      ldpp_dout(dpp, 10) << "D4NFilterWriter::" << __func__ << "(): ofs is: " << ofs << dendl;
-    }
-    std::string version = object->get_object_version();
-    std::string prefix = get_cache_block_prefix(obj, version);
+  bufferlist bl = data;
+  off_t bl_len = bl.length();
+  off_t ofs = offset;
+  bool dirty = true;
+  bool cache_request = object->is_cache_request();
+  bool remote_cache_request = object->is_remote_cache_request();
+  if (remote_cache_request || cache_request) {
+    dirty = false;
+  }
+  if (remote_cache_request) {
+    ofs = object->get_remote_block_offset();
+    ldpp_dout(dpp, 10) << "D4NFilterWriter::" << __func__ << "(): ofs is: " << ofs << dendl;
+  }
+  std::string version = object->get_object_version();
+  std::string prefix = get_cache_block_prefix(obj, version);
 
-    if (!d4n_writecache) {
-      if (cache_request || remote_cache_request) {
-		return -EINVAL;
-      }
-      ldpp_dout(dpp, 10) << "D4NFilterWriter::" << __func__ << "(): calling next process" << dendl;
-      return next->process(std::move(data), offset);
-    } else {
-      rgw::sal::Attrs attrs;
-      std::string oid = prefix + CACHE_DELIM + std::to_string(ofs);
-      std::string oid_in_cache = oid + CACHE_DELIM + std::to_string(bl_len);
-      if (bl.length() > 0) {
-        ldpp_dout(dpp, 10) << "D4NFilterWriter::" << __func__ << "(): oid_in_cache is: " << oid_in_cache << dendl;
-        auto local_cache_ret = driver->get_policy_driver()->get_cache_policy()->eviction(dpp, bl.length(), y);
+  if (!d4n_writecache) {
+    if (cache_request || remote_cache_request) {
+  return -EINVAL;
+    }
+    ldpp_dout(dpp, 10) << "D4NFilterWriter::" << __func__ << "(): calling next process" << dendl;
+    return next->process(std::move(data), offset);
+  } else {
+    rgw::sal::Attrs attrs;
+    std::string oid = prefix + CACHE_DELIM + std::to_string(ofs);
+    std::string oid_in_cache = oid + CACHE_DELIM + std::to_string(bl_len);
+    if (bl.length() > 0) {
+      ldpp_dout(dpp, 10) << "D4NFilterWriter::" << __func__ << "(): oid_in_cache is: " << oid_in_cache << dendl;
+      auto local_cache_ret = driver->get_policy_driver()->get_cache_policy()->eviction(dpp, bl.length(), y);
+      if (local_cache_ret == 0) {
+        if (dirty) {
+          bufferlist bl_val;
+          bl_val.append("1");
+          attrs[RGW_CACHE_ATTR_DIRTY] = std::move(bl_val);
+        }
+        if (object->have_instance()) {
+          bufferlist bl_val;
+          bl_val.append(object->get_instance());
+          attrs[RGW_CACHE_ATTR_VERSION_ID] = std::move(bl_val);
+        }
+        bufferlist bl_val;
+        bl_val.append(object->get_key().ns);
+        attrs[RGW_CACHE_ATTR_OBJECT_NS] = std::move(bl_val);
+        local_cache_ret = driver->get_cache_driver()->put(dpp, oid_in_cache, bl, bl.length(), attrs, y);
         if (local_cache_ret == 0) {
-          if (dirty) {
-            bufferlist bl_val;
-            bl_val.append("1");
-            attrs[RGW_CACHE_ATTR_DIRTY] = std::move(bl_val);
-          }
-          local_cache_ret = driver->get_cache_driver()->put(dpp, oid_in_cache, bl, bl.length(), attrs, y);
-          if (local_cache_ret == 0) {
-            driver->get_policy_driver()->get_cache_policy()->update(dpp, oid_in_cache, ofs, bl.length(), version, dirty, rgw::d4n::RefCount::NOOP, y);
-          }
+          driver->get_policy_driver()->get_cache_policy()->update(dpp, oid_in_cache, ofs, bl.length(), version, dirty, rgw::d4n::RefCount::NOOP, y);
         }
-        if (local_cache_ret < 0) {
-          ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): adding block to local cache failed with ret= " << local_cache_ret << dendl;
+      }
+      if (local_cache_ret < 0) {
+        ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): adding block to local cache failed with ret= " << local_cache_ret << dendl;
+      }
+      //send it to remote only if it is not a remote request from another rgw
+      if (!remote_cache_request && dpp->get_cct()->_conf->rgw_d4n_remote_put && !dpp->get_cct()->_conf->rgw_d4n_async_remote_put) {
+        auto user = obj->get_bucket()->get_owner();
+        std::string remote_addr = dpp->get_cct()->_conf->rgw_d4n_remote_cache_address;
+        ldpp_dout(dpp, 20) << "D4NFilterWriter::" << __func__ << "(): remoteaddr =" << remote_addr << dendl;
+        uint64_t offset = ofs;
+        rgw::d4n::RemoteCachePutOp::RemoteCachePutOpData op {
+            obj->get_bucket()->get_name(),
+            obj->get_key().get_oid(),
+            offset,
+            bl.length(),
+            version,
+      dirty,
+            std::get<rgw_user>(user),
+            remote_addr
+        };
+        std::unique_ptr<rgw::d4n::RemoteCachePutOp> remote_put = std::make_unique<rgw::d4n::RemoteCachePutOp>(driver, op);
+        auto ret = remote_put->send_and_complete_request(dpp, y, &bl);
+        if (ret < 0) {
+          ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): send_and_complete_request failed for remote cache: " << remote_addr <<  "ret= " << ret << dendl;
         }
-        //send it to remote only if it is not a remote request from another rgw
-        if (!remote_cache_request && dpp->get_cct()->_conf->rgw_d4n_remote_put && !dpp->get_cct()->_conf->rgw_d4n_async_remote_put) {
-          auto user = obj->get_bucket()->get_owner();
-          std::string remote_addr = dpp->get_cct()->_conf->rgw_d4n_remote_cache_address;
-          ldpp_dout(dpp, 20) << "D4NFilterWriter::" << __func__ << "(): remoteaddr =" << remote_addr << dendl;
-          uint64_t offset = ofs;
-          rgw::d4n::RemoteCachePutOp::RemoteCachePutOpData op {
-              obj->get_bucket()->get_name(),
-              obj->get_key().get_oid(),
-              offset,
-              bl.length(),
-              version,
-			  dirty,
-              std::get<rgw_user>(user),
-              remote_addr
-          };
-          std::unique_ptr<rgw::d4n::RemoteCachePutOp> remote_put = std::make_unique<rgw::d4n::RemoteCachePutOp>(driver, op);
-          auto ret = remote_put->send_and_complete_request(dpp, y, &bl);
-          if (ret < 0) {
-            ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): send_and_complete_request failed for remote cache: " << remote_addr <<  "ret= " << ret << dendl;
-          }
-        } //end - if (!remote_cache_request)
-        if (local_cache_ret < 0) {
-          return local_cache_ret;
-        }
-      } //end - if (bl.lenght() > 0)
-    } 
-    return 0;
+      } //end - if (!remote_cache_request)
+      if (local_cache_ret < 0) {
+        return local_cache_ret;
+      }
+    } //end - if (bl.lenght() > 0)
+  } 
+  return 0;
 }
 
 int D4NFilterWriter::complete(size_t accounted_size, const std::string& etag,
@@ -3572,12 +3442,7 @@ int D4NFilterWriter::complete(size_t accounted_size, const std::string& etag,
       m_time = real_clock::now();
     }
     object->set_mtime(m_time);
-    if (object->is_remote_head_block_request()) {
-      object->set_accounted_size(object->get_remote_obj_size());
-      object->set_obj_size(object->get_remote_obj_size());
-    } else {
-      object->set_accounted_size(accounted_size);
-    }
+    object->set_accounted_size(accounted_size);
     ldpp_dout(dpp, 20) << "D4NFilterWriter::" << __func__ << " size is: " << object->get_size() << dendl;
     object->set_attr_crypt_parts(dpp, y, attrs);
     object->set_attrs(attrs);
@@ -3608,122 +3473,82 @@ int D4NFilterWriter::complete(size_t accounted_size, const std::string& etag,
     }
   }
 
-  if (object->is_remote_head_block_request() || !object->is_remote_cache_request()) {
-    std::string version = object->get_object_version();
-    std::string key = get_cache_block_prefix(obj, version);
+  std::string version = object->get_object_version();
+  std::string key = get_cache_block_prefix(obj, version);
 
-    bufferlist bl;
-    //same as key, as there is no len or offset attached to head oid in cache
-    ldpp_dout(dpp, 20) << "D4NFilterWriter::" << __func__ << "(): key is: " << key << dendl;
-    ret = driver->get_policy_driver()->get_cache_policy()->eviction(dpp, attrs.size(), y);
-    if (ret == 0) {
-      ret = driver->get_cache_driver()->put(dpp, key, bl, 0, attrs, y);
-      attrs.erase(RGW_CACHE_ATTR_MTIME);
-      attrs.erase(RGW_CACHE_ATTR_OBJECT_SIZE);
-      attrs.erase(RGW_CACHE_ATTR_ACCOUNTED_SIZE);
-      attrs.erase(RGW_CACHE_ATTR_EPOCH);
-      attrs.erase(RGW_CACHE_ATTR_MULTIPART);
-      attrs.erase(RGW_CACHE_ATTR_OBJECT_NS);
-      attrs.erase(RGW_CACHE_ATTR_BUCKET_NAME);
-      object->set_object_version(version);
-      if (ret == 0) {
-        ldpp_dout(dpp, 20) << "D4NFilterWriter::" << __func__ << "(): version stored in update method is: " << version << dendl;
-        driver->get_policy_driver()->get_cache_policy()->update(dpp, key, 0, bl.length(), version, dirty, rgw::d4n::RefCount::NOOP, y);
-        if (remote_cache_request) {
-          //update only hostslist since it is a remote cache request
-          ret = object->update_head_block_hostslist(dpp, y);
-        } else {
-          ret = object->set_head_obj_dir_entry(dpp, y, true, dirty);
-        }
-        if (ret < 0) {
-          ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): BlockDirectory set method failed for head object, ret=" << ret << dendl;
-          return ret;
-        }
-        if (dirty) {
-          auto creationTime = ceph::real_clock::to_double(object->get_mtime());
-          ldpp_dout(dpp, 20) << "D4NFilterWriter::" << __func__ << "(): key=" << key << dendl;
-          ldpp_dout(dpp, 20) << "D4NFilterWriter::" << __func__ << "(): obj->get_key()=" << obj->get_key() << dendl;
-          driver->get_policy_driver()->get_cache_policy()->update_dirty_object(dpp, key, version, false, accounted_size, creationTime, std::get<rgw_user>(obj->get_bucket()->get_owner()), objEtag, obj->get_bucket()->get_name(), obj->get_bucket()->get_bucket_id(), obj->get_key(), rgw::d4n::RefCount::NOOP, y);
-          if (!prev_oid_in_cache.empty()) {
-            driver->get_policy_driver()->get_cache_policy()->invalidate_dirty_object(dpp, prev_oid_in_cache);
-          }
-          if (dpp->get_cct()->_conf->rgw_d4n_remote_put && !object->is_remote_cache_request()) {
-            auto user = obj->get_bucket()->get_owner();
-            std::string remote_addr = dpp->get_cct()->_conf->rgw_d4n_remote_cache_address;
-            if (!dpp->get_cct()->_conf->rgw_d4n_async_remote_put) {
-              ldpp_dout(dpp, 20) << "D4NFilterWriter::" << __func__ << "(): remoteaddr =" << remote_addr << dendl;
-              rgw::d4n::RemoteCachePutOp::RemoteCachePutOpData op {
-                  obj->get_bucket()->get_name(),
-                  obj->get_key().get_oid(),
-                  0,
-                  0,
-                  version,
-				  dirty,
-                  std::get<rgw_user>(user),
-                  remote_addr,
-                  obj->get_size()
-              };
-              bufferlist bl;
-              std::unique_ptr<rgw::d4n::RemoteCachePutOp> remote_put = std::make_unique<rgw::d4n::RemoteCachePutOp>(driver, op);
-              ret = remote_put->send_and_complete_request(dpp, y, &bl);
-              if (ret < 0) {
-                ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): send_and_complete_request failed for remote cache: " << remote_addr <<  "ret= " << ret << dendl;
-              }
-            } else {
-              CephContext* cct = dpp->get_cct();
-              auto pool = driver->get_pool();
-              if (pool) {
-                pool->submit(
-                  [cct,
-                  prefix = key,
-                  size = obj->get_size(),
-                  usr = std::get<rgw_user>(user),
-                  remote_addr,
-                  bucket_name = obj->get_bucket()->get_name(),
-                  oid = obj->get_key().get_oid(),
-                  version,
-				  dirty,
-                  driver = this->driver]
-                  (boost::asio::yield_context yield) {
-
-                  std::string dpp_prefix = "async_write_to_remote_cache: ";
-                  auto dpp_local = std::make_shared<D4NFilterDPP>(cct, dpp_prefix);
-                  try {
-                    D4NFilterWriter::write_to_remote_cache(
-                        dpp_local.get(),
-                        prefix,
-                        size,
-                        usr,
-                        remote_addr,
-                        bucket_name,
-                        oid,
-                        version,
-						dirty,
-                        driver,
-                        yield
-                    );
-
-                    ldpp_dout(dpp_local.get(), 10)
-                        << "Successfully completed remote cache write for "
-                        << oid << dendl;
-
-                  } catch (const std::exception& e) {
-                      ldpp_dout(dpp_local.get(), 0)
-                          << "Error in remote cache write: "
-                          << e.what() << dendl;
-                  }
-                });
-              }
-            }
-          }
-        }
-      } else { //if get_cache_driver()->put()
-        ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): put failed for head_oid_in_cache, ret=" << ret << dendl;
-        return ret;
-      }
-    } else {
-      ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): eviction failed for head_oid_in_cache, ret=" << ret << dendl;
+  object->set_object_version(version);
+  //don't update directory head block entry for a remote request
+  if (!remote_cache_request) {
+    ret = object->set_head_block_dir_entry(dpp, y, attrs, true, dirty);
+    attrs.erase(RGW_CACHE_ATTR_MTIME);
+    attrs.erase(RGW_CACHE_ATTR_OBJECT_SIZE);
+    attrs.erase(RGW_CACHE_ATTR_ACCOUNTED_SIZE);
+    attrs.erase(RGW_CACHE_ATTR_EPOCH);
+    attrs.erase(RGW_CACHE_ATTR_MULTIPART);
+    attrs.erase(RGW_CACHE_ATTR_OBJECT_NS);
+    attrs.erase(RGW_CACHE_ATTR_BUCKET_NAME);
+    if (ret < 0) {
+      ldpp_dout(dpp, 0) << "D4NFilterWriter::" << __func__ << "(): set_head_block_dir_entry set method failed for head object, ret=" << ret << dendl;
       return ret;
+    }
+  }
+  if (dirty) {
+    auto creationTime = ceph::real_clock::to_double(object->get_mtime());
+    ldpp_dout(dpp, 20) << "D4NFilterWriter::" << __func__ << "(): key=" << key << dendl;
+    ldpp_dout(dpp, 20) << "D4NFilterWriter::" << __func__ << "(): obj->get_key()=" << obj->get_key() << dendl;
+    driver->get_policy_driver()->get_cache_policy()->update_dirty_object(dpp, key, version, false, accounted_size, creationTime, std::get<rgw_user>(obj->get_bucket()->get_owner()), objEtag, obj->get_bucket()->get_name(), obj->get_bucket()->get_bucket_id(), obj->get_key(), rgw::d4n::RefCount::NOOP, y);
+    if (!prev_oid_in_cache.empty()) {
+      driver->get_policy_driver()->get_cache_policy()->invalidate_dirty_object(dpp, prev_oid_in_cache);
+    }
+    if (dpp->get_cct()->_conf->rgw_d4n_remote_put && !remote_cache_request) {
+      auto user = obj->get_bucket()->get_owner();
+      std::string remote_addr = dpp->get_cct()->_conf->rgw_d4n_remote_cache_address;
+      if (dpp->get_cct()->_conf->rgw_d4n_async_remote_put) {
+        CephContext* cct = dpp->get_cct();
+        auto pool = driver->get_pool();
+        if (pool) {
+          pool->submit(
+            [cct,
+            prefix = key,
+            size = obj->get_size(),
+            usr = std::get<rgw_user>(user),
+            remote_addr,
+            bucket_name = obj->get_bucket()->get_name(),
+            oid = obj->get_key().get_oid(),
+            version,
+    dirty,
+            driver = this->driver]
+            (boost::asio::yield_context yield) {
+
+            std::string dpp_prefix = "async_write_to_remote_cache: ";
+            auto dpp_local = std::make_shared<D4NFilterDPP>(cct, dpp_prefix);
+            try {
+              D4NFilterWriter::write_to_remote_cache(
+                  dpp_local.get(),
+                  prefix,
+                  size,
+                  usr,
+                  remote_addr,
+                  bucket_name,
+                  oid,
+                  version,
+      dirty,
+                  driver,
+                  yield
+              );
+
+              ldpp_dout(dpp_local.get(), 10)
+                  << "Successfully completed remote cache write for "
+                  << oid << dendl;
+
+            } catch (const std::exception& e) {
+                ldpp_dout(dpp_local.get(), 0)
+                    << "Error in remote cache write: "
+                    << e.what() << dendl;
+            }
+          });
+        }
+      } //end-if rgw_d4n_async_remote_put
     }
   }
   return 0;
@@ -3779,25 +3604,6 @@ void D4NFilterWriter::write_to_remote_cache(const DoutPrefixProvider* dpp_o, con
       fst += cur_len;
     }
   } while(fst < lst);
-  rgw::d4n::RemoteCachePutOp::RemoteCachePutOpData op {
-              bucket_name,
-              oid,
-              0,
-              0,
-              version,
-			  dirty,
-              user,
-              remote_addr,
-              size
-            };
-  bufferlist bl;
-
-  std::unique_ptr<rgw::d4n::RemoteCachePutOp> remote_put = std::make_unique<rgw::d4n::RemoteCachePutOp>(driver, op);
-  auto ret = remote_put->send_and_complete_request(dpp_o, y, &bl);
-  if (ret < 0) {
-    ldpp_dout(dpp_o, 0) << "D4NFilterWriter::" << __func__ << "(): send_and_complete_request failed for remote cache: " << remote_addr <<  "ret= " << ret << dendl;
-  }
-
   if (driver->get_pool()) {
     auto stats = driver->get_pool()->get_stats();
     ldpp_dout(dpp_o, 20) << "D4NFilterWriter::" << __func__
@@ -3831,7 +3637,7 @@ int D4NFilterMultipartUpload::complete(const DoutPrefixProvider *dpp,
     return ret;
   }
 
-  //Cache only the head object for multipart objects
+  //Cache only the head block for multipart objects
   D4NFilterObject* d4n_target_obj = dynamic_cast<D4NFilterObject*>(target_obj);
   /* we want to always load latest object state from store
      to avoid reading stale state in case of object overwrites. */
@@ -3850,26 +3656,9 @@ int D4NFilterMultipartUpload::complete(const DoutPrefixProvider *dpp,
     ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): version could not be calculated." << dendl;
   }
 
-  bufferlist bl;
-  std::string head_oid_in_cache = get_cache_block_prefix(d4n_target_obj, version);
-  // we are evicting data if needed, since the head object will be a part of read cache, as the whole multipart object is written to the backend store
-  ret = driver->get_policy_driver()->get_cache_policy()->eviction(dpp, attrs.size(), y);
-  if (ret == 0) {
-    ret = driver->get_cache_driver()->put(dpp, head_oid_in_cache, bl, 0, attrs, y);
-    if (ret == 0) {
-      ldpp_dout(dpp, 20) << "D4NFilterMultipartUpload::" << __func__ << " version stored in update method is: " << d4n_target_obj->get_object_version() << dendl;
-      driver->get_policy_driver()->get_cache_policy()->update(dpp, head_oid_in_cache, 0, bl.length(), version, false, rgw::d4n::RefCount::NOOP, y);
-      ret = d4n_target_obj->set_head_obj_dir_entry(dpp, y, true);
-      if (ret < 0) {
-        ldpp_dout(dpp, 0) << "D4NFilterMultipartUpload::" << __func__ << "(): BlockDirectory set method failed for head object, ret=" << ret << dendl;
-      }
-    } else {
-      ldpp_dout(dpp, 0) << "D4NFilterMultipartUpload::" << __func__ << "(): put for head object failed, ret=" << ret << dendl;
-      return ret;
-    }
-  } else {
-    ldpp_dout(dpp, 0) << "D4NFilterMultipartUpload::" << __func__ << "(): failed to cache head object during eviction, ret=" << ret << dendl;
-    return ret;
+  ret = d4n_target_obj->set_head_block_dir_entry(dpp, y, attrs, true);
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "D4NFilterMultipartUpload::" << __func__ << "(): BlockDirectory set method failed for head object, ret=" << ret << dendl;
   }
 
   return 0;

--- a/src/rgw/driver/d4n/rgw_sal_d4n.cc
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.cc
@@ -1271,7 +1271,7 @@ int D4NFilterObject::write_if_space_available(const DoutPrefixProvider* dpp, con
   };
 
   int ret = cacheDriver->check_and_reserve_space(dpp, len, y);
-  if (ret == -ENOSPC) {
+  //if (ret == -ENOSPC) {
     // Not enough space — reserve upfront unconditionally and evict to free space
 	cacheDriver->reserve_space(dpp, len, y);  
 	ret = driver->get_policy_driver()->get_cache_policy()->eviction(dpp, len, y);
@@ -1280,9 +1280,9 @@ int D4NFilterObject::write_if_space_available(const DoutPrefixProvider* dpp, con
 	  rollback_reservation();
       return ret;
     }
-  } else if (ret < 0) {
-    return ret;
-  }
+ // } else if (ret < 0) {
+ //   return ret;
+ // }
 
   ret = driver->get_cache_driver()->put(dpp, key, bl, len, attrs, y);
   if (ret == 0) {
@@ -1292,6 +1292,7 @@ int D4NFilterObject::write_if_space_available(const DoutPrefixProvider* dpp, con
 	rollback_reservation();
 	return ret;
   }
+
   return 0;
 }
 

--- a/src/rgw/driver/d4n/rgw_sal_d4n.cc
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.cc
@@ -1293,7 +1293,7 @@ int D4NFilterObject::create_delete_marker(const DoutPrefixProvider* dpp, optiona
     ret = driver->get_cache_driver()->put(dpp, key, bl, 0, attrs, y);
     if (ret == 0) {
       ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << "(): version stored in update method is: " << version << dendl;
-      driver->get_policy_driver()->get_cache_policy()->update(dpp, key, 0, bl.length(), version, true, rgw::d4n::RefCount::NOOP, y);
+      driver->get_policy_driver()->get_cache_policy()->update(dpp, key, 0, bl.length(), version, true, std::get<rgw_user>(this->get_bucket()->get_owner()), rgw::d4n::RefCount::NOOP, y);
       ret = this->set_head_block_dir_entry(dpp, y, attrs, true, true);
       if (ret < 0) {
         ldpp_dout(dpp, 0) << "D4NFilterObject::" << __func__ << "(): BlockDirectory set method failed for head object, ret=" << ret << dendl;
@@ -2185,7 +2185,7 @@ int D4NFilterObject::D4NFilterReadOp::flush(const DoutPrefixProvider* dpp, rgw::
       if(!is_remote) {
         ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " calling update for offset: " << cur_ofs << " adjusted offset: " << ofs  << " length: " << len << " oid_in_cache: " << oid_in_cache << dendl;
         ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " version stored in update method is: " << version << " " << source->get_object_version() << dendl;
-        source->driver->get_policy_driver()->get_cache_policy()->update(dpp, oid_in_cache, ofs, len, version, std::nullopt, rgw::d4n::RefCount::DECR, y);
+        source->driver->get_policy_driver()->get_cache_policy()->update(dpp, oid_in_cache, ofs, len, version, std::nullopt, std::get<rgw_user>(source->get_bucket()->get_owner()), rgw::d4n::RefCount::DECR, y);
       }
       if ((source->dest_object && source->dest_bucket) || is_remote) {
         std::string dest_version;
@@ -2239,7 +2239,7 @@ int D4NFilterObject::D4NFilterReadOp::flush(const DoutPrefixProvider* dpp, rgw::
             // destination key is the same as key
             ret = source->driver->get_cache_driver()->put(dpp, key, bl, bl.length(), attrs, y);
             if (ret == 0) {
-              source->driver->get_policy_driver()->get_cache_policy()->update(dpp, key, ofs, bl.length(), dest_version, true, rgw::d4n::RefCount::NOOP, y);
+              source->driver->get_policy_driver()->get_cache_policy()->update(dpp, key, ofs, bl.length(), dest_version, true, std::get<rgw_user>(source->get_bucket()->get_owner()), rgw::d4n::RefCount::NOOP, y);
             }
             if (ret = source->driver->get_block_dir()->set(dpp, &dest_block, y); ret < 0){
               ldpp_dout(dpp, 20) << "D4NFilterObject::" << __func__ << " BlockDirectory set failed with ret: " << ret << dendl;
@@ -2387,6 +2387,8 @@ int D4NFilterObject::D4NFilterReadOp::iterate(const DoutPrefixProvider* dpp, int
           ldpp_dout(dpp, 0) << "D4NFilterObject::iterate:: " << __func__ << "(): Error: failed to flush, ret=" << r << dendl;
           return r;
         }
+        //setting read_flag = 0
+		source->driver->get_policy_driver()->get_cache_policy()->set_read_flag(dpp, oid_in_cache, 0);
       } else { // else - if update_refcount_if_key_exists
         int r = -1;
         ldpp_dout(dpp, 20) << "D4NFilterObject::iterate:: " << __func__ << "(): Info: Fetching from remote cache! " << dendl;
@@ -2698,7 +2700,7 @@ int D4NFilterObject::D4NFilterReadOp::D4NFilterGetCB::handle_data(bufferlist& bl
           ret = cache_driver->put(dpp, oid, bl, bl.length(), attrs, *y);
           if (ret == 0) {
             std::string objEtag = "";
-            policy->update(dpp, oid, adjusted_start_ofs, bl.length(), version, dirty, rgw::d4n::RefCount::NOOP, *y);
+            policy->update(dpp, oid, adjusted_start_ofs, bl.length(), version, dirty, std::get<rgw_user>(source->get_bucket()->get_owner()), rgw::d4n::RefCount::NOOP, *y);
             blocks.emplace_back(block);
           } else {
             ldpp_dout(dpp, 10) << "D4NFilterObject::D4NFilterReadOp::D4NFilterGetCB::" << __func__ << "(): put() to cache backend failed, ret=" << ret << dendl;
@@ -2715,7 +2717,7 @@ int D4NFilterObject::D4NFilterReadOp::D4NFilterGetCB::handle_data(bufferlist& bl
         if (ret == 0) {
           ret = cache_driver->put(dpp, dest_oid, bl, bl.length(), attrs, *y);
           if (ret == 0) {
-            policy->update(dpp, dest_oid, adjusted_start_ofs, bl.length(), dest_version, dirty, rgw::d4n::RefCount::NOOP, *y);
+            policy->update(dpp, dest_oid, adjusted_start_ofs, bl.length(), dest_version, dirty, std::get<rgw_user>(source->get_bucket()->get_owner()), rgw::d4n::RefCount::NOOP, *y);
             dest_blocks.emplace_back(dest_block);
           }
         }
@@ -2729,7 +2731,7 @@ int D4NFilterObject::D4NFilterReadOp::D4NFilterGetCB::handle_data(bufferlist& bl
         if (ret == 0) {
           ret = cache_driver->put(dpp, oid, bl, bl.length(), attrs, *y);
           if (ret == 0) {
-            policy->update(dpp, oid, adjusted_start_ofs, bl.length(), version, dirty, rgw::d4n::RefCount::NOOP, *y);
+            policy->update(dpp, oid, adjusted_start_ofs, bl.length(), version, dirty, std::get<rgw_user>(source->get_bucket()->get_owner()), rgw::d4n::RefCount::NOOP, *y);
             blocks.emplace_back(block);
           } else {
             ldpp_dout(dpp, 10) << "D4NFilterObject::D4NFilterReadOp::D4NFilterGetCB::" << __func__ << "(): put() to cache backend failed, ret=" << ret << dendl;
@@ -2746,7 +2748,7 @@ int D4NFilterObject::D4NFilterReadOp::D4NFilterGetCB::handle_data(bufferlist& bl
         if (ret == 0) {
           ret = cache_driver->put(dpp, dest_oid, bl, bl.length(), attrs, *y);
           if (ret == 0) {
-            policy->update(dpp, dest_oid, adjusted_start_ofs, bl.length(), dest_version, dirty, rgw::d4n::RefCount::NOOP, *y);
+            policy->update(dpp, dest_oid, adjusted_start_ofs, bl.length(), dest_version, dirty, std::get<rgw_user>(source->get_bucket()->get_owner()), rgw::d4n::RefCount::NOOP, *y);
             dest_blocks.emplace_back(dest_block);
           }
         }
@@ -2770,7 +2772,7 @@ int D4NFilterObject::D4NFilterReadOp::D4NFilterGetCB::handle_data(bufferlist& bl
           if (ret == 0) {
             ret = cache_driver->put(dpp, oid, bl_rem, bl_rem.length(), attrs, *y);
             if (ret == 0) {
-              policy->update(dpp, oid, adjusted_start_ofs, bl_rem.length(), version, dirty, rgw::d4n::RefCount::NOOP, *y);
+              policy->update(dpp, oid, adjusted_start_ofs, bl_rem.length(), version, dirty, std::get<rgw_user>(source->get_bucket()->get_owner()), rgw::d4n::RefCount::NOOP, *y);
               blocks.emplace_back(block);
             } else {
               ldpp_dout(dpp, 0) << "D4NFilterObject::D4NFilterReadOp::D4NFilterGetCB::" << __func__ << "(): put() to cache backend failed, ret=" << ret << dendl;
@@ -2790,7 +2792,7 @@ int D4NFilterObject::D4NFilterReadOp::D4NFilterGetCB::handle_data(bufferlist& bl
           if (ret == 0) {
             ret = cache_driver->put(dpp, dest_oid, bl_rem, bl_rem.length(), attrs, *y);
             if (ret == 0) {
-              policy->update(dpp, dest_oid, adjusted_start_ofs, bl_rem.length(), dest_version, dirty, rgw::d4n::RefCount::NOOP, *y);
+              policy->update(dpp, dest_oid, adjusted_start_ofs, bl_rem.length(), dest_version, dirty, std::get<rgw_user>(source->get_bucket()->get_owner()), rgw::d4n::RefCount::NOOP, *y);
               dest_blocks.emplace_back(dest_block);
             }
           }
@@ -3310,7 +3312,7 @@ int D4NFilterWriter::process(bufferlist&& data, uint64_t offset)
         attrs[RGW_CACHE_ATTR_OBJECT_NS] = std::move(bl_val);
         local_cache_ret = driver->get_cache_driver()->put(dpp, oid_in_cache, bl, bl.length(), attrs, y);
         if (local_cache_ret == 0) {
-          driver->get_policy_driver()->get_cache_policy()->update(dpp, oid_in_cache, ofs, bl.length(), version, dirty, rgw::d4n::RefCount::NOOP, y);
+          driver->get_policy_driver()->get_cache_policy()->update(dpp, oid_in_cache, ofs, bl.length(), version, dirty, std::get<rgw_user>(object->get_bucket()->get_owner()), rgw::d4n::RefCount::NOOP, y);
         }
       }
       if (local_cache_ret < 0) {

--- a/src/rgw/driver/d4n/rgw_sal_d4n.cc
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.cc
@@ -66,7 +66,7 @@ int D4NFilterDriver::initialize(CephContext *cct, const DoutPrefixProvider *dpp)
 							  "lfuda",
                                                           this->y);
 
-  std::string address = cct->_conf->rgw_d4n_address;
+  std::string address = cct->_conf->rgw_d4n_l1_datacache_address;
   config cfg;
   cfg.addr.host = address.substr(0, address.find(":"));
   cfg.addr.port = address.substr(address.find(":") + 1, address.length());

--- a/src/rgw/driver/d4n/rgw_sal_d4n.h
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.h
@@ -38,7 +38,9 @@
 
 namespace rgw::d4n {
   class PolicyDriver;
-  class RemoteCachePut;
+  class RemoteCacheOp;
+  class RemoteCacheDeleteOp;
+  class RemoteCachePutOp;
   class RemoteCachePutBatch;
 }
 
@@ -295,6 +297,7 @@ class D4NFilterObject : public FilterObject {
   private:
     D4NFilterDriver* driver;
     std::string version;
+	bool remote_dirty;
     std::string prefix;
     Attrs attrs_d4n;
     rgw_obj obj;
@@ -482,8 +485,10 @@ class D4NFilterObject : public FilterObject {
     void set_remote_cache_request() { remote_cache_request = true; }
     void set_block_offset(uint64_t offset) { blk_offset = offset; }
     void set_block_len(uint64_t len) { blk_len = len; }
-    uint64_t get_remote_block_offset() const { return blk_offset; }
-    uint64_t get_remote_block_len() const { return blk_len; }
+    uint64_t get_remote_block_offset() { return blk_offset; }
+    uint64_t get_remote_block_len() { return blk_len; }
+	const bool get_remote_dirty_flag() {return remote_dirty;}
+	void set_remote_dirty_flag(bool flag) {remote_dirty = flag;}
     void set_remote_obj_size(uint64_t size) { obj_size = size; }
     uint64_t get_remote_obj_size() const { return obj_size; }
     bool is_remote_head_block_request() const { return (remote_cache_request && (blk_offset == 0) && (blk_len == 0)); }
@@ -511,9 +516,9 @@ class D4NFilterWriter : public FilterWriter {
     bool d4n_writecache;
     std::string version;
     std::string prev_oid_in_cache;
-    std::vector<std::unique_ptr<rgw::d4n::RemoteCachePut>> requests;
+    std::vector<std::unique_ptr<rgw::d4n::RemoteCachePutOp>> requests;
 
-    static void write_to_remote_cache(const DoutPrefixProvider* dpp_o, const std::string& prefix, uint64_t size, const rgw_user& user, const std::string& remote_addr, const std::string& bucket_name, const std::string& oid, const std::string& version, D4NFilterDriver* driver, optional_yield y);
+    static void write_to_remote_cache(const DoutPrefixProvider* dpp_o, const std::string& prefix, uint64_t size, const rgw_user& user, const std::string& remote_addr, const std::string& bucket_name, const std::string& oid, const std::string& version, bool dirty, D4NFilterDriver* driver, optional_yield y);
 
   public:
     D4NFilterWriter(std::unique_ptr<Writer> _next, D4NFilterDriver* _driver, Object* _obj, 

--- a/src/rgw/driver/d4n/rgw_sal_d4n.h
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.h
@@ -68,16 +68,50 @@ public:
   }
 };
 
+struct TaskGroup {
+  std::atomic<int> in_flight{0};
+  std::atomic<bool> timer_set{false};
+  boost::asio::steady_timer signal_timer;
+
+  TaskGroup(boost::asio::any_io_executor ex) : signal_timer(ex) {
+    signal_timer.expires_at(std::chrono::steady_clock::time_point::max());
+  }
+
+  void wait(const DoutPrefixProvider *dpp, boost::asio::yield_context yield) {
+    ldpp_dout(dpp, 0) << "DEBUG: wait() starting, in_flight=" << in_flight << dendl;
+    timer_set.store(true, std::memory_order_release);
+    while (in_flight.load(std::memory_order_acquire) > 0) {
+      signal_timer.expires_at(std::chrono::steady_clock::time_point::max());
+      boost::system::error_code ec;
+      signal_timer.async_wait(yield[ec]);
+
+      if (ec == boost::asio::error::operation_aborted) {
+        continue;
+      }
+
+      if (ec) {
+        throw boost::system::system_error(ec);
+      }
+    }
+    ldpp_dout(dpp, 0) << "DEBUG: wait() exiting, in_flight=" << in_flight << dendl;
+    timer_set.store(false, std::memory_order_release);
+  }
+};
+
 class CoroutinePool {
 public:
   using Task = std::function<void(boost::asio::yield_context)>;
 
-  CoroutinePool(boost::asio::any_io_executor executor, size_t pool_size)
+  CoroutinePool(boost::asio::any_io_executor executor, size_t pool_size, bool on_strand=false)
       : executor(executor),
         pool_size(pool_size),
         strand(boost::asio::make_strand(executor)),
-        running(false)
-  {}
+        running(false),
+        on_strand(on_strand),
+        work_notifier(executor)
+  { 
+    work_notifier.expires_at(std::chrono::steady_clock::time_point::max());
+  }
 
   void start(const DoutPrefixProvider *dpp) {
     running = true;
@@ -88,16 +122,16 @@ public:
 
   void stop() {
     running = false;
-    cv.notify_all();
+    work_notifier.cancel();
   }
 
   void submit(Task task) {
     {
-        std::lock_guard<std::mutex> lock(queue_mutex);
-        task_queue.push(std::move(task));
-        queued_tasks++;
+      std::lock_guard<std::mutex> lock(queue_mutex);
+      task_queue.push(std::move(task));
+      queued_tasks++;
     }
-    cv.notify_one();
+    work_notifier.cancel_one();
   }
 
   struct Stats {
@@ -121,8 +155,9 @@ public:
 
 private:
   void spawn_worker(const DoutPrefixProvider *dpp, size_t worker_id) {
+    auto context = on_strand ? strand : executor;
     boost::asio::spawn(
-      executor,
+      context,
       [this, dpp, worker_id](boost::asio::yield_context yield) {
         worker_loop(dpp, worker_id, yield);
       },
@@ -134,11 +169,13 @@ private:
       Task task;
       {
         std::unique_lock<std::mutex> lock(queue_mutex);
-
-        cv.wait(lock, [&] {
-          return !running || !task_queue.empty();
-        });
-
+        while (running && task_queue.empty()) {
+          lock.unlock();
+          boost::system::error_code ec;
+          ldpp_dout(dpp, 20) << "Worker " << worker_id << " yielding (queue empty)" << dendl;
+          work_notifier.async_wait(yield[ec]);
+          lock.lock();
+        }
         if (!running && task_queue.empty()) {
           return;
         }
@@ -169,10 +206,11 @@ private:
   boost::asio::strand<boost::asio::any_io_executor> strand;
   std::queue<Task> task_queue;
   mutable std::mutex queue_mutex;
-  std::condition_variable cv;
   std::atomic<bool> running;
   std::atomic<int> active_workers{0};
   std::atomic<int> queued_tasks{0};
+  bool on_strand{false};
+  boost::asio::steady_timer work_notifier;
 };
 
 class D4NFilterDriver : public FilterDriver {
@@ -187,6 +225,7 @@ class D4NFilterDriver : public FilterDriver {
     optional_yield y;
     std::unique_ptr<boost::asio::thread_pool> d4n_thread_pool;
     std::unique_ptr<CoroutinePool> d4n_coroutine_pool;
+    std::unique_ptr<CoroutinePool> d4n_coroutine_get_pool;
 
     // Redis connection pool
     std::shared_ptr<rgw::d4n::RedisPool> redis_pool;
@@ -200,10 +239,23 @@ class D4NFilterDriver : public FilterDriver {
         d4n_coroutine_pool->start(dpp);
       }
     }
+
+    void initialize_get_pool(const DoutPrefixProvider *dpp,
+                        boost::asio::any_io_executor executor,
+                               size_t pool_size = 32) {
+      if (!d4n_coroutine_get_pool) {
+        d4n_coroutine_get_pool = std::make_unique<CoroutinePool>(executor, pool_size);
+        d4n_coroutine_get_pool->start(dpp);
+      }
+    }
     void shutdown_pool() {
       if (d4n_coroutine_pool) {
         d4n_coroutine_pool->stop();
         d4n_coroutine_pool.reset();
+      }
+      if (d4n_coroutine_get_pool) {
+        d4n_coroutine_get_pool->stop();
+        d4n_coroutine_get_pool.reset();
       }
     }
     CoroutinePool::Stats get_pool_stats() {
@@ -215,6 +267,10 @@ class D4NFilterDriver : public FilterDriver {
 
     CoroutinePool* get_pool() {
       return d4n_coroutine_pool.get();
+    }
+
+    CoroutinePool* get_d4n_get_pool() {
+      return d4n_coroutine_get_pool.get();
     }
 
     D4NFilterDriver(Driver* _next, boost::asio::io_context& io_context, bool admin);
@@ -291,6 +347,20 @@ class D4NFilterBucket : public FilterBucket {
 				std::optional<std::string> upload_id=std::nullopt,
 				ACLOwner owner={}, ceph::real_time mtime=real_clock::now()) override;
     void set_cache_request() { cache_request = true; }
+};
+
+struct BlockMeta {
+  uint64_t id;
+  uint64_t offset;
+  uint64_t len;
+  uint64_t read_offset;
+  uint64_t read_len;
+  bool is_remote{false};
+};
+
+struct RemoteTaskResult {
+  std::vector<BlockMeta> blocks;
+  rgw::AioResultList result_list;
 };
 
 class D4NFilterObject : public FilterObject {
@@ -374,18 +444,17 @@ class D4NFilterObject : public FilterObject {
       private:
 	RGWGetDataCB* client_cb;
 	std::unique_ptr<D4NFilterGetCB> cb;
-        std::unique_ptr<rgw::Aio> aio;
+        std::shared_ptr<rgw::Aio> aio;
 	uint64_t offset = 0; // next offset to write to client
         rgw::AioResultList completed; // completed read results, sorted by offset
-	std::unordered_map<uint64_t, std::pair<uint64_t,uint64_t>> blocks_info;
-  std::map<off_t, std::tuple<off_t, bool, bufferlist>> read_data;
-  bool last_part_done = false;
-  uint64_t last_adjusted_ofs = -1;
-  bool first_block = true; //is it first_block
+        std::map<uint64_t, std::unique_ptr<rgw::AioResultEntry>> completed_map;
+	std::unordered_map<uint64_t, BlockMeta> blocks_info;
+  std::mutex data_mutex;
+  std::vector<std::shared_ptr<RemoteTaskResult>> remote_task_results;
 
-  void set_first_block(bool val) {first_block = val;}
 	int flush(const DoutPrefixProvider* dpp, rgw::AioResultList&& results, optional_yield y);
 	void cancel();
+  int process_remote_results(const DoutPrefixProvider* dpp, std::shared_ptr<TaskGroup> group, optional_yield y);
 	int drain(const DoutPrefixProvider* dpp, optional_yield y);
     };
 
@@ -496,8 +565,9 @@ class D4NFilterObject : public FilterObject {
 
 class D4NFilterDPP : public DoutPrefixProvider {
   CephContext* cct;
+  std::string prefix;
 public:
-  explicit D4NFilterDPP(CephContext* c) : cct(c) {}
+  explicit D4NFilterDPP(CephContext* c, std::string& prefix) : cct(c), prefix(prefix) {}
   CephContext* get_cct() const override { return cct; }
   unsigned get_subsys() const override { return ceph_subsys_rgw; }
   std::ostream& gen_prefix(std::ostream& out) const override {

--- a/src/rgw/driver/d4n/rgw_sal_d4n.h
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.h
@@ -26,16 +26,20 @@
 
 #include "driver/d4n/d4n_directory.h"
 #include "driver/d4n/d4n_policy.h"
+#include "driver/d4n/d4n_remote_cache_manager.h"
 
 #include <boost/intrusive/list.hpp>
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/detached.hpp>
 #include <boost/redis/connection.hpp>
+#include <boost/asio/thread_pool.hpp>
 
 #include <fmt/core.h>
 
 namespace rgw::d4n {
   class PolicyDriver;
+  class RemoteCachePut;
+  class RemoteCachePutBatch;
 }
 
 namespace rgw { namespace sal {
@@ -62,6 +66,113 @@ public:
   }
 };
 
+class CoroutinePool {
+public:
+  using Task = std::function<void(boost::asio::yield_context)>;
+
+  CoroutinePool(boost::asio::any_io_executor executor, size_t pool_size)
+      : executor(executor),
+        pool_size(pool_size),
+        strand(boost::asio::make_strand(executor)),
+        running(false)
+  {}
+
+  void start(const DoutPrefixProvider *dpp) {
+    running = true;
+    for (size_t i = 0; i < pool_size; ++i) {
+      spawn_worker(dpp, i);
+    }
+  }
+
+  void stop() {
+    running = false;
+    cv.notify_all();
+  }
+
+  void submit(Task task) {
+    {
+        std::lock_guard<std::mutex> lock(queue_mutex);
+        task_queue.push(std::move(task));
+        queued_tasks++;
+    }
+    cv.notify_one();
+  }
+
+  struct Stats {
+    size_t pool_size;
+    size_t queue_size;
+    int active_workers;
+    int idle_workers;
+    int queued_tasks;
+  };
+
+  Stats get_stats() const {
+    std::lock_guard<std::mutex> lock(queue_mutex);
+    return Stats{
+      pool_size,
+      task_queue.size(),
+      active_workers,
+      static_cast<int>(pool_size) - active_workers,
+      queued_tasks
+    };
+  }
+
+private:
+  void spawn_worker(const DoutPrefixProvider *dpp, size_t worker_id) {
+    boost::asio::spawn(
+      executor,
+      [this, dpp, worker_id](boost::asio::yield_context yield) {
+        worker_loop(dpp, worker_id, yield);
+      },
+      boost::asio::detached);
+  }
+
+  void worker_loop(const DoutPrefixProvider *dpp, size_t worker_id, boost::asio::yield_context yield) {
+    while (running) {
+      Task task;
+      {
+        std::unique_lock<std::mutex> lock(queue_mutex);
+
+        cv.wait(lock, [&] {
+          return !running || !task_queue.empty();
+        });
+
+        if (!running && task_queue.empty()) {
+          return;
+        }
+
+        task = std::move(task_queue.front());
+        task_queue.pop();
+        queued_tasks--;
+      }
+
+      auto task_start = std::chrono::steady_clock::now();
+      active_workers++;
+      try {
+        task(yield);
+      } catch (const std::exception& e) {
+        ldpp_dout(dpp, 0) << "ERROR: CoroutinePool Worker: " << worker_id
+                           << " caught exception: " << e.what() << dendl;
+      }
+      auto task_duration = std::chrono::steady_clock::now() - task_start;
+      active_workers--;
+      ldpp_dout(dpp, 20) << "Worker " << worker_id << " task took "
+          << std::chrono::duration_cast<std::chrono::milliseconds>(task_duration).count()
+          << "ms" << dendl;
+    }
+  }
+
+  boost::asio::any_io_executor executor;
+  size_t pool_size;
+  boost::asio::strand<boost::asio::any_io_executor> strand;
+  std::queue<Task> task_queue;
+  mutable std::mutex queue_mutex;
+  std::condition_variable cv;
+  std::atomic<bool> running;
+  std::atomic<int> active_workers{0};
+  std::atomic<int> queued_tasks{0};
+};
+
 class D4NFilterDriver : public FilterDriver {
   private:
     std::shared_ptr<connection> conn;
@@ -72,11 +183,38 @@ class D4NFilterDriver : public FilterDriver {
     std::unique_ptr<rgw::d4n::PolicyDriver> policyDriver;
     boost::asio::io_context& io_context;
     optional_yield y;
+    std::unique_ptr<boost::asio::thread_pool> d4n_thread_pool;
+    std::unique_ptr<CoroutinePool> d4n_coroutine_pool;
 
     // Redis connection pool
     std::shared_ptr<rgw::d4n::RedisPool> redis_pool;
 
   public:
+    void initialize_pool(const DoutPrefixProvider *dpp,
+                        boost::asio::any_io_executor executor,
+                               size_t pool_size = 32) {
+      if (!d4n_coroutine_pool) {
+        d4n_coroutine_pool = std::make_unique<CoroutinePool>(executor, pool_size);
+        d4n_coroutine_pool->start(dpp);
+      }
+    }
+    void shutdown_pool() {
+      if (d4n_coroutine_pool) {
+        d4n_coroutine_pool->stop();
+        d4n_coroutine_pool.reset();
+      }
+    }
+    CoroutinePool::Stats get_pool_stats() {
+      if (d4n_coroutine_pool) {
+        return d4n_coroutine_pool->get_stats();
+      }
+      return CoroutinePool::Stats{0, 0, 0, 0, 0};
+    }
+
+    CoroutinePool* get_pool() {
+      return d4n_coroutine_pool.get();
+    }
+
     D4NFilterDriver(Driver* _next, boost::asio::io_context& io_context, bool admin);
     virtual ~D4NFilterDriver();
 
@@ -102,7 +240,11 @@ class D4NFilterDriver : public FilterDriver {
     void save_y(optional_yield y) { this->y = y; }
     std::shared_ptr<connection> get_conn() { return conn; }
     std::shared_ptr<rgw::d4n::RedisPool> get_redis_pool() { return redis_pool; }
+    boost::asio::io_context& get_io_context() { return io_context; }
     void shutdown() override;
+    auto get_d4n_executor() {
+      return d4n_thread_pool->get_executor();
+    }
 };
 
 class D4NFilterUser : public FilterUser {
@@ -164,6 +306,10 @@ class D4NFilterObject : public FilterObject {
     bool load_from_store{false};
     bool attrs_read_from_cache{false};
     bool cache_request{false};
+    bool remote_cache_request{false}; //sent by another rgw
+    uint64_t blk_offset;
+    uint64_t blk_len;
+    uint64_t obj_size; //sent by remote rgw
 
   public:
     struct D4NFilterReadOp : FilterReadOp {
@@ -314,7 +460,8 @@ class D4NFilterObject : public FilterObject {
     int get_obj_attrs_from_cache(const DoutPrefixProvider* dpp, optional_yield y);
     void set_attrs_from_obj_state(const DoutPrefixProvider* dpp, optional_yield y, rgw::sal::Attrs& attrs, bool dirty = false);
     int calculate_version(const DoutPrefixProvider* dpp, optional_yield y, std::string& version, rgw::sal::Attrs& attrs);
-    int set_head_obj_dir_entry(const DoutPrefixProvider* dpp, std::vector<std::string>* exec_responses, optional_yield y, bool is_latest_version = true, bool dirty = false);
+    int set_head_obj_dir_entry(const DoutPrefixProvider* dpp, optional_yield y, bool is_latest_version = true, bool dirty = false);
+    int update_head_block_hostslist(const DoutPrefixProvider* dpp, optional_yield y);
     int set_data_block_dir_entries(const DoutPrefixProvider* dpp, optional_yield y, std::string& version, bool dirty = false);
     int delete_data_block_cache_entries(const DoutPrefixProvider* dpp, optional_yield y, std::string& version, bool dirty = false);
     bool check_head_exists_in_cache_get_oid(const DoutPrefixProvider* dpp, std::string& head_oid_in_cache, rgw::sal::Attrs& attrs, rgw::d4n::CacheBlock& blk, optional_yield y);
@@ -329,7 +476,29 @@ class D4NFilterObject : public FilterObject {
     void set_load_obj_from_store(bool load_from_store) { this->load_from_store = load_from_store; }
     int delete_cache_entry(const DoutPrefixProvider* dpp, const std::string key, optional_yield y);
     void set_cache_request() { cache_request = true; }
-    bool is_cache_request() { return cache_request; }
+    bool is_cache_request() const { return cache_request; }
+    //the following are helper methods to get/set from/to cache
+    bool is_remote_cache_request() const { return remote_cache_request; }
+    void set_remote_cache_request() { remote_cache_request = true; }
+    void set_block_offset(uint64_t offset) { blk_offset = offset; }
+    void set_block_len(uint64_t len) { blk_len = len; }
+    uint64_t get_remote_block_offset() const { return blk_offset; }
+    uint64_t get_remote_block_len() const { return blk_len; }
+    void set_remote_obj_size(uint64_t size) { obj_size = size; }
+    uint64_t get_remote_obj_size() const { return obj_size; }
+    bool is_remote_head_block_request() const { return (remote_cache_request && (blk_offset == 0) && (blk_len == 0)); }
+};
+
+class D4NFilterDPP : public DoutPrefixProvider {
+  CephContext* cct;
+public:
+  explicit D4NFilterDPP(CephContext* c) : cct(c) {}
+  CephContext* get_cct() const override { return cct; }
+  unsigned get_subsys() const override { return ceph_subsys_rgw; }
+  std::ostream& gen_prefix(std::ostream& out) const override {
+    out << "write_to_remote_cache: ";
+    return out;
+  }
 };
 
 class D4NFilterWriter : public FilterWriter {
@@ -342,6 +511,9 @@ class D4NFilterWriter : public FilterWriter {
     bool d4n_writecache;
     std::string version;
     std::string prev_oid_in_cache;
+    std::vector<std::unique_ptr<rgw::d4n::RemoteCachePut>> requests;
+
+    static void write_to_remote_cache(const DoutPrefixProvider* dpp_o, const std::string& prefix, uint64_t size, const rgw_user& user, const std::string& remote_addr, const std::string& bucket_name, const std::string& oid, const std::string& version, D4NFilterDriver* driver, optional_yield y);
 
   public:
     D4NFilterWriter(std::unique_ptr<Writer> _next, D4NFilterDriver* _driver, Object* _obj, 
@@ -367,10 +539,9 @@ class D4NFilterWriter : public FilterWriter {
 			 const req_context& rctx,
 			 uint32_t flags) override;
    bool is_atomic() { return atomic; };
-   int sendRemote(const DoutPrefixProvider* dpp, rgw::d4n::CacheObj *object, std::string remoteCacheAddress, std::string key, bufferlist*
-    out_bl, optional_yield y);
    const DoutPrefixProvider* get_dpp() { return this->dpp; } 
    void set_cache_request() { object->set_cache_request(); }
+   void set_remote_cache_request() { object->set_remote_cache_request(); }
 };
 
 class D4NGetObjectCB : public RGWHTTPStreamRWRequest::ReceiveCB {

--- a/src/rgw/driver/d4n/rgw_sal_d4n.h
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.h
@@ -22,6 +22,7 @@
 #include "rgw_aio_throttle.h"
 #include "rgw_ssd_driver.h"
 #include "rgw_redis_driver.h"
+#include "rgw_rest_conn.h"
 
 #include "driver/d4n/d4n_directory.h"
 #include "driver/d4n/d4n_policy.h"
@@ -50,6 +51,16 @@ inline std::string get_key_in_cache(const std::string& prefix, const std::string
 }
 
 using boost::redis::connection;
+
+class RGWRemoteD4NGetCB : public RGWHTTPStreamRWRequest::ReceiveCB {
+public:
+  bufferlist *in_bl;                                  
+  RGWRemoteD4NGetCB(bufferlist* _bl): in_bl(_bl) {}
+  int handle_data(bufferlist& bl, bool *pause) override {
+    this->in_bl->append(bl);
+    return 0;
+  }
+};
 
 class D4NFilterDriver : public FilterDriver {
   private:
@@ -143,6 +154,7 @@ class D4NFilterObject : public FilterObject {
     D4NFilterDriver* driver;
     std::string version;
     std::string prefix;
+    Attrs attrs_d4n;
     rgw_obj obj;
     rgw::sal::Object* dest_object{nullptr}; //for copy-object
     rgw::sal::Bucket* dest_bucket{nullptr}; //for copy-object
@@ -201,6 +213,9 @@ class D4NFilterObject : public FilterObject {
 	}
 	virtual ~D4NFilterReadOp() = default;
 
+  int getRemote(const DoutPrefixProvider* dpp, long long start, long long end, std::string key, std::string remoteCacheAddress, bufferlist *bl, optional_yield y);
+  int remoteFlush(const DoutPrefixProvider* dpp, bufferlist bl, uint64_t ofs, uint64_t len, uint64_t read_ofs, std::string creationTime, optional_yield y);
+
 	virtual int prepare(optional_yield y, const DoutPrefixProvider* dpp) override;
 	virtual int iterate(const DoutPrefixProvider* dpp, int64_t ofs, int64_t end,
 			     RGWGetDataCB* cb, optional_yield y) override;
@@ -214,7 +229,12 @@ class D4NFilterObject : public FilterObject {
 	uint64_t offset = 0; // next offset to write to client
         rgw::AioResultList completed; // completed read results, sorted by offset
 	std::unordered_map<uint64_t, std::pair<uint64_t,uint64_t>> blocks_info;
+  std::map<off_t, std::tuple<off_t, bool, bufferlist>> read_data;
+  bool last_part_done = false;
+  uint64_t last_adjusted_ofs = -1;
+  bool first_block = true; //is it first_block
 
+  void set_first_block(bool val) {first_block = val;}
 	int flush(const DoutPrefixProvider* dpp, rgw::AioResultList&& results, optional_yield y);
 	void cancel();
 	int drain(const DoutPrefixProvider* dpp, optional_yield y);
@@ -289,6 +309,8 @@ class D4NFilterObject : public FilterObject {
 
     void set_prefix(const std::string& prefix) { this->prefix = prefix; }
     const std::string get_prefix() { return this->prefix; }
+    void set_object_attrs(Attrs attrs) { this->attrs_d4n = attrs; }
+    Attrs get_object_attrs() { return this->attrs_d4n; }
     int get_obj_attrs_from_cache(const DoutPrefixProvider* dpp, optional_yield y);
     void set_attrs_from_obj_state(const DoutPrefixProvider* dpp, optional_yield y, rgw::sal::Attrs& attrs, bool dirty = false);
     int calculate_version(const DoutPrefixProvider* dpp, optional_yield y, std::string& version, rgw::sal::Attrs& attrs);
@@ -345,8 +367,20 @@ class D4NFilterWriter : public FilterWriter {
 			 const req_context& rctx,
 			 uint32_t flags) override;
    bool is_atomic() { return atomic; };
+   int sendRemote(const DoutPrefixProvider* dpp, rgw::d4n::CacheObj *object, std::string remoteCacheAddress, std::string key, bufferlist*
+    out_bl, optional_yield y);
    const DoutPrefixProvider* get_dpp() { return this->dpp; } 
    void set_cache_request() { object->set_cache_request(); }
+};
+
+class D4NGetObjectCB : public RGWHTTPStreamRWRequest::ReceiveCB {
+public:                                                     
+  bufferlist *in_bl;
+  D4NGetObjectCB(bufferlist* _bl): in_bl(_bl) {}
+  int handle_data(bufferlist& bl, bool *pause) override {
+    this->in_bl->append(bl);
+    return 0;
+  }
 };
 
 class D4NFilterMultipartUpload : public FilterMultipartUpload {

--- a/src/rgw/driver/d4n/rgw_sal_d4n.h
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.h
@@ -19,6 +19,7 @@
 #include "rgw_sal.h"
 #include "rgw_role.h"
 #include "common/dout.h" 
+#include "common/split.h"
 #include "rgw_aio_throttle.h"
 #include "rgw_ssd_driver.h"
 #include "rgw_redis_driver.h"
@@ -59,6 +60,30 @@ inline std::string get_cache_block_prefix(rgw::sal::Object* object, const std::s
 inline std::string get_key_in_cache(const std::string& prefix, const std::string& offset, const std::string& len)
 {
   return fmt::format("{}{}{}{}{}", prefix, CACHE_DELIM, offset, CACHE_DELIM, len);
+}
+
+inline std::optional<rgw::d4n::CacheBlock> parse_block_from_cache(const std::string& key)
+{
+  rgw::d4n::CacheBlock block;
+  auto parts = split(key, "#");
+  std::vector<std::string> block_info;
+  block_info.assign(parts.begin(), parts.end());
+
+  if (block_info.size() != 5) {
+	return std::nullopt;
+  }
+
+  block.cacheObj.bucketName = block_info[0]; 
+  block.version = block_info[1];
+  block.cacheObj.objName = block_info[2]; 
+  try {
+	block.blockID = std::stoull(block_info[3]);
+	block.size = std::stoull(block_info[4]);
+  } catch (std::exception &e) {
+	return std::nullopt;
+  }
+
+  return block; 
 }
 
 using boost::redis::connection;
@@ -388,6 +413,7 @@ class D4NFilterObject : public FilterObject {
     uint64_t blk_offset;
     uint64_t blk_len;
     uint64_t obj_size; //sent by remote rgw
+    bool block_only = false; // sent by remote rgw; used in PUT op for an evicted block
 
   public:
     struct D4NFilterReadOp : FilterReadOp {
@@ -451,14 +477,9 @@ class D4NFilterObject : public FilterObject {
         rgw::AioResultList completed; // completed read results, sorted by offset
         std::map<uint64_t, std::unique_ptr<rgw::AioResultEntry>> completed_map;
 	std::unordered_map<uint64_t, BlockMeta> blocks_info;
-	std::map<off_t, std::tuple<off_t, bool, bufferlist>> read_data;
-	bool last_part_done = false;
-	uint64_t last_adjusted_ofs = -1;
-	bool first_block = true; //is it first_block
   std::mutex data_mutex;
   std::vector<std::shared_ptr<RemoteTaskResult>> remote_task_results;
 
-	void set_first_block(bool val) {first_block = val;}
 	int flush(const DoutPrefixProvider* dpp, rgw::AioResultList&& results, optional_yield y);
 	void cancel();
   int process_remote_results(const DoutPrefixProvider* dpp, std::shared_ptr<TaskGroup> group, optional_yield y);
@@ -565,8 +586,13 @@ class D4NFilterObject : public FilterObject {
     uint64_t get_remote_block_len() { return blk_len; }
 	const bool get_remote_dirty_flag() {return remote_dirty;}
 	void set_remote_dirty_flag(bool flag) {remote_dirty = flag;}
+    bool get_remote_block_only() const { return block_only; }
     void set_remote_obj_size(uint64_t size) { obj_size = size; }
+    void set_remote_block_only(bool flag) { block_only = flag; }
     uint64_t get_remote_obj_size() const { return obj_size; }
+	int write_if_space_available(const DoutPrefixProvider* dpp, const std::string& key, const bufferlist& bl, uint64_t len, const Attrs& attrs,
+								  uint64_t offset, const std::string& version, const bool& dirty, const rgw_user user, const std::string& bucketName,
+								  uint8_t op, optional_yield y);
 };
 
 class D4NFilterDPP : public DoutPrefixProvider {

--- a/src/rgw/driver/d4n/rgw_sal_d4n.h
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.h
@@ -451,9 +451,14 @@ class D4NFilterObject : public FilterObject {
         rgw::AioResultList completed; // completed read results, sorted by offset
         std::map<uint64_t, std::unique_ptr<rgw::AioResultEntry>> completed_map;
 	std::unordered_map<uint64_t, BlockMeta> blocks_info;
+	std::map<off_t, std::tuple<off_t, bool, bufferlist>> read_data;
+	bool last_part_done = false;
+	uint64_t last_adjusted_ofs = -1;
+	bool first_block = true; //is it first_block
   std::mutex data_mutex;
   std::vector<std::shared_ptr<RemoteTaskResult>> remote_task_results;
 
+	void set_first_block(bool val) {first_block = val;}
 	int flush(const DoutPrefixProvider* dpp, rgw::AioResultList&& results, optional_yield y);
 	void cancel();
   int process_remote_results(const DoutPrefixProvider* dpp, std::shared_ptr<TaskGroup> group, optional_yield y);

--- a/src/rgw/driver/d4n/rgw_sal_d4n.h
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.h
@@ -46,9 +46,14 @@ namespace rgw::d4n {
 
 namespace rgw { namespace sal {
 
+inline std::string get_cache_block_prefix(const std::string& bucket_id, const std::string& object_name, const std::string& version)
+{
+  return fmt::format("{}{}{}{}{}", url_encode(bucket_id, true), CACHE_DELIM, url_encode(version, true), CACHE_DELIM, url_encode(object_name, true));
+}
+
 inline std::string get_cache_block_prefix(rgw::sal::Object* object, const std::string& version)
 {
-  return fmt::format("{}{}{}{}{}", url_encode(object->get_bucket()->get_bucket_id(), true), CACHE_DELIM, url_encode(version, true), CACHE_DELIM, url_encode(object->get_name(), true));
+  return get_cache_block_prefix(object->get_bucket()->get_bucket_id(), object->get_name(), version);
 }
 
 inline std::string get_key_in_cache(const std::string& prefix, const std::string& offset, const std::string& len)
@@ -432,9 +437,6 @@ class D4NFilterObject : public FilterObject {
 	}
 	virtual ~D4NFilterReadOp() = default;
 
-  int getRemote(const DoutPrefixProvider* dpp, long long start, long long end, std::string key, std::string remoteCacheAddress, bufferlist *bl, optional_yield y);
-  int remoteFlush(const DoutPrefixProvider* dpp, bufferlist bl, uint64_t ofs, uint64_t len, uint64_t read_ofs, std::string creationTime, optional_yield y);
-
 	virtual int prepare(optional_yield y, const DoutPrefixProvider* dpp) override;
 	virtual int iterate(const DoutPrefixProvider* dpp, int64_t ofs, int64_t end,
 			     RGWGetDataCB* cb, optional_yield y) override;
@@ -532,7 +534,7 @@ class D4NFilterObject : public FilterObject {
     int get_obj_attrs_from_cache(const DoutPrefixProvider* dpp, optional_yield y);
     void set_attrs_from_obj_state(const DoutPrefixProvider* dpp, optional_yield y, rgw::sal::Attrs& attrs, bool dirty = false);
     int calculate_version(const DoutPrefixProvider* dpp, optional_yield y, std::string& version, rgw::sal::Attrs& attrs);
-    int set_head_obj_dir_entry(const DoutPrefixProvider* dpp, optional_yield y, bool is_latest_version = true, bool dirty = false);
+    int set_head_block_dir_entry(const DoutPrefixProvider* dpp, optional_yield y, rgw::sal::Attrs& attrs, bool is_latest_version = true, bool dirty = false);
     int update_head_block_hostslist(const DoutPrefixProvider* dpp, optional_yield y);
     int set_data_block_dir_entries(const DoutPrefixProvider* dpp, optional_yield y, std::string& version, bool dirty = false);
     int delete_data_block_cache_entries(const DoutPrefixProvider* dpp, optional_yield y, std::string& version, bool dirty = false);
@@ -560,7 +562,6 @@ class D4NFilterObject : public FilterObject {
 	void set_remote_dirty_flag(bool flag) {remote_dirty = flag;}
     void set_remote_obj_size(uint64_t size) { obj_size = size; }
     uint64_t get_remote_obj_size() const { return obj_size; }
-    bool is_remote_head_block_request() const { return (remote_cache_request && (blk_offset == 0) && (blk_len == 0)); }
 };
 
 class D4NFilterDPP : public DoutPrefixProvider {

--- a/src/rgw/rgw_cache_driver.h
+++ b/src/rgw/rgw_cache_driver.h
@@ -21,9 +21,8 @@ constexpr char CACHE_DELIM = '#';
 
 namespace rgw { namespace cache {
 
-typedef std::function<void(const DoutPrefixProvider* dpp, const std::string& key, const std::string& version, bool deleteMarker, uint64_t size, 
-			    time_t creationTime, const rgw_user user, const std::string& etag, const std::string& bucket_name, const std::string& bucket_id,
-			    const rgw_obj_key& obj_key, optional_yield y, std::string& restore_val)> ObjectDataCallback;
+typedef std::function<void(const DoutPrefixProvider* dpp, const std::string& key, const std::string& version, bool deleteMarker, const std::string& bucket_id,
+			    const rgw_obj_key& obj_key, const std::string& instance, optional_yield y, std::string& restore_val)> ObjectDataCallback;
 
 typedef std::function<void(const DoutPrefixProvider* dpp, const std::string& key, uint64_t offset, uint64_t len, const std::string& version,
         bool dirty, optional_yield y, std::string& restore_val)> BlockDataCallback;

--- a/src/rgw/rgw_cache_driver.h
+++ b/src/rgw/rgw_cache_driver.h
@@ -25,7 +25,7 @@ typedef std::function<void(const DoutPrefixProvider* dpp, const std::string& key
 			    const rgw_obj_key& obj_key, const std::string& instance, optional_yield y, std::string& restore_val)> ObjectDataCallback;
 
 typedef std::function<void(const DoutPrefixProvider* dpp, const std::string& key, uint64_t offset, uint64_t len, const std::string& version,
-        bool dirty, const rgw_user user, optional_yield y, std::string& restore_val)> BlockDataCallback;
+        bool dirty, const rgw_user user, const std::string& bucketName, optional_yield y, std::string& restore_val)> BlockDataCallback;
 
 struct Partition {
   std::string name;
@@ -57,6 +57,9 @@ class CacheDriver {
     /* Partition */
     virtual Partition get_current_partition_info(const DoutPrefixProvider* dpp) = 0;
     virtual uint64_t get_free_space(const DoutPrefixProvider* dpp, optional_yield y) = 0;
+    virtual int reserve_space(const DoutPrefixProvider* dpp, uint64_t size, optional_yield y) = 0;
+    virtual int check_and_reserve_space(const DoutPrefixProvider* dpp, uint64_t size, optional_yield y) = 0;
+    virtual int release_reservation(const DoutPrefixProvider* dpp, uint64_t size, optional_yield y) = 0;
 
     /* Data Recovery from Cache */
     virtual int restore_blocks_objects(const DoutPrefixProvider* dpp, ObjectDataCallback obj_func, BlockDataCallback block_func) = 0;

--- a/src/rgw/rgw_cache_driver.h
+++ b/src/rgw/rgw_cache_driver.h
@@ -25,7 +25,7 @@ typedef std::function<void(const DoutPrefixProvider* dpp, const std::string& key
 			    const rgw_obj_key& obj_key, const std::string& instance, optional_yield y, std::string& restore_val)> ObjectDataCallback;
 
 typedef std::function<void(const DoutPrefixProvider* dpp, const std::string& key, uint64_t offset, uint64_t len, const std::string& version,
-        bool dirty, optional_yield y, std::string& restore_val)> BlockDataCallback;
+        bool dirty, const rgw_user user, optional_yield y, std::string& restore_val)> BlockDataCallback;
 
 struct Partition {
   std::string name;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4713,8 +4713,25 @@ void RGWPutObj::execute(optional_yield y)
 					 pdest_placement, olh_epoch, s->req_id);
   }
 #ifdef WITH_RADOSGW_D4N
-  if (s->info.env->get_optional("HTTP_X_RGW_CACHE_REQUEST") && (g_conf().get_val<std::string>("rgw_filter") == "d4n")) {
-    dynamic_cast<rgw::sal::D4NFilterWriter*>(processor.get())->set_cache_request();
+  if (g_conf().get_val<std::string>("rgw_filter") == "d4n") {
+    if (s->info.env->get_optional("HTTP_X_RGW_REMOTE_CACHE_REQUEST")) {
+      ldpp_dout(this, 20) << "This is a remote cache request !!!" << dendl;
+      dynamic_cast<rgw::sal::D4NFilterWriter*>(processor.get())->set_remote_cache_request();
+      rgw::sal::D4NFilterObject* d4n_obj = dynamic_cast<rgw::sal::D4NFilterObject*>(s->object.get());
+      auto object_version = s->info.env->get_optional("HTTP_X_RGW_CACHE_OBJECT_VERSION");
+      if (object_version) {
+        d4n_obj->set_object_version(object_version.get());
+      }
+      if (auto blk_offset = s->info.env->get_optional("HTTP_X_RGW_CACHE_BLK_OFFSET"); blk_offset) {
+        d4n_obj->set_block_offset(std::stoull(blk_offset.get()));
+      }
+      if (auto blk_len = s->info.env->get_optional("HTTP_X_RGW_CACHE_BLK_LEN"); blk_len) {
+        d4n_obj->set_block_len(std::stoull(blk_len.get()));
+      }
+      if (auto obj_size = s->info.env->get_optional("HTTP_X_RGW_CACHE_OBJ_SIZE"); obj_size) {
+        d4n_obj->set_remote_obj_size(std::stoull(obj_size.get()));
+      }
+    }
   }
 #endif
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4722,6 +4722,10 @@ void RGWPutObj::execute(optional_yield y)
       if (object_version) {
         d4n_obj->set_object_version(object_version.get());
       }
+      auto object_dirty = s->info.env->get_optional("HTTP_X_RGW_CACHE_OBJECT_DIRTY");
+      if (object_dirty) {
+        d4n_obj->set_remote_dirty_flag(object_dirty.get() == "true" || object_dirty.get() == "1" );
+      }
       if (auto blk_offset = s->info.env->get_optional("HTTP_X_RGW_CACHE_BLK_OFFSET"); blk_offset) {
         d4n_obj->set_block_offset(std::stoull(blk_offset.get()));
       }
@@ -5858,6 +5862,16 @@ void RGWDeleteObj::execute(optional_yield y)
       if (s->info.env->get_optional("HTTP_X_RGW_CACHE_REQUEST") && (g_conf().get_val<std::string>("rgw_filter") == "d4n")) {
 		dynamic_cast<rgw::sal::D4NFilterObject*>(s->object.get())->set_cache_request();
       }
+#endif
+
+#ifdef WITH_RADOSGW_D4N
+  if (g_conf().get_val<std::string>("rgw_filter") == "d4n") {
+    if (s->info.env->get_optional("HTTP_X_RGW_REMOTE_CACHE_REQUEST")) {
+      ldpp_dout(this, 20) << "This is a remote cache request !!!" << dendl;
+      rgw::sal::D4NFilterObject* d4n_obj = dynamic_cast<rgw::sal::D4NFilterObject*>(s->object.get());
+      d4n_obj->set_remote_cache_request();
+    }
+  }
 #endif
 
       op_ret = del_op->delete_obj(this, y, rgw::sal::FLAG_LOG_OP);

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4735,6 +4735,11 @@ void RGWPutObj::execute(optional_yield y)
       if (auto obj_size = s->info.env->get_optional("HTTP_X_RGW_CACHE_OBJ_SIZE"); obj_size) {
         d4n_obj->set_remote_obj_size(std::stoull(obj_size.get()));
       }
+      if (auto block_only = s->info.env->get_optional("HTTP_X_RGW_CACHE_BLOCK_ONLY"); block_only) {
+        if (block_only.get() == "true") {
+	      d4n_obj->set_remote_block_only(true);
+        }
+      }
     }
   }
 #endif

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -2403,7 +2403,13 @@ inline int rgw_get_request_metadata(const DoutPrefixProvider *dpp,
       "x-amz-storage-class",
       "x-amz-content-sha256",
       "x-amz-checksum-algorithm",
-      "x-amz-date"
+      "x-amz-date",
+      //D4N cache related headers
+      "x-amz-remote-cache-request",
+      "x-amz-cache-blk-offset",
+      "x-amz-cache-blk-len",
+      "x-amz-cache-obj-size",
+      "x-amz-cache-object-version"
   };
 
   size_t valid_meta_count = 0;

--- a/src/rgw/rgw_redis_driver.h
+++ b/src/rgw/rgw_redis_driver.h
@@ -33,6 +33,9 @@ class RedisDriver : public CacheDriver {
     /* Partition */
     virtual Partition get_current_partition_info(const DoutPrefixProvider* dpp) override { return partition_info; }
     virtual uint64_t get_free_space(const DoutPrefixProvider* dpp, optional_yield y) override;
+	virtual int reserve_space(const DoutPrefixProvider* dpp, uint64_t size, optional_yield y) { return 0; } // TODO: Implement
+	virtual int check_and_reserve_space(const DoutPrefixProvider* dpp, uint64_t size, optional_yield y) { return 0; } // TODO: Implement
+	virtual int release_reservation(const DoutPrefixProvider* dpp, uint64_t size, optional_yield y) { return 0; } // TODO: Implement
 
     virtual int initialize(const DoutPrefixProvider* dpp) override;
     virtual int put(const DoutPrefixProvider* dpp, const std::string& key, const bufferlist& bl, uint64_t len, const rgw::sal::Attrs& attrs, optional_yield y) override;

--- a/src/rgw/rgw_ssd_driver.cc
+++ b/src/rgw/rgw_ssd_driver.cc
@@ -259,55 +259,24 @@ int SSDDriver::restore_blocks_objects(const DoutPrefixProvider* dpp, ObjectDataC
 					    block_func(dpp, key, offset, len, version, false, null_yield, localWeightStr);
 					    parsed = true;
 				        } else if (dirtyStr == "1") {
-                                            //dirty blocks - version in head block and offset, len in data blocks
+                            //we still have parsing for a head block because we maintain a head block only for delete markers
+                            // as there are no data blocks associated with it.
 					    std::string localWeightStr;
 					    std::string invalidStr;
 					    rgw::sal::Attrs attrs;
 					    get_attrs(dpp, file_entry.path(), attrs, null_yield);
-					    std::string etag, bucket_name;
-					    uint64_t size = 0;
-					    time_t creationTime = time_t(nullptr);
-					    rgw_user user;
 					    rgw_obj_key obj_key;
 					    bool deleteMarker = false;
-					    if (attrs.find(RGW_ATTR_ETAG) != attrs.end()) {
-						etag = attrs[RGW_ATTR_ETAG].to_str();
-						ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): etag: " << etag << dendl;
-					    }
-					    if (attrs.find(RGW_CACHE_ATTR_OBJECT_SIZE) != attrs.end()) {
-						size = std::stoull(attrs[RGW_CACHE_ATTR_OBJECT_SIZE].to_str());
-						ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): size: " << size << dendl;
-					    }
-					    if (attrs.find(RGW_CACHE_ATTR_MTIME) != attrs.end()) {
-						creationTime = ceph::real_clock::to_time_t(ceph::real_clock::from_double(std::stod(attrs[RGW_CACHE_ATTR_MTIME].to_str())));
-						ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): creationTime: " << creationTime << dendl;
-					    }
-					    if (attrs.find(RGW_ATTR_ACL) != attrs.end()) {
-						bufferlist bl_acl = attrs[RGW_ATTR_ACL];
-						RGWAccessControlPolicy policy;
-						auto iter = bl_acl.cbegin();
-						try {
-						    policy.decode(iter);
-						} catch (buffer::error& err) {
-						    ldpp_dout(dpp, 0) << "ERROR: could not decode policy, caught buffer::error" << dendl;
-						    continue;
-						}
-						user = std::get<rgw_user>(policy.get_owner().id);
-						ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): rgw_user: " << user.to_str() << dendl;
-					    }
 					    obj_key.name = object_name;
+                        std::string instance;
 					    if (attrs.find(RGW_CACHE_ATTR_VERSION_ID) != attrs.end()) {
-						std::string instance = attrs[RGW_CACHE_ATTR_VERSION_ID].to_str();
-                            obj_key.instance = instance;
+						instance = attrs[RGW_CACHE_ATTR_VERSION_ID].to_str();
+						obj_key.instance = instance;
 					    }
 					    if (attrs.find(RGW_CACHE_ATTR_OBJECT_NS) != attrs.end()) {
 						obj_key.ns = attrs[RGW_CACHE_ATTR_OBJECT_NS].to_str();
 					    }
 					    ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): rgw_obj_key: " << obj_key.get_oid() << dendl;
-					    if (attrs.find(RGW_CACHE_ATTR_BUCKET_NAME) != attrs.end()) {
-						bucket_name = attrs[RGW_CACHE_ATTR_BUCKET_NAME].to_str();
-						ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): bucket_name: " << bucket_name << dendl;
-					    }
 
 					    if (attrs.find(RGW_CACHE_ATTR_LOCAL_WEIGHT) != attrs.end()) {
 						localWeightStr = attrs[RGW_CACHE_ATTR_LOCAL_WEIGHT].to_str();
@@ -326,11 +295,31 @@ int SSDDriver::restore_blocks_objects(const DoutPrefixProvider* dpp, ObjectDataC
 					    }
 
 					    ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): calling func for: " << key << dendl;
-					    obj_func(dpp, key, version, deleteMarker, size, creationTime, user, etag, bucket_name, bucket_id, obj_key, null_yield, invalidStr);
+					    obj_func(dpp, key, version, deleteMarker, bucket_id, obj_key, instance, null_yield, invalidStr);
 					    block_func(dpp, key, offset, len, version, dirty, null_yield, localWeightStr);
 					    parsed = true;
                                         } // end-if dirtyStr == "1"
 				    } else if (parts.size() == 3) { //end-if parts.size() == 1
+                        std::string invalidStr;
+                        std::string etag, bucket_name;
+					    uint64_t size = 0;
+					    time_t creationTime = time_t(nullptr);
+					    rgw_user user;
+                        rgw::sal::Attrs attrs;
+                        get_attrs(dpp, file_entry.path(), attrs, null_yield);
+                        rgw_obj_key obj_key;
+                        obj_key.name = object_name;
+                        std::string instance;
+					    if (attrs.find(RGW_CACHE_ATTR_VERSION_ID) != attrs.end()) {
+						instance = attrs[RGW_CACHE_ATTR_VERSION_ID].to_str();
+						if (instance != "null") {
+						    obj_key.instance = instance;
+						}
+					    }
+					    if (attrs.find(RGW_CACHE_ATTR_OBJECT_NS) != attrs.end()) {
+						obj_key.ns = attrs[RGW_CACHE_ATTR_OBJECT_NS].to_str();
+					    }
+					    bool deleteMarker = false;
 					offset = std::stoull(parts[1]);
 					ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): offset: " << offset << dendl;
 
@@ -341,12 +330,19 @@ int SSDDriver::restore_blocks_objects(const DoutPrefixProvider* dpp, ObjectDataC
 					ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): key: " << key << dendl;
 
 					std::string localWeightStr;
-					auto ret = get_attr(dpp, file_entry.path(), RGW_CACHE_ATTR_LOCAL_WEIGHT, localWeightStr, null_yield);
-					if (ret < 0) {
-					    ldpp_dout(dpp, 0) << "SSDCache: " << __func__ << "(): Failed to get attr: " << RGW_CACHE_ATTR_LOCAL_WEIGHT << dendl;
-					} else {
-					    ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): localWeightStr: " << localWeightStr << dendl;
-					}
+					 if (attrs.find(RGW_CACHE_ATTR_LOCAL_WEIGHT) != attrs.end()) {
+                        localWeightStr = attrs[RGW_CACHE_ATTR_LOCAL_WEIGHT].to_str();
+                        ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): localWeightStr: " << localWeightStr << dendl;
+                    }
+                    if (attrs.find(RGW_CACHE_ATTR_INVALID) != attrs.end()) {
+                        invalidStr = attrs[RGW_CACHE_ATTR_INVALID].to_str();
+                        ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): invalidStr: " << invalidStr << dendl;
+                        //mark invalid data blocks as clean so that they are up for eviction.
+                        if (invalidStr == "1") {
+                            dirty = false;
+                        }
+                    }
+                    obj_func(dpp, key, version, deleteMarker, bucket_id, obj_key, instance, null_yield, invalidStr);
 					block_func(dpp, key, offset, len, version, dirty, null_yield, localWeightStr);
 					parsed = true;
 				    } 

--- a/src/rgw/rgw_ssd_driver.cc
+++ b/src/rgw/rgw_ssd_driver.cc
@@ -401,47 +401,6 @@ int SSDDriver::put(const DoutPrefixProvider* dpp, const std::string& key, const 
     return 0;
 }
 
-int SSDDriver::get(const DoutPrefixProvider* dpp, const std::string& key, off_t offset, uint64_t len, bufferlist& bl, rgw::sal::Attrs& attrs, optional_yield y)
-{
-    char buffer[len];
-    std::string location = create_dirs_get_filepath_from_key(dpp, partition_info.location, key);
-    ldpp_dout(dpp, 20) << __func__ << "(): location=" << location << dendl;
-    FILE *cache_file = nullptr;
-    int r = 0;
-    size_t nbytes = 0;
-
-    cache_file = fopen(location.c_str(), "r+");
-    if (cache_file == nullptr) {
-        ldpp_dout(dpp, 0) << "ERROR: get::fopen file has return error, errno=" << errno << dendl;
-        return -errno;
-    }
-
-    fseek(cache_file, offset, SEEK_SET);
-
-    nbytes = fread(buffer, 1, len, cache_file);
-    if (nbytes != len) {
-        fclose(cache_file);
-        ldpp_dout(dpp, 0) << "ERROR: get::io_read: fread has returned error: nbytes!=len, nbytes=" << nbytes << ", len=" << len << dendl;
-        return -EIO;
-    }
-
-    r = fclose(cache_file);
-    if (r != 0) {
-        ldpp_dout(dpp, 0) << "ERROR: get::fclose file has return error, errno=" << errno << dendl;
-        return -errno;
-    }
-
-    bl.append(buffer, len);
-
-    r = get_attrs(dpp, key, attrs, y);
-    if (r < 0) {
-        ldpp_dout(dpp, 0) << "ERROR: get::get_attrs: failed to get attrs, r = " << r << dendl;
-        return r;
-    }
-
-    return 0;
-}
-
 int SSDDriver::append_data(const DoutPrefixProvider* dpp, const::std::string& key, const bufferlist& bl_data, optional_yield y)
 {
     bufferlist src = bl_data;
@@ -608,6 +567,54 @@ rgw::AioResultList SSDDriver::put_async(const DoutPrefixProvider* dpp, optional_
     rgw_raw_obj r_obj;
     r_obj.oid = key;
     return aio->get(r_obj, ssd_cache_write_op(dpp, y, this, bl, len, attrs, key), cost, id);
+}
+
+int SSDDriver::get(const DoutPrefixProvider* dpp, const std::string& key, off_t offset, uint64_t len, bufferlist& bl, rgw::sal::Attrs& attrs, optional_yield y)
+{
+    std::string location = create_dirs_get_filepath_from_key(dpp, partition_info.location, key);
+    ldpp_dout(dpp, 20) << __func__ << "(): location=" << location << dendl;
+
+    if (y) {
+        using namespace boost::asio;
+        boost::system::error_code ec;
+        yield_context yield = y.get_yield_context();
+        auto ex = yield.get_executor();
+        bl = this->get_async(dpp, ex, key, offset, len, boost::asio::bind_executor(ex, yield[ec]));
+        if (ec) {
+            ldpp_dout(dpp, 0) << "ERROR: SSDCache: get_async failed, ec=" << ec.message() << dendl;
+            return -ec.value();
+        }
+    } else {
+        std::vector<char> buffer(len);
+        auto deleter = [](FILE* f) { fclose(f); };
+        auto cache_file = std::unique_ptr<FILE, decltype(deleter)>(
+            fopen(location.c_str(), "r+"), deleter);
+
+        if (cache_file == nullptr) {
+            ldpp_dout(dpp, 0) << "ERROR: get::fopen file has return error, errno=" << errno << dendl;
+            return -errno;
+        }
+
+        if (fseek(cache_file.get(), offset, SEEK_SET) != 0) {
+            ldpp_dout(dpp, 0) << "ERROR: get::fseek failed, errno=" << errno << dendl;
+            return -errno;
+        }
+
+        size_t nbytes = fread(buffer.data(), 1, len, cache_file.get());
+        if (nbytes != len) {
+            ldpp_dout(dpp, 0) << "ERROR: get::io_read: fread has returned error: nbytes!=len, nbytes=" << nbytes << ", len=" << len << dendl;
+            return -EIO;
+        }
+
+        bl.append(buffer.data(), len);
+    }
+
+    ldpp_dout(dpp, 20) << "INFO: get::bl length: = " << bl.length() << dendl;
+    if (auto r = get_attrs(dpp, location, attrs, y); r < 0) {
+        ldpp_dout(dpp, 0) << "ERROR: get::get_attrs: failed to get attrs, r = " << r << dendl;
+        return r;
+    }
+    return 0;
 }
 
 int SSDDriver::delete_data(const DoutPrefixProvider* dpp, const::std::string& key, optional_yield y)

--- a/src/rgw/rgw_ssd_driver.cc
+++ b/src/rgw/rgw_ssd_driver.cc
@@ -1,4 +1,3 @@
-#include <boost/asio/system_executor.hpp>
 #include "common/async/completion.h"
 #include "common/errno.h"
 #include "common/async/blocked_completion.h"
@@ -8,11 +7,12 @@
 #include <sys/xattr.h>
 #endif
 
-#include <filesystem>
 #include <errno.h>
 namespace efs = std::filesystem;
 
 namespace rgw { namespace cache {
+
+constexpr auto CHECK_INTERVAL = std::chrono::minutes(10);  // Check every 10 minutes
 
 static std::atomic<uint64_t> index{0};
 static std::atomic<uint64_t> dir_index{0};
@@ -111,6 +111,28 @@ static std::string create_dirs_get_filepath_from_key(const DoutPrefixProvider* d
 
 }
 
+/* This coroutine operates in a background thread to sync the free_space variable with efs::space.
+ * The efs::space call is expensive (especially under a lock) so this sync occurs every 10 minutes. */
+void SSDDriver::background_free_space_sync_worker(const DoutPrefixProvider* dpp, optional_yield y)
+{
+  ldpp_dout(dpp, 10) << "Background free_space co-routine started" << dendl;
+  while (!quit) {
+    free_space_timer->expires_after(CHECK_INTERVAL);
+    boost::system::error_code ec;
+    free_space_timer->async_wait(y.get_yield_context()[ec]);
+
+    if (ec == boost::asio::error::operation_aborted || quit.load()) {
+      break;
+    }
+
+    std::unique_lock<std::shared_mutex> l(cache_lock);
+    efs::space_info space = efs::space(partition_info.location);
+    free_space = (space.available < partition_info.reserve_size) ? 0 : (space.available - partition_info.reserve_size);
+
+    ldpp_dout(dpp, 20) << "SSDDriver:: " << __func__ << "(): free_space: " << free_space << dendl;
+  }
+}
+
 int SSDDriver::initialize(const DoutPrefixProvider* dpp)
 {
     if(partition_info.location.back() != '/') {
@@ -183,10 +205,30 @@ int SSDDriver::initialize(const DoutPrefixProvider* dpp)
     aio_init(&ainit);
     #endif
 
+    /* The free_space variable is to be set using efs::space only upon initialization in the main thread. Afterwards, it will 
+     * be updated during cache ops that handle data (not attributes) by adding/subtracting the size of the data itself.
+     * Recalibration of free_space occurs in a background thread every 10 minutes with additional efs::space calls to improve 
+     * cache performance while maintaining partition correctedness. */
     efs::space_info space = efs::space(partition_info.location);
-    //currently partition_info.size is unused
-    this->free_space = space.available;
+    free_space = (space.available < partition_info.reserve_size) ? 0 : (space.available - partition_info.reserve_size);
+    reserved_space = 0;
 
+    free_space_timer.emplace(io_context);
+    boost::asio::spawn(
+        io_context,
+        [this, dpp](boost::asio::yield_context yield) {
+          optional_yield y{yield};
+          background_free_space_sync_worker(dpp, y);
+        },
+        [this, dpp](std::exception_ptr e) {
+          if (e) {
+            free_space_done_promise.set_exception(e);
+          } else {
+            free_space_done_promise.set_value();
+          }
+          ldpp_dout(dpp, 10) << "Background free_space co-routine stopped" << dendl;
+      }
+    );
     return 0;
 }
 
@@ -226,6 +268,7 @@ int SSDDriver::restore_blocks_objects(const DoutPrefixProvider* dpp, ObjectDataC
                                 ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): parts.size(): " << parts.size() << dendl;
   
 				std::string dirtyStr;
+                                std::string bucket_name;
 				bool dirty;
 				auto ret = get_attr(dpp, file_entry.path(), RGW_CACHE_ATTR_DIRTY, dirtyStr, null_yield);
 				if (ret == 0 && dirtyStr == "1") {
@@ -272,7 +315,11 @@ int SSDDriver::restore_blocks_objects(const DoutPrefixProvider* dpp, ObjectDataC
 						user = std::get<rgw_user>(policy.get_owner().id);
 						ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): rgw_user: " << user.to_str() << dendl;
 					    }
-					    block_func(dpp, key, offset, len, version, false, user, null_yield, localWeightStr);
+											if (attrs.find(RGW_CACHE_ATTR_BUCKET_NAME) != attrs.end()) {
+												bucket_name = attrs[RGW_CACHE_ATTR_BUCKET_NAME].to_str();
+												ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): bucket_name: " << bucket_name << dendl;
+											}
+											block_func(dpp, key, offset, len, version, false, user, bucket_name, null_yield, localWeightStr);
 					    parsed = true;
 				        } else if (dirtyStr == "1") {
                             //we still have parsing for a head block because we maintain a head block only for delete markers
@@ -324,7 +371,7 @@ int SSDDriver::restore_blocks_objects(const DoutPrefixProvider* dpp, ObjectDataC
 					    }
 					    ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): calling func for: " << key << dendl;
 					    obj_func(dpp, key, version, deleteMarker, bucket_id, obj_key, instance, null_yield, invalidStr);
-					    block_func(dpp, key, offset, len, version, dirty, user, null_yield, localWeightStr);
+											block_func(dpp, key, offset, len, version, dirty, user, bucket_name, null_yield, localWeightStr);
 					    parsed = true;
                                         } // end-if dirtyStr == "1"
 				    } else if (parts.size() == 3) { //end-if parts.size() == 1
@@ -370,8 +417,12 @@ int SSDDriver::restore_blocks_objects(const DoutPrefixProvider* dpp, ObjectDataC
                             dirty = false;
                         }
                     }
+										if (attrs.find(RGW_CACHE_ATTR_BUCKET_NAME) != attrs.end()) {
+											bucket_name = attrs[RGW_CACHE_ATTR_BUCKET_NAME].to_str();
+											ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): bucket_name: " << bucket_name << dendl;
+										}
+										block_func(dpp, key, offset, len, version, dirty, user, bucket_name, null_yield, localWeightStr);
                     obj_func(dpp, key, version, deleteMarker, bucket_id, obj_key, instance, null_yield, invalidStr);
-					block_func(dpp, key, offset, len, version, dirty, user, null_yield, localWeightStr);
 					parsed = true;
 				    } 
 				    if (!parsed) {
@@ -396,14 +447,33 @@ int SSDDriver::restore_blocks_objects(const DoutPrefixProvider* dpp, ObjectDataC
 
 uint64_t SSDDriver::get_free_space(const DoutPrefixProvider* dpp, optional_yield y)
 {
-    efs::space_info space = efs::space(partition_info.location);
-    return (space.available < partition_info.reserve_size) ? 0 : (space.available - partition_info.reserve_size);
+	std::shared_lock<std::shared_mutex> l(cache_lock);
+	return (free_space < reserved_space) ? 0 : (free_space - reserved_space);
 }
 
-void SSDDriver::set_free_space(const DoutPrefixProvider* dpp, uint64_t free_space)
+int SSDDriver::reserve_space(const DoutPrefixProvider* dpp, uint64_t size, optional_yield y) 
 {
-    std::lock_guard l(cache_lock);
-    this->free_space = free_space;
+    std::unique_lock<std::shared_mutex> l(cache_lock);
+	reserved_space += size;
+	return 0;
+}
+
+int SSDDriver::check_and_reserve_space(const DoutPrefixProvider* dpp, uint64_t size, optional_yield y) 
+{
+    std::unique_lock<std::shared_mutex> l(cache_lock);
+	uint64_t visible = (free_space < reserved_space) ? 0 : (free_space - reserved_space);
+	if (visible < size) {
+		return -ENOSPC;
+	}
+	reserved_space += size;
+	return 0;
+}
+
+int SSDDriver::release_reservation(const DoutPrefixProvider* dpp, uint64_t size, optional_yield y) 
+{
+    std::unique_lock<std::shared_mutex> l(cache_lock);
+	reserved_space = (reserved_space < size) ? 0 : (reserved_space - size);
+	return 0;
 }
 
 int SSDDriver::put(const DoutPrefixProvider* dpp, const std::string& key, const bufferlist& bl, uint64_t len, const rgw::sal::Attrs& attrs, optional_yield y)
@@ -422,7 +492,15 @@ int SSDDriver::put(const DoutPrefixProvider* dpp, const std::string& key, const 
     if (ec) {
         return ec.value();
     }
-    return 0;
+
+    uint64_t size = len;
+    if (attrs.size()) {
+      size += XATTR_OVERHEAD_ESTIMATE;
+    } 
+	std::unique_lock<std::shared_mutex> l(cache_lock);
+    free_space = (free_space > size) ? (free_space - size) : 0;
+	reserved_space -= size;
+	return 0;
 }
 
 int SSDDriver::append_data(const DoutPrefixProvider* dpp, const::std::string& key, const bufferlist& bl_data, optional_yield y)
@@ -452,11 +530,10 @@ int SSDDriver::append_data(const DoutPrefixProvider* dpp, const::std::string& ke
         ldpp_dout(dpp, 0) << "ERROR: append_data::fclose file has return error, errno=" << errno << dendl;
         return -errno;
     }
-    std::lock_guard l(cache_lock);
-    efs::space_info space = efs::space(partition_info.location);
-    this->free_space = space.available;
-
-    return 0;
+	std::unique_lock<std::shared_mutex> l(cache_lock);
+    free_space = (free_space > bl_data.length()) ? (free_space - bl_data.length()) : 0;
+	reserved_space -= bl_data.length();
+	return 0;
 }
 
 template <typename Executor1, typename CompletionHandler>
@@ -648,6 +725,11 @@ int SSDDriver::delete_data(const DoutPrefixProvider* dpp, const::std::string& ke
     std::string location = get_file_path(dpp, dir_path, file_name);
     ldpp_dout(dpp, 20) << "INFO: delete_data::file to remove: " << location << dendl;
     std::error_code ec;
+	uint64_t size = 0;
+
+	if (efs::is_regular_file(location)) {
+		size = efs::file_size(location);
+	}
 
     //Remove file
     if (!efs::remove(location, ec)) {
@@ -676,11 +758,9 @@ int SSDDriver::delete_data(const DoutPrefixProvider* dpp, const::std::string& ke
             }
         }
     }
-
-    efs::space_info space = efs::space(partition_info.location);
-    this->free_space = space.available;
-
-    return 0;
+	std::unique_lock<std::shared_mutex> l(cache_lock);
+    free_space += size;
+	return 0;
 }
 
 int SSDDriver::rename(const DoutPrefixProvider* dpp, const::std::string& oldKey, const::std::string& newKey, optional_yield y)
@@ -766,10 +846,6 @@ void SSDDriver::AsyncWriteRequest::libaio_write_cb(sigval sigval) {
         }
     }
 
-    Partition partition_info = op.priv_data->get_current_partition_info(op.dpp);
-    efs::space_info space = efs::space(partition_info.location);
-    op.priv_data->set_free_space(op.dpp, space.available);
-
     ldpp_dout(op.dpp, 20) << "INFO: AsyncWriteRequest::libaio_write_yield_cb: new_path: " << op.file_path << dendl;
     ldpp_dout(op.dpp, 20) << "INFO: AsyncWriteRequest::libaio_write_yield_cb: old_path: " << op.temp_file_path << dendl;
 
@@ -842,8 +918,6 @@ int SSDDriver::update_attrs(const DoutPrefixProvider* dpp, const std::string& ke
         }
     }
 
-    efs::space_info space = efs::space(partition_info.location);
-    this->free_space = space.available;
     return 0;
 }
 
@@ -859,9 +933,6 @@ int SSDDriver::delete_attrs(const DoutPrefixProvider* dpp, const std::string& ke
             return ret;
         }
     }
-
-    efs::space_info space = efs::space(partition_info.location);
-    this->free_space = space.available;
 
     return 0;
 }
@@ -904,6 +975,7 @@ int SSDDriver::get_attrs(const DoutPrefixProvider* dpp, const std::string& key, 
         bl_value.append(attr_value);
         attrs.emplace(std::move(attr_name), std::move(bl_value));
     }
+
     return 0;
 }
 
@@ -929,9 +1001,6 @@ int SSDDriver::set_attrs(const DoutPrefixProvider* dpp, const std::string& key, 
             }
         }
     }
-
-    efs::space_info space = efs::space(partition_info.location);
-    this->free_space = space.available;
 
     return 0;
 }
@@ -1031,9 +1100,6 @@ int SSDDriver::set_attr(const DoutPrefixProvider* dpp, const std::string& key, c
         return ret;
     }
 
-    efs::space_info space = efs::space(partition_info.location);
-    this->free_space = space.available;
-
     return 0;
 }
 
@@ -1047,9 +1113,6 @@ int SSDDriver::delete_attr(const DoutPrefixProvider* dpp, const std::string& key
         ldpp_dout(dpp, 0) << "SSDCache: " << __func__ << "(): could not remove attr value for attr name: " << attr_name << " key: " << key << cpp_strerror(errno) << dendl;
         return ret;
     }
-
-    efs::space_info space = efs::space(partition_info.location);
-    this->free_space = space.available;
 
     return 0;
 }

--- a/src/rgw/rgw_ssd_driver.cc
+++ b/src/rgw/rgw_ssd_driver.cc
@@ -246,17 +246,33 @@ int SSDDriver::restore_blocks_objects(const DoutPrefixProvider* dpp, ObjectDataC
 				    ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): key: " << key << dendl;
 
 				    uint64_t len = 0, offset = 0;
+				    rgw_user user;
+				    rgw::sal::Attrs attrs;
 				    if (parts.size() == 1) {
+					get_attrs(dpp, file_entry.path(), attrs, null_yield);
 					if (dirtyStr == "0") {
 					    //non-dirty or clean blocks - version in head block and offset, len in data blocks
 					    std::string localWeightStr;
-					    ret = get_attr(dpp, file_entry.path(), RGW_CACHE_ATTR_LOCAL_WEIGHT, localWeightStr, null_yield);
-					    if (ret < 0) {
-						ldpp_dout(dpp, 0) << "SSDCache: " << __func__ << "(): Failed to get attr: " << RGW_CACHE_ATTR_LOCAL_WEIGHT << dendl;
-					    } else {
+					    if (attrs.find(RGW_CACHE_ATTR_LOCAL_WEIGHT) != attrs.end()) {
+                                                localWeightStr = attrs[RGW_CACHE_ATTR_LOCAL_WEIGHT].to_str();
 						ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): localWeightStr: " << localWeightStr << dendl;
+					    } else {
+						ldpp_dout(dpp, 0) << "SSDCache: " << __func__ << "(): Failed to get attr: " << RGW_CACHE_ATTR_LOCAL_WEIGHT << dendl;
+                                            }
+					    if (attrs.find(RGW_ATTR_ACL) != attrs.end()) {
+						bufferlist bl_acl = attrs[RGW_ATTR_ACL];
+						RGWAccessControlPolicy policy;
+						auto iter = bl_acl.cbegin();
+						try {
+						    policy.decode(iter);
+						} catch (buffer::error& err) {
+						    ldpp_dout(dpp, 0) << "ERROR: could not decode policy, caught buffer::error" << dendl;
+						    continue;
+						}
+						user = std::get<rgw_user>(policy.get_owner().id);
+						ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): rgw_user: " << user.to_str() << dendl;
 					    }
-					    block_func(dpp, key, offset, len, version, false, null_yield, localWeightStr);
+					    block_func(dpp, key, offset, len, version, false, user, null_yield, localWeightStr);
 					    parsed = true;
 				        } else if (dirtyStr == "1") {
                             //we still have parsing for a head block because we maintain a head block only for delete markers
@@ -293,10 +309,22 @@ int SSDDriver::restore_blocks_objects(const DoutPrefixProvider* dpp, ObjectDataC
 						invalidStr = attrs[RGW_CACHE_ATTR_INVALID].to_str();
 						ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): invalidStr: " << invalidStr << dendl;
 					    }
-
+					    if (attrs.find(RGW_ATTR_ACL) != attrs.end()) {
+						bufferlist bl_acl = attrs[RGW_ATTR_ACL];
+						RGWAccessControlPolicy policy;
+						auto iter = bl_acl.cbegin();
+						try {
+						    policy.decode(iter);
+						} catch (buffer::error& err) {
+						    ldpp_dout(dpp, 0) << "ERROR: could not decode policy, caught buffer::error" << dendl;
+						    continue;
+						}
+						user = std::get<rgw_user>(policy.get_owner().id);
+						ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): rgw_user: " << user.to_str() << dendl;
+					    }
 					    ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): calling func for: " << key << dendl;
 					    obj_func(dpp, key, version, deleteMarker, bucket_id, obj_key, instance, null_yield, invalidStr);
-					    block_func(dpp, key, offset, len, version, dirty, null_yield, localWeightStr);
+					    block_func(dpp, key, offset, len, version, dirty, user, null_yield, localWeightStr);
 					    parsed = true;
                                         } // end-if dirtyStr == "1"
 				    } else if (parts.size() == 3) { //end-if parts.size() == 1
@@ -343,7 +371,7 @@ int SSDDriver::restore_blocks_objects(const DoutPrefixProvider* dpp, ObjectDataC
                         }
                     }
                     obj_func(dpp, key, version, deleteMarker, bucket_id, obj_key, instance, null_yield, invalidStr);
-					block_func(dpp, key, offset, len, version, dirty, null_yield, localWeightStr);
+					block_func(dpp, key, offset, len, version, dirty, user, null_yield, localWeightStr);
 					parsed = true;
 				    } 
 				    if (!parsed) {

--- a/src/rgw/rgw_ssd_driver.h
+++ b/src/rgw/rgw_ssd_driver.h
@@ -3,13 +3,19 @@
 #include <aio.h>
 #include "rgw_common.h"
 #include "rgw_cache_driver.h"
+#include <filesystem>
+#include <shared_mutex>
+#include <boost/asio.hpp>
 
+namespace efs = std::filesystem;
 namespace rgw { namespace cache {
+
+static constexpr size_t XATTR_OVERHEAD_ESTIMATE = 4096;
 
 class SSDDriver : public CacheDriver {
 public:
-  SSDDriver(Partition& partition_info, bool admin) : partition_info(partition_info), admin(admin) {}
-  virtual ~SSDDriver() {}
+  SSDDriver(Partition& partition_info, boost::asio::io_context& io_context, bool admin) : partition_info(partition_info), io_context(io_context), admin(admin) {}
+  virtual ~SSDDriver() { quit = true; }
 
   virtual int initialize(const DoutPrefixProvider* dpp) override;
   virtual int put(const DoutPrefixProvider* dpp, const std::string& key, const bufferlist& bl, uint64_t len, const rgw::sal::Attrs& attrs, optional_yield y) override;
@@ -30,15 +36,22 @@ public:
   /* Partition */
   virtual Partition get_current_partition_info(const DoutPrefixProvider* dpp) override { return partition_info; }
   virtual uint64_t get_free_space(const DoutPrefixProvider* dpp, optional_yield y) override;
-  void set_free_space(const DoutPrefixProvider* dpp, uint64_t free_space);
+  virtual int reserve_space(const DoutPrefixProvider* dpp, uint64_t size, optional_yield y) override;
+  virtual int check_and_reserve_space(const DoutPrefixProvider* dpp, uint64_t size, optional_yield y) override;
+  virtual int release_reservation(const DoutPrefixProvider* dpp, uint64_t size, optional_yield y) override;
 
   virtual int restore_blocks_objects(const DoutPrefixProvider* dpp, ObjectDataCallback obj_func, BlockDataCallback block_func) override;
 
 private:
   Partition partition_info;
-  uint64_t free_space;
+  std::atomic<uint64_t> free_space;
+  uint64_t reserved_space;
+  boost::asio::io_context& io_context;
   CephContext* cct;
-  std::mutex cache_lock;
+  std::shared_mutex cache_lock;
+  std::optional<boost::asio::steady_timer> free_space_timer;
+  std::promise<void> free_space_done_promise;
+  inline static std::atomic<bool> quit{false};
   bool admin;
 
   struct libaio_read_handler {
@@ -72,6 +85,8 @@ private:
       delete c;
     }
   };
+
+  void background_free_space_sync_worker(const DoutPrefixProvider* dpp, optional_yield y);
 
   template <typename Executor, typename CompletionToken>
     auto get_async(const DoutPrefixProvider *dpp, const Executor& ex, const std::string& key,

--- a/src/test/rgw/test_d4n_directory.cc
+++ b/src/test/rgw/test_d4n_directory.cc
@@ -34,7 +34,7 @@ class Environment : public ::testing::Environment {
       cct = common_preinit(iparams, CODE_ENVIRONMENT_UTILITY, {}); 
       dpp = new DoutPrefix(cct->get(), dout_subsys, "D4N Object Directory Test: ");
       
-      redisHost = cct->_conf->rgw_d4n_address; 
+      redisHost = cct->_conf->rgw_d4n_l1_datacache_address; 
     }
     
     void TearDown() override {

--- a/src/test/rgw/test_d4n_filter.cc
+++ b/src/test/rgw/test_d4n_filter.cc
@@ -64,7 +64,7 @@ class Environment : public ::testing::Environment {
 
       dpp = new DoutPrefix(cct->get(), dout_subsys, "D4N Object Directory Test: ");
 
-      redisHost = cct->_conf->rgw_d4n_address; 
+      redisHost = cct->_conf->rgw_d4n_l1_datacache_address; 
     }
 
     virtual void TearDown() {

--- a/src/test/rgw/test_d4n_policy.cc
+++ b/src/test/rgw/test_d4n_policy.cc
@@ -38,7 +38,7 @@ class Environment : public ::testing::Environment {
       dpp = new DoutPrefix(cct->get(), dout_subsys, "D4N Policy Test: ");
       common_init_finish(g_ceph_context);
       
-      redisHost = cct->_conf->rgw_d4n_address; 
+      redisHost = cct->_conf->rgw_d4n_l1_datacache_address; 
     }
 
     std::string redisHost;

--- a/src/test/rgw/test_d4n_policy.cc
+++ b/src/test/rgw/test_d4n_policy.cc
@@ -83,7 +83,6 @@ class LFUDAPolicyFixture : public ::testing::Test {
       ASSERT_NE(policyDriver, nullptr);
       ASSERT_NE(conn, nullptr);
 
-      env->cct->_conf->rgw_d4n_l1_datacache_address = "127.0.0.1:6379";
       cacheDriver->initialize(env->dpp);
 
       bl.append("test data");
@@ -114,7 +113,7 @@ class LFUDAPolicyFixture : public ::testing::Test {
       std::string oid = rgw::sal::get_key_in_cache(get_prefix(block->cacheObj.bucketName, block->cacheObj.objName, version), std::to_string(block->blockID), std::to_string(block->size));
 
       if (this->policyDriver->get_cache_policy()->exist_key(oid)) { /* Local copy */
-        policyDriver->get_cache_policy()->update(env->dpp, oid, 0, TEST_DATA_LENGTH, "", false, rgw::d4n::RefCount::NOOP, y);
+		policyDriver->get_cache_policy()->update(env->dpp, oid, 0, TEST_DATA_LENGTH, "", false, uid, block->cacheObj.bucketName, rgw::d4n::RefCount::NOOP, y);
         return 0;
       } else {
         if (this->policyDriver->get_cache_policy()->eviction(dpp, block->size, y) < 0)
@@ -142,7 +141,7 @@ class LFUDAPolicyFixture : public ::testing::Test {
           if (dir->set(env->dpp, block, y) < 0)
             return -1;
 
-          this->policyDriver->get_cache_policy()->update(dpp, oid, 0, TEST_DATA_LENGTH, "", false, rgw::d4n::RefCount::NOOP, y);
+		  this->policyDriver->get_cache_policy()->update(dpp, oid, 0, TEST_DATA_LENGTH, "", false, uid, block->cacheObj.bucketName, rgw::d4n::RefCount::NOOP, y);
           if (cacheDriver->put(dpp, oid, bl, TEST_DATA_LENGTH, attrs, y) < 0)
             return -1;
           return cacheDriver->set_attr(dpp, oid, "localWeight", std::to_string(age), y);
@@ -157,6 +156,7 @@ class LFUDAPolicyFixture : public ::testing::Test {
     rgw::d4n::PolicyDriver* policyDriver;
     rgw::cache::RedisDriver* cacheDriver;
     rgw::sal::D4NFilterDriver* driver = nullptr;
+	rgw_user uid{"test_tenant", "test"};
 
     net::io_context io;
     std::shared_ptr<connection> conn;
@@ -266,7 +266,7 @@ TEST_F(LFUDAPolicyFixture, LocalGetBlockYield)
     std::string version;
     std::string key = rgw::sal::get_key_in_cache(get_prefix(block->cacheObj.bucketName, block->cacheObj.objName, version), std::to_string(block->blockID), std::to_string(block->size));
     ASSERT_EQ(0, cacheDriver->put(env->dpp, key, bl, TEST_DATA_LENGTH, attrs, optional_yield{yield}));
-    policyDriver->get_cache_policy()->update(env->dpp, key, 0, TEST_DATA_LENGTH, "", false, rgw::d4n::RefCount::NOOP, optional_yield{yield});
+	policyDriver->get_cache_policy()->update(env->dpp, key, 0, TEST_DATA_LENGTH, "", false, uid, block->cacheObj.bucketName, rgw::d4n::RefCount::NOOP, optional_yield{yield});
 
     ASSERT_EQ(lfuda(env->dpp, block, cacheDriver, yield), 0);
 
@@ -299,7 +299,6 @@ TEST_F(LFUDAPolicyFixture, EvictionYield)
     TestRedisDriver testDriver(io, partition_info);
     rgw::d4n::PolicyDriver policyDriver(conn, &testDriver, "lfuda", optional_yield{yield});
 
-    env->cct->_conf->rgw_d4n_l1_datacache_address = "127.0.0.1:6379";
     testDriver.initialize(env->dpp);
     policyDriver.get_cache_policy()->init(env->cct, env->dpp, io, driver);
 
@@ -334,7 +333,7 @@ TEST_F(LFUDAPolicyFixture, EvictionYield)
     std::string victimKeyInCache = rgw::sal::get_key_in_cache(get_prefix(victim.cacheObj.bucketName, victim.cacheObj.objName, victim.version), 
                                                                std::to_string(victim.blockID), std::to_string(TEST_DATA_LENGTH));
     ASSERT_EQ(0, testDriver.put(env->dpp, victimKeyInCache, bl, TEST_DATA_LENGTH, attrs, optional_yield{yield}));
-    policyDriver.get_cache_policy()->update(env->dpp, victimKeyInCache, 0, TEST_DATA_LENGTH, victim.version, false, rgw::d4n::RefCount::NOOP, optional_yield{yield});
+	policyDriver.get_cache_policy()->update(env->dpp, victimKeyInCache, 0, TEST_DATA_LENGTH, victim.version, false, uid, block->cacheObj.bucketName, rgw::d4n::RefCount::NOOP, optional_yield{yield});
 
     ASSERT_EQ(0, dir->set(env->dpp, &victim, optional_yield{yield}));
 

--- a/src/test/rgw/test_redis_driver.cc
+++ b/src/test/rgw/test_redis_driver.cc
@@ -74,7 +74,7 @@ class Environment : public ::testing::Environment {
       cct = common_preinit(iparams, CODE_ENVIRONMENT_UTILITY, {});
       dpp = new DoutPrefix(cct->get(), dout_subsys, "D4N Object Directory Test: ");
 
-      redisHost = cct->_conf->rgw_d4n_address; 
+      redisHost = cct->_conf->rgw_d4n_l1_datacache_address; 
     }
 
     std::string redisHost;


### PR DESCRIPTION
Currently working on completing the LFUDA `eviction` logic by adding code to push the victim block to a remote cache of interest.
 
Relevant changes: 
- I removed the `D_` prefix for dirty objects because this is no longer used.
- Head objects are not explicitly deleted when data blocks are evicted
- The bucket name is now stored in the `LFUDAEntry` structure because it is needed for remote PUTs

TODO:
- Update unit tests
- Create test suite

## Local Testing
Script (please modify according to your own environment):
```
ps cax | grep valkey-server > /dev/null
if [ $? -eq 0 ];
then
  echo "Redis process found; flushing!"
  valkey-cli FLUSHALL
else
  valkey-server --daemonize yes
fi
sudo ../src/stop.sh
rm -rf /tmp/rgw_d4n_datacache
mkdir /tmp/rgw_d4n_datacache
rm -rf /tmp/rgw_d4n_datacache_c2
mkdir /tmp/rgw_d4n_datacache_c2
MON=1 OSD=1 RGW=2 MGR=0 MDS=0 ../src/vstart.sh -n -d -o rgw_filter=d4n -o d4n_writecache_enabled=true -o rgw_d4n_cache_cleaning_interval=5 -o rgw_d4n_l1_evict_cache_on_start=false -o rgw_d4n_directory_address=127.0.0.1:6379 -o rgw_d4n_thread_pool_size=8

# ceph.conf changes for the local RGW
sed -i "64i\        rgw_d4n_local_rgw_address = 127.0.0.1:8000\n        rgw_d4n_remote_cache_address = 127.0.0.1:8001\n        rgw_d4n_remote_put = false" ceph.conf

# ceph.conf changes for the remote RGW
sed -i "69i\        rgw_d4n_local_rgw_address = 127.0.0.1:8001\n        rgw_d4n_l1_datacache_persistent_path = /tmp/rgw_d4n_datacache_c2/\n        rgw_d4n_remote_cache_address = 127.0.0.1:8000\n        rgw_d4n_remote_put = false" ceph.conf

# restart both
kill -9 $(cat out/radosgw.8000.pid)
kill -9 $(cat out/radosgw.8001.pid)
/ceph/build/bin/radosgw -c /ceph/build/ceph.conf --log-file=/ceph/build/out/radosgw.8000.log --admin-socket=/ceph/build/out/radosgw.8000.asok --pid-file=/ceph/build/out/radosgw.8000.pid --rgw_luarocks_location=/ceph/build/out/radosgw.8000.luarocks --debug-rgw=20 --debug-rgw-lifecycle=20 --debug-ms=1 -n client.rgw.8000 --rgw_frontends="beast port=8000"
/ceph/build/bin/radosgw -c /ceph/build/ceph.conf --log-file=/ceph/build/out/radosgw.8001.log --admin-socket=/ceph/build/out/radosgw.8001.asok --pid-file=/ceph/build/out/radosgw.8001.pid --rgw_luarocks_location=/ceph/build/out/radosgw.8001.luarocks --debug-rgw=20 --debug-rgw-lifecycle=20 --debug-ms=1 -n client.rgw.8001 --rgw_frontends="beast port=8001"

touch test.txt
echo "hello world" > test.txt
./bin/radosgw-admin -c ceph.conf user create --uid=test3 --display-name=test3 --access-key=test3 --secret-key=test3
s3cmd --access_key=test3 --secret_key=test3 --host=127.0.0.1:8000 mb s3://bkt
s3cmd --access_key=test3 --secret_key=test3 --host=127.0.0.1:8000 put ./test.txt s3://bkt

# trigger eviction of first object (requires first object to be clean)
touch test_2.txt
echo "hello world! again" > test_2.txt
sleep 10
s3cmd --access_key=test3 --secret_key=test3 --host=127.0.0.1:8000 put ./test_2.txt s3://bkt
```

After running this script, you can confirm the remote eviction workflow succeeded with the following checks:
1. Check the datacache of the local rgw to ensure there is no data block for `test.txt`
2. Check the datacache of the remote rgw to ensure it contains the data block for `test.txt` and no head object
3. Check the valkey directory to ensure the data block entry for `test.txt` has the remote rgw address under its `hostsList` and not the local rgw address