### PR TITLE
D4N policy updates

### DIFF
--- a/src/rgw/driver/d4n/d4n_policy.cc
+++ b/src/rgw/driver/d4n/d4n_policy.cc
@@ -517,7 +517,6 @@ int LFUDAPolicy::eviction(const DoutPrefixProvider* dpp, uint64_t size, optional
     }
 
     std::string object_name = block.cacheObj.objName; // without version
-    bool is_versioned = false;
     bufferlist out_bl;
 	rgw::sal::Attrs obj_attrs;
 	int ret = cacheDriver->get(dpp, entry.key, block.blockID, block.size, out_bl, obj_attrs, y);
@@ -525,13 +524,14 @@ int LFUDAPolicy::eviction(const DoutPrefixProvider* dpp, uint64_t size, optional
 	  ldpp_dout(dpp, 0) << "ERROR: " << __func__ << "(): " << __LINE__ << ": Failed to retrieve victim data block from cache." << dendl;
 	  return ret;
 	} 
-    
+
+    std::string instance_id = "";
 	if (obj_attrs.contains(RGW_CACHE_ATTR_VERSION_ID)) {
-	  is_versioned = true;
-	  std::string instance = obj_attrs.at(RGW_CACHE_ATTR_VERSION_ID).to_str();
-	  if (instance != "null") {
-		block.cacheObj.objName = "_:" + instance + "_" + block.cacheObj.objName;
+	  instance_id = obj_attrs.at(RGW_CACHE_ATTR_VERSION_ID).to_str();
+	  if (instance_id != "null") {
+		block.cacheObj.objName = "_:" + instance_id + "_" + block.cacheObj.objName;
 	  } // null version is not part of the data block's objName
+	  ldpp_dout(dpp, 20) << "LFUDAPolicy::" << __func__ << "(): Info: populating remote op instance ID with " << instance_id << dendl;
 	}
 
 	bufferlist bl = obj_attrs[RGW_CACHE_ATTR_INVALID];
@@ -565,7 +565,7 @@ int LFUDAPolicy::eviction(const DoutPrefixProvider* dpp, uint64_t size, optional
 			  entry.user,
 			  remoteCacheAddress,
 			  block.cacheObj.size,
-			  is_versioned
+              instance_id
 			};
 			std::unique_ptr<rgw::d4n::RemoteCachePutOp> remote_put = std::make_unique<rgw::d4n::RemoteCachePutOp>(driver, op, true);
 			if ((ret = remote_put->send_and_complete_request(dpp, y, &out_bl)) < 0){

--- a/src/rgw/driver/d4n/d4n_remote_cache_manager.cc
+++ b/src/rgw/driver/d4n/d4n_remote_cache_manager.cc
@@ -26,12 +26,14 @@ int RemoteCacheGetOp::send_request(const DoutPrefixProvider* dpp, optional_yield
 
   HostStyle host_style = PathStyle;
   std::map<std::string, std::string> extra_headers;
+  extra_headers["x-rgw-remote-cache-request"] = "true";
+  extra_headers["x-rgw-cache-obj-version"] = op.version;
   uint64_t end_offset = op.offset + op.len - 1;
   std::string range_val = "bytes=" + std::to_string(op.offset) + "-" + std::to_string(end_offset);
   extra_headers["RANGE"] = std::move(range_val);
   param_vec_t params;
-  if (op.is_bucket_versioned) {
-    params.push_back(param_pair_t("versionId", op.version));
+  if (op.instance_id.size()) {
+	params.push_back(param_pair_t("versionId", op.instance_id));
   }
 
   auto resource = get_resource(op.bucket_name, op.object_name);
@@ -74,13 +76,15 @@ rgw::AioResultList RemoteCacheGetOp::send_request(const DoutPrefixProvider* dpp,
 
     HostStyle host_style = PathStyle;
     std::map<std::string, std::string> extra_headers;
+	extra_headers["x-rgw-remote-cache-request"] = "true";
+	extra_headers["x-rgw-cache-object-version"] = op.version;
     uint64_t end_offset = op.offset + op.len - 1;
     std::string range_val = "bytes=" + std::to_string(op.offset) + "-" + std::to_string(end_offset);
     extra_headers["RANGE"] = std::move(range_val);
     param_vec_t params;
-    if (op.is_bucket_versioned) {
-      params.push_back(param_pair_t("versionId", op.version));
-    }
+	if (op.instance_id.size()) {
+	  params.push_back(param_pair_t("versionId", op.instance_id));
+	}
     auto resource = get_resource(op.bucket_name, op.object_name);
     sender = std::make_unique<RGWRESTStreamRWRequest>(dpp->get_cct(), "GET", op.remote_addr, &cb, nullptr, &params, "", host_style);
 

--- a/src/rgw/driver/d4n/d4n_remote_cache_manager.h
+++ b/src/rgw/driver/d4n/d4n_remote_cache_manager.h
@@ -36,12 +36,12 @@ class RemoteCacheOp {
       std::string object_name;
       uint64_t offset = 0;
       uint64_t len = 0;
-      std::string version;
+      std::string version; // Cache version (equivalent to "instance_id" param in versioning enabled buckets)
 	  bool dirty{false};
       rgw_user bucket_owner;
       std::string remote_addr;
       uint64_t obj_size = 0;
-      bool is_bucket_versioned{false};
+      std::string instance_id = "";
     };
     RemoteCacheOp(rgw::sal::Driver* driver, RemoteCacheOpData& op) : driver(driver), op(op), cb(in_bl) {}
     virtual ~RemoteCacheOp() = default; 

--- a/src/rgw/driver/d4n/rgw_sal_d4n.cc
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.cc
@@ -2010,6 +2010,12 @@ bool D4NFilterObject::check_head_exists_in_cache_get_oid(const DoutPrefixProvide
   int ret;
   //if the block corresponding to head object does not exist in directory, implies it is not cached
   if ((ret = blockDir->get(dpp, &block, y)) == 0) {
+    if (this->is_remote_cache_request()) {
+      if (block.version != get_object_version()) {
+        ldpp_dout(dpp, 10) << "D4NFilterObject:: " << __func__ << "(): Error: Version mismatch" << dendl;
+        return -EINVAL;
+      }
+    }
     blk = block;
 
     std::string version;
@@ -2453,6 +2459,15 @@ int D4NFilterObject::D4NFilterReadOp::flush(const DoutPrefixProvider* dpp, rgw::
           } else {
             write_to_local_cache = false;
           }
+          // TODO: Add DIRTY attr as well
+          bufferlist bl_val;
+          if (source->have_instance()) {
+            bl_val.append(source->get_instance());
+            attrs[RGW_CACHE_ATTR_VERSION_ID] = std::move(bl_val);
+          }
+          bl_val.clear();
+          bl_val.append(source->get_key().ns);
+          attrs[RGW_CACHE_ATTR_OBJECT_NS] = std::move(bl_val);
         } else { // for copy object
           bl_val.append("1");
           attrs[RGW_CACHE_ATTR_DIRTY] = std::move(bl_val);
@@ -2657,6 +2672,11 @@ int D4NFilterObject::D4NFilterReadOp::iterate(const DoutPrefixProvider* dpp, int
           if (hostsListSize > 0) { /* Remote copy */
             ldpp_dout(dpp, 20) << "D4NFilterObject::iterate:: " << __func__ << "(): Block with oid=" << oid_in_cache << " found in remote cache." << dendl;
             auto& user = source->get_bucket()->get_owner();
+            std::string instance_id = "";
+            if (source->have_instance()) {
+              instance_id = source->get_instance(); 
+              ldpp_dout(dpp, 20) << "D4NFilterObject::iterate:: " << __func__ << "(): Info: populating remote op instance ID with " << instance_id << dendl;
+            }
             std::string remote_addr = *(block.cacheObj.hostsList.begin());
             if (!dpp->get_cct()->_conf->rgw_d4n_remote_async_get) {
               ldpp_dout(dpp, 20) << "D4NFilterObject::iterate:: " << __func__ << "(): Info: remote_addr: " << remote_addr << dendl;
@@ -2668,7 +2688,9 @@ int D4NFilterObject::D4NFilterReadOp::iterate(const DoutPrefixProvider* dpp, int
                   version,
                   block.cacheObj.dirty,
                   std::get<rgw_user>(user),
-                  remote_addr
+                  remote_addr,
+                  block.cacheObj.size,
+                  instance_id
                 };
               std::unique_ptr<rgw::d4n::RemoteCacheGetOp> remote_get = std::make_unique<rgw::d4n::RemoteCacheGetOp>(source->driver, op);
               auto completed = remote_get->send_and_complete_request(dpp, aio.get(), cost, id, y);
@@ -2707,6 +2729,8 @@ int D4NFilterObject::D4NFilterReadOp::iterate(const DoutPrefixProvider* dpp, int
                 driver = source->driver,
                 aio_shared = aio,
                 dirty = block.cacheObj.dirty,
+                objSize = block.cacheObj.size,
+                instance_id = instance_id,
                 this]
                 (boost::asio::yield_context yield) mutable {
                 optional_yield y(yield);
@@ -2731,7 +2755,9 @@ int D4NFilterObject::D4NFilterReadOp::iterate(const DoutPrefixProvider* dpp, int
                       version,
                       dirty,
                       usr,
-                      remote_addr
+                      remote_addr,
+                      objSize,
+                      instance_id
                     };
                   std::unique_ptr<rgw::d4n::RemoteCacheGetOp> remote_get = std::make_unique<rgw::d4n::RemoteCacheGetOp>(driver, op);
                   task_result->result_list = remote_get->send_and_complete_request(dpp_local.get(), aio_shared.get(), cost, id, y);
@@ -3441,9 +3467,6 @@ int D4NFilterWriter::prepare(optional_yield y)
   } else {
     //for non-versioned buckets or version suspended buckets, we need to delete the older dirty blocks of the object from the cache as dirty blocks do not get evicted
     if (!object->get_bucket()->versioned() || (object->get_bucket()->versioned() && !object->get_bucket()->versioning_enabled())) {
-      if (object->get_bucket()->versioned() && !object->get_bucket()->versioning_enabled()) {
-        object->set_instance("null");
-      }
       rgw::d4n::CacheBlock block;
       rgw::sal::Attrs attrs;
       if (object->check_head_exists_in_cache_get_oid(dpp, prev_oid_in_cache, attrs, block, y)) {

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2723,6 +2723,18 @@ void RGWGetObj::execute(optional_yield y)
   }
   if (s->info.env->get_optional("HTTP_X_RGW_CACHE_REQUEST"))
     s->object->set_cache_request();
+#ifdef RGW_HAVE_D4N_FILTER
+  if (g_conf().get_val<std::string>("rgw_filter") == "d4n") {
+    if (s->info.env->get_optional("HTTP_X_RGW_REMOTE_CACHE_REQUEST")) {
+      rgw::sal::D4NFilterObject* d4n_obj = dynamic_cast<rgw::sal::D4NFilterObject*>(s->object.get());
+      d4n_obj->set_remote_cache_request();
+      auto object_version = s->info.env->get_optional("HTTP_X_RGW_CACHE_OBJECT_VERSION");
+      if (object_version) {
+        d4n_obj->set_object_version(object_version.get());
+      }
+    }
+  }
+#endif
 
   op_ret = read_op->prepare(s->yield, this);
   version_id = s->object->get_instance();
@@ -4882,7 +4894,6 @@ void RGWPutObj::execute(optional_yield y)
 #ifdef RGW_HAVE_D4N_FILTER
   if (g_conf().get_val<std::string>("rgw_filter") == "d4n") {
     if (s->info.env->get_optional("HTTP_X_RGW_REMOTE_CACHE_REQUEST")) {
-      ldpp_dout(this, 20) << "This is a remote cache request !!!" << dendl;
       dynamic_cast<rgw::sal::D4NFilterWriter*>(processor.get())->set_remote_cache_request();
       rgw::sal::D4NFilterObject* d4n_obj = dynamic_cast<rgw::sal::D4NFilterObject*>(s->object.get());
       auto object_version = s->info.env->get_optional("HTTP_X_RGW_CACHE_OBJECT_VERSION");
@@ -4904,7 +4915,7 @@ void RGWPutObj::execute(optional_yield y)
       }
       if (auto block_only = s->info.env->get_optional("HTTP_X_RGW_CACHE_BLOCK_ONLY"); block_only) {
         if (block_only.get() == "true") {
-	      d4n_obj->set_remote_block_only(true);
+          d4n_obj->set_remote_block_only(true);
         }
       }
     }
@@ -6062,7 +6073,6 @@ void RGWDeleteObj::execute(optional_yield y)
 #ifdef RGW_HAVE_D4N_FILTER
   if (g_conf().get_val<std::string>("rgw_filter") == "d4n") {
     if (s->info.env->get_optional("HTTP_X_RGW_REMOTE_CACHE_REQUEST")) {
-      ldpp_dout(this, 20) << "This is a remote cache request !!!" << dendl;
       rgw::sal::D4NFilterObject* d4n_obj = dynamic_cast<rgw::sal::D4NFilterObject*>(s->object.get());
       d4n_obj->set_remote_cache_request();
     }

--- a/src/rgw/rgw_ssd_driver.cc
+++ b/src/rgw/rgw_ssd_driver.cc
@@ -500,36 +500,38 @@ int SSDDriver::initialize(const DoutPrefixProvider* dpp)
      * be updated during cache ops that handle data (not attributes) by adding/subtracting the size of the data itself.
      * Recalibration of free_space occurs in a background thread every 10 minutes with additional efs::space calls to improve 
      * cache performance while maintaining partition correctedness. */
-    try {
-        efs::space_info space = efs::space(partition_info.location);
-        partition_info.size = space.capacity - partition_info.reserve_size;
-        free_space = calculate_free_space(space.available, partition_info.reserve_size);
-    } catch (const efs::filesystem_error& e) {
-        ldpp_dout(dpp, 0) << "initialize::: ERROR initializing the cache storage space info: " << e.what() << dendl;
-        return -EINVAL;
-    }
-    reserved_space = 0;
-    ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): reserved_space=" << reserved_space << dendl;
+    if (!admin) {
+	  try {
+		  efs::space_info space = efs::space(partition_info.location);
+		  partition_info.size = space.capacity - partition_info.reserve_size;
+		  free_space = calculate_free_space(space.available, partition_info.reserve_size);
+	  } catch (const efs::filesystem_error& e) {
+		  ldpp_dout(dpp, 0) << "initialize::: ERROR initializing the cache storage space info: " << e.what() << dendl;
+		  return -EINVAL;
+	  }
+	  reserved_space = 0;
+	  ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): reserved_space=" << reserved_space << dendl;
 
-    free_space_timer.emplace(io_context);
-    free_space_worker_started = true;
-    boost::asio::spawn(
-        io_context,
-        [this, dpp](boost::asio::yield_context yield) {
-          optional_yield y{yield};
-          background_free_space_sync_worker(dpp, y);
-        },
-        [this, dpp](std::exception_ptr e) {
-            ldpp_dout(dpp, 10) << "SSDDriver: free_space worker done" << dendl;
-            try {
-                if (e) free_space_done_promise.set_exception(e);
-                else   free_space_done_promise.set_value();
-            } catch (const std::future_error& fe) {
-                ldpp_dout(dpp, 0) << "SSDDriver: DOUBLE SET: " << fe.what() << dendl;
-            }
-            ldpp_dout(dpp, 10) << "Background free_space co-routine stopped" << dendl;
-      }
-    );
+	  free_space_timer.emplace(io_context);
+	  free_space_worker_started = true;
+	  boost::asio::spawn(
+		  io_context,
+		  [this, dpp](boost::asio::yield_context yield) {
+			optional_yield y{yield};
+			background_free_space_sync_worker(dpp, y);
+		  },
+		  [this, dpp](std::exception_ptr e) {
+			  ldpp_dout(dpp, 10) << "SSDDriver: free_space worker done" << dendl;
+			  try {
+				  if (e) free_space_done_promise.set_exception(e);
+				  else   free_space_done_promise.set_value();
+			  } catch (const std::future_error& fe) {
+				  ldpp_dout(dpp, 0) << "SSDDriver: DOUBLE SET: " << fe.what() << dendl;
+			  }
+			  ldpp_dout(dpp, 10) << "Background free_space co-routine stopped" << dendl;
+		}
+	  );
+    }
     return 0;
 }
 

--- a/src/test/rgw/test_d4n_policy.cc
+++ b/src/test/rgw/test_d4n_policy.cc
@@ -93,14 +93,22 @@ class LFUDAPolicyFixture : public ::testing::Test {
       };
 
       conn = std::make_shared<connection>(boost::asio::make_strand(io));
-	  redis_native = std::make_shared<rgw::d4n::RedisConnection>(conn);
+	  auto redis_native = std::make_shared<rgw::d4n::RedisConnection>(conn);
       redis_conn = std::dynamic_pointer_cast<rgw::d4n::RedisConnection>(redis_native);
       rgw::cache::Partition partition_info{ .location = "RedisCache", .reserve_size = 1073741824 };
       cacheDriver = new rgw::cache::RedisDriver{io, partition_info};
-      policyDriver = new rgw::d4n::PolicyDriver(redis_native, "redis", cacheDriver, "lfuda", null_yield);
-      dir = new rgw::d4n::RedisBlockDirectory{redis_conn};
+
+	  dir = std::make_unique<rgw::d4n::RedisDirectory>(redis_conn);
+      blockDir = new rgw::d4n::RedisBlockDirectory{redis_conn};
+      objDir = new rgw::d4n::RedisObjectDirectory{redis_conn};
+      bucketDir = new rgw::d4n::RedisBucketDirectory{redis_conn};
+
+      policyDriver = new rgw::d4n::PolicyDriver(*dir, *blockDir, *objDir, *bucketDir, "redis", cacheDriver, "lfuda", null_yield);
 
       ASSERT_NE(dir, nullptr);
+      ASSERT_NE(blockDir, nullptr);
+      ASSERT_NE(objDir, nullptr);
+      ASSERT_NE(bucketDir, nullptr);
       ASSERT_NE(cacheDriver, nullptr);
       ASSERT_NE(policyDriver, nullptr);
       ASSERT_NE(conn, nullptr);
@@ -122,7 +130,9 @@ class LFUDAPolicyFixture : public ::testing::Test {
 
     virtual void TearDown() {
       delete block;
-      delete dir;
+      delete blockDir;
+      delete objDir;
+      delete bucketDir;
       
       if (policyDriver)
         delete policyDriver;
@@ -144,7 +154,7 @@ class LFUDAPolicyFixture : public ::testing::Test {
 		policyDriver->get_cache_policy()->update(env->dpp, oid, 0, TEST_DATA_LENGTH, "", std::nullopt, uid, block->cacheObj.bucketName, rgw::d4n::RefCount::NOOP, y, nullptr);
         return 0;
       } else {
-		if ((ret = dir->get(env->dpp, block, y)) < 0 && ret != -ENOENT) {
+		if ((ret = blockDir->get(env->dpp, block, y)) < 0 && ret != -ENOENT) {
 		  std::cout << "ERROR: Directory get failed, ret=" << ret << std::endl;
 		  return ret;
 		} else if (ret == 0) { 
@@ -157,7 +167,7 @@ class LFUDAPolicyFixture : public ::testing::Test {
 		  if (block->cacheObj.hostsList.size() > 0) { /* Remote copy */
 			block->globalWeight += age;
 			auto globalWeight = std::to_string(block->globalWeight);
-			if ((ret = dir->update_field(env->dpp, block, "globalWeight", globalWeight, y)) < 0) {
+			if ((ret = blockDir->update_field(env->dpp, block, "globalWeight", globalWeight, y)) < 0) {
 			  std::cout << "ERROR: update_field failed, ret=" << ret << std::endl;
 			  return ret;
 			} 
@@ -169,7 +179,7 @@ class LFUDAPolicyFixture : public ::testing::Test {
 			this->policyDriver->get_cache_policy()->update(dpp, oid, 0, TEST_DATA_LENGTH, "", false, uid, block->cacheObj.bucketName, rgw::d4n::RefCount::NOOP, y, nullptr);
 			// Add local cache address to block's directory entry
             std::string host = "127.0.0.1:6379";
-			if ((ret = dir->update_field(env->dpp, block, "hosts", host, y)) < 0) {
+			if ((ret = blockDir->update_field(env->dpp, block, "hosts", host, y)) < 0) {
 			  std::cout << "ERROR: update_field failed, ret=" << ret << std::endl;
 			  return ret;
 			}
@@ -184,7 +194,7 @@ class LFUDAPolicyFixture : public ::testing::Test {
 		  }
 		  this->policyDriver->get_cache_policy()->update(dpp, oid, 0, TEST_DATA_LENGTH, "", false, uid, block->cacheObj.bucketName, rgw::d4n::RefCount::NOOP, y, nullptr);
 		  // Add local cache address to block's directory entry
-		  if ((ret = dir->set(env->dpp, block, y)) < 0) {
+		  if ((ret = blockDir->set(env->dpp, block, y)) < 0) {
 			std::cout << "ERROR: Directory set failed, ret=" << ret << std::endl;
 			return ret;
 		  }
@@ -194,7 +204,10 @@ class LFUDAPolicyFixture : public ::testing::Test {
     }
 
     rgw::d4n::CacheBlock* block;
-    rgw::d4n::RedisBlockDirectory* dir;
+    std::unique_ptr<rgw::d4n::RedisDirectory> dir;
+    rgw::d4n::RedisBlockDirectory* blockDir;
+    rgw::d4n::RedisObjectDirectory* objDir;
+    rgw::d4n::RedisBucketDirectory* bucketDir;
     rgw::d4n::PolicyDriver* policyDriver;
     rgw::cache::RedisDriver* cacheDriver;
     rgw::sal::D4NFilterDriver* driver = nullptr;
@@ -202,7 +215,6 @@ class LFUDAPolicyFixture : public ::testing::Test {
 
     net::io_context io;
     std::shared_ptr<connection> conn;
-	std::shared_ptr<rgw::d4n::DirectoryConnection> redis_native;
     std::shared_ptr<rgw::d4n::RedisConnection> redis_conn;
 
     bufferlist bl;
@@ -294,13 +306,13 @@ TEST_F(LFUDAPolicyFixture, RemoteGetBlockYield)
     ASSERT_EQ(0, cacheDriver->put(env->dpp, victimKeyInCache, bl, TEST_DATA_LENGTH, attrs, optional_yield{yield}));
 	policyDriver->get_cache_policy()->update(env->dpp, victimKeyInCache, 0, TEST_DATA_LENGTH, victim.version, false, uid, block->cacheObj.bucketName, rgw::d4n::RefCount::NOOP, optional_yield{yield}, nullptr);
 
-    ASSERT_EQ(0, dir->set(env->dpp, &victim, optional_yield{yield}));
+    ASSERT_EQ(0, blockDir->set(env->dpp, &victim, optional_yield{yield}));
 
     // Remote block
     block->cacheObj.hostsList.clear();
     block->cacheObj.hostsList.insert("127.0.0.1:6000");
 
-    ASSERT_EQ(0, dir->set(env->dpp, block, optional_yield{yield}));
+    ASSERT_EQ(0, blockDir->set(env->dpp, block, optional_yield{yield}));
 
     { // Avoid sending victim block to remote cache since no network is available
       boost::system::error_code ec;
@@ -388,14 +400,14 @@ TEST_F(LFUDAPolicyFixture, RemoteVersionEnabledGetBlockYield)
     ASSERT_EQ(0, cacheDriver->put(env->dpp, victimKeyInCache, bl, TEST_DATA_LENGTH, attrs, optional_yield{yield}));
 	policyDriver->get_cache_policy()->update(env->dpp, victimKeyInCache, 0, TEST_DATA_LENGTH, victim.version, false, uid, block->cacheObj.bucketName, rgw::d4n::RefCount::NOOP, optional_yield{yield}, nullptr);
 
-    ASSERT_EQ(0, dir->set(env->dpp, &victim, optional_yield{yield}));
+    ASSERT_EQ(0, blockDir->set(env->dpp, &victim, optional_yield{yield}));
 
     // Remote block
     block->cacheObj.hostsList.clear();
     block->cacheObj.hostsList.insert("127.0.0.1:6000");
 
     block->cacheObj.objName = "_:version_testName";
-    ASSERT_EQ(0, dir->set(env->dpp, block, optional_yield{yield}));
+    ASSERT_EQ(0, blockDir->set(env->dpp, block, optional_yield{yield}));
 
     { // Avoid sending victim block to remote cache since no network is available
       boost::system::error_code ec;
@@ -483,14 +495,14 @@ TEST_F(LFUDAPolicyFixture, RemoteVersionSuspendedGetBlockYield)
     ASSERT_EQ(0, cacheDriver->put(env->dpp, victimKeyInCache, bl, TEST_DATA_LENGTH, attrs, optional_yield{yield}));
 	policyDriver->get_cache_policy()->update(env->dpp, victimKeyInCache, 0, TEST_DATA_LENGTH, victim.version, false, uid, block->cacheObj.bucketName, rgw::d4n::RefCount::NOOP, optional_yield{yield}, nullptr);
 
-    ASSERT_EQ(0, dir->set(env->dpp, &victim, optional_yield{yield}));
+    ASSERT_EQ(0, blockDir->set(env->dpp, &victim, optional_yield{yield}));
 
     // Remote block
     block->cacheObj.hostsList.clear();
     block->cacheObj.hostsList.insert("127.0.0.1:6000");
 
     block->cacheObj.objName = "_:version_testName";
-    ASSERT_EQ(0, dir->set(env->dpp, block, optional_yield{yield}));
+    ASSERT_EQ(0, blockDir->set(env->dpp, block, optional_yield{yield}));
 
     { // Avoid sending victim block to remote cache since no network is available
       boost::system::error_code ec;


### PR DESCRIPTION
Local testing completed on remote eviction workflow and remote GET workflow using unversioned, versioning enabled, and versioning suspended buckets.

Observation: Head blocks kept in the directory hold certain parameters that are redundant (globalWeight, hostsList) because only the data blocks make use of them. While this doesn't produce bugs, it's a design inefficiency and may be worth improving upon in the future. 